### PR TITLE
Rename commands

### DIFF
--- a/microcloud/cmd/microcloud/main.go
+++ b/microcloud/cmd/microcloud/main.go
@@ -1,4 +1,4 @@
-// Package microctl provides the main client tool.
+// Package microcloud provides the main client tool.
 package main
 
 import (
@@ -9,7 +9,7 @@ import (
 	"github.com/canonical/microcloud/microcloud/version"
 )
 
-// CmdControl has functions that are common to the microctl commands.
+// CmdControl has functions that are common to the microcloud commands.
 // command line tools.
 type CmdControl struct {
 	cmd *cobra.Command //nolint:structcheck,unused // FIXME: Remove the nolint flag when this is in use.
@@ -26,7 +26,7 @@ func main() {
 	commonCmd := CmdControl{}
 
 	app := &cobra.Command{
-		Use:               "microctl",
+		Use:               "microcloud",
 		Short:             "Command for managing the MicroCloud daemon",
 		Version:           version.Version,
 		SilenceUsage:      true,

--- a/microcloud/cmd/microcloud/main_init.go
+++ b/microcloud/cmd/microcloud/main_init.go
@@ -21,8 +21,8 @@ func (c *cmdInit) Command() *cobra.Command {
 		Use:   "init <name> <address>",
 		Short: "Initialize the network endpoint and create or join a new cluster",
 		RunE:  c.Run,
-		Example: `  microctl init member1 127.0.0.1:8443 --bootstrap
-    microctl init member1 127.0.0.1:8443 --token <token>`,
+		Example: `  microcloud init member1 127.0.0.1:8443 --bootstrap
+    microcloud init member1 127.0.0.1:8443 --token <token>`,
 	}
 
 	cmd.Flags().BoolVar(&c.flagBootstrap, "bootstrap", false, "Configure a new cluster with this daemon")

--- a/microcloud/go.mod
+++ b/microcloud/go.mod
@@ -3,7 +3,7 @@ module github.com/canonical/microcloud/microcloud
 go 1.18
 
 require (
-	github.com/canonical/microcluster v0.0.0-20221011200002-813eda8412c3
+	github.com/canonical/microcluster v0.0.0-20221012211856-fd33137ea536
 	github.com/hashicorp/mdns v1.0.5
 	github.com/lxc/lxd v0.0.0-20221012194334-c30459f05309
 	github.com/olekukonko/tablewriter v0.0.5

--- a/microcloud/go.sum
+++ b/microcloud/go.sum
@@ -52,8 +52,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/canonical/go-dqlite v1.11.5 h1:Mbqh/iTd+bHjyJmr00/BZ9YudujU2U+RRMxYMjZWHWM=
 github.com/canonical/go-dqlite v1.11.5/go.mod h1:Dwp/03G1r4dtc+QSB9tV84RAAS7Mc6gy7tEvzCgcuQ8=
-github.com/canonical/microcluster v0.0.0-20221011200002-813eda8412c3 h1:iPSgBJ3NooHZUSK1WL4Nj+DAaokMP2k3sFiatoBgxpU=
-github.com/canonical/microcluster v0.0.0-20221011200002-813eda8412c3/go.mod h1:OHD57RQjyYEBqg4PRz7yUMz3h1wZpUibR6pqOAL5r/4=
+github.com/canonical/microcluster v0.0.0-20221012211856-fd33137ea536 h1:XB25d/kEEbcDUNNqYeb0kH1QCMQPBnCDk+i7dFuw51A=
+github.com/canonical/microcluster v0.0.0-20221012211856-fd33137ea536/go.mod h1:OHD57RQjyYEBqg4PRz7yUMz3h1wZpUibR6pqOAL5r/4=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/microcloud/mdns/mdns.go
+++ b/microcloud/mdns/mdns.go
@@ -3,8 +3,6 @@ package mdns
 import (
 	"fmt"
 	"net"
-	"strconv"
-	"strings"
 
 	"github.com/hashicorp/mdns"
 )
@@ -18,17 +16,13 @@ const ClusterService = "_microcloud"
 // clusterSize is the maximum number of cluster members we can find.
 const clusterSize = 30
 
-func NewBroadcast(service string, name string, addr string, txt []byte) (*mdns.Server, error) {
-	i, p, _ := strings.Cut(addr, ":")
-	port, _ := strconv.Atoi(p)
-	ip := net.ParseIP(i)
-
+func NewBroadcast(service string, name string, addr string, port int, txt []byte) (*mdns.Server, error) {
 	var sendTXT []string
 	if txt != nil {
 		sendTXT = dnsTXTSlice(txt)
 	}
 
-	config, err := mdns.NewMDNSService(name, service, "", "", port, []net.IP{ip}, sendTXT)
+	config, err := mdns.NewMDNSService(name, service, "", "", port, []net.IP{net.ParseIP(addr)}, sendTXT)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create configuration for broadcast: %w", err)
 	}


### PR DESCRIPTION
Uses `microcloudd` for the daemon and `microcloud` to control it. 

Also `microcloudd` now takes no args, instead using the default interface address on port `7001`, and the hostname for mDNS.