### PR TITLE
Init updates

### DIFF
--- a/microcloud/service/lxd.go
+++ b/microcloud/service/lxd.go
@@ -1,22 +1,18 @@
 package service
 
 import (
-	"bytes"
-	"context"
 	"fmt"
 	"path/filepath"
 
 	"github.com/lxc/lxd/client"
+	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/util"
-	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
-	"gopkg.in/yaml.v2"
 )
 
 // LXDService is a LXD service.
 type LXDService struct {
-	client lxd.InstanceServer
-	dir    string
+	dir string
 
 	name    string
 	address string
@@ -25,18 +21,23 @@ type LXDService struct {
 
 // NewLXDService creates a new LXD service with a client attached.
 func NewLXDService(name string, addr string, dir string) (*LXDService, error) {
-	client, err := lxd.ConnectLXDUnix(filepath.Join(dir, "unix.socket"), nil)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to connect to local LXD: %w", err)
-	}
 
 	return &LXDService{
-		client:  client,
 		dir:     dir,
 		name:    name,
 		address: addr,
 		port:    LXDPort,
 	}, nil
+}
+
+// client returns a client to the LXD unix socket.
+func (s LXDService) client() (lxd.InstanceServer, error) {
+	client, err := lxd.ConnectLXDUnix(filepath.Join(s.dir, "unix.socket"), nil)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to connect to local LXD: %w", err)
+	}
+
+	return client, nil
 }
 
 // Bootstrap bootstraps the LXD daemon on the default port.
@@ -57,17 +58,19 @@ func (s LXDService) Bootstrap() error {
 	revert := revert.New()
 	defer revert.Fail()
 
+	client, err := s.client()
 	if err != nil {
+		return err
 	}
 
-	revertFunc, err := initDataNodeApply(s.client, initData)
+	revertFunc, err := initDataNodeApply(client, initData)
 	if err != nil {
-		return fmt.Errorf("Failed to initialize locel LXD: %w", err)
+		return fmt.Errorf("Failed to initialize local LXD: %w", err)
 	}
 
 	revert.Add(revertFunc)
 
-	currentCluster, etag, err := s.client.GetCluster()
+	currentCluster, etag, err := client.GetCluster()
 	if err != nil {
 		return fmt.Errorf("Failed to retrieve current cluster config: %w", err)
 	}
@@ -76,7 +79,7 @@ func (s LXDService) Bootstrap() error {
 		return fmt.Errorf("This LXD server is already clustered")
 	}
 
-	op, err := s.client.UpdateCluster(api.ClusterPut{Cluster: api.Cluster{ServerName: s.name, Enabled: true}}, etag)
+	op, err := client.UpdateCluster(api.ClusterPut{Cluster: api.Cluster{ServerName: s.name, Enabled: true}}, etag)
 	if err != nil {
 		return fmt.Errorf("Failed to enable clustering on local LXD: %w", err)
 	}
@@ -85,6 +88,8 @@ func (s LXDService) Bootstrap() error {
 	if err != nil {
 		return fmt.Errorf("Failed to configure cluster :%w", err)
 	}
+
+	revert.Success()
 
 	return nil
 }
@@ -107,7 +112,12 @@ func (s LXDService) Join(token string) error {
 		return fmt.Errorf("Failed to setup trust relationship with cluster: %w", err)
 	}
 
-	op, err := s.client.UpdateCluster(*config, "")
+	client, err := s.client()
+	if err != nil {
+		return err
+	}
+
+	op, err := client.UpdateCluster(*config, "")
 	if err != nil {
 		return fmt.Errorf("Failed to join cluster: %w", err)
 	}
@@ -122,7 +132,12 @@ func (s LXDService) Join(token string) error {
 
 // IssueToken issues a token for the given peer.
 func (s LXDService) IssueToken(peer string) (string, error) {
-	op, err := s.client.CreateClusterMember(api.ClusterMembersPost{ServerName: peer})
+	client, err := s.client()
+	if err != nil {
+		return "", err
+	}
+
+	op, err := client.CreateClusterMember(api.ClusterMembersPost{ServerName: peer})
 	if err != nil {
 		return "", err
 	}

--- a/microcloud/service/lxd_init.go
+++ b/microcloud/service/lxd_init.go
@@ -1,0 +1,234 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/lxc/lxd/client"
+	"github.com/lxc/lxd/lxd/revert"
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
+)
+
+type initDataNode struct {
+	api.ServerPut `yaml:",inline"`
+	StoragePools  []api.StoragePoolsPost `json:"storage_pools" yaml:"storage_pools"`
+	Profiles      []api.ProfilesPost     `json:"profiles" yaml:"profiles"`
+}
+
+// Helper to initialize node-specific entities on a LXD instance using the
+// definitions from the given initDataNode object.
+//
+// It's used both by the 'lxd init' command and by the PUT /1.0/cluster API.
+//
+// In case of error, the returned function can be used to revert the changes.
+func initDataNodeApply(d lxd.InstanceServer, config initDataNode) (func(), error) {
+	revert := revert.New()
+	defer revert.Fail()
+
+	// Apply server configuration.
+	if config.Config != nil && len(config.Config) > 0 {
+		// Get current config.
+		currentServer, etag, err := d.GetServer()
+		if err != nil {
+			return nil, fmt.Errorf("Failed to retrieve current server configuration: %w", err)
+		}
+
+		// Setup reverter.
+		revert.Add(func() { _ = d.UpdateServer(currentServer.Writable(), "") })
+
+		// Prepare the update.
+		newServer := api.ServerPut{}
+		err = shared.DeepCopy(currentServer.Writable(), &newServer)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to copy server configuration: %w", err)
+		}
+
+		for k, v := range config.Config {
+			newServer.Config[k] = fmt.Sprintf("%v", v)
+		}
+
+		// Apply it.
+		err = d.UpdateServer(newServer, etag)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to update server configuration: %w", err)
+		}
+	}
+
+	// Apply storage configuration.
+	if config.StoragePools != nil && len(config.StoragePools) > 0 {
+		// Get the list of storagePools.
+		storagePoolNames, err := d.GetStoragePoolNames()
+		if err != nil {
+			return nil, fmt.Errorf("Failed to retrieve list of storage pools: %w", err)
+		}
+
+		// StoragePool creator
+		createStoragePool := func(storagePool api.StoragePoolsPost) error {
+			// Create the storagePool if doesn't exist.
+			err := d.CreateStoragePool(storagePool)
+			if err != nil {
+				return fmt.Errorf("Failed to create storage pool %q: %w", storagePool.Name, err)
+			}
+
+			// Setup reverter.
+			revert.Add(func() { _ = d.DeleteStoragePool(storagePool.Name) })
+			return nil
+		}
+
+		// StoragePool updater.
+		updateStoragePool := func(storagePool api.StoragePoolsPost) error {
+			// Get the current storagePool.
+			currentStoragePool, etag, err := d.GetStoragePool(storagePool.Name)
+			if err != nil {
+				return fmt.Errorf("Failed to retrieve current storage pool %q: %w", storagePool.Name, err)
+			}
+
+			// Quick check.
+			if currentStoragePool.Driver != storagePool.Driver {
+				return fmt.Errorf("Storage pool %q is of type %q instead of %q", currentStoragePool.Name, currentStoragePool.Driver, storagePool.Driver)
+			}
+
+			// Setup reverter.
+			revert.Add(func() { _ = d.UpdateStoragePool(currentStoragePool.Name, currentStoragePool.Writable(), "") })
+
+			// Prepare the update.
+			newStoragePool := api.StoragePoolPut{}
+			err = shared.DeepCopy(currentStoragePool.Writable(), &newStoragePool)
+			if err != nil {
+				return fmt.Errorf("Failed to copy configuration of storage pool %q: %w", storagePool.Name, err)
+			}
+
+			// Description override.
+			if storagePool.Description != "" {
+				newStoragePool.Description = storagePool.Description
+			}
+
+			// Config overrides.
+			for k, v := range storagePool.Config {
+				newStoragePool.Config[k] = fmt.Sprintf("%v", v)
+			}
+
+			// Apply it.
+			err = d.UpdateStoragePool(currentStoragePool.Name, newStoragePool, etag)
+			if err != nil {
+				return fmt.Errorf("Failed to update storage pool %q: %w", storagePool.Name, err)
+			}
+
+			return nil
+		}
+
+		for _, storagePool := range config.StoragePools {
+			// New storagePool.
+			if !shared.StringInSlice(storagePool.Name, storagePoolNames) {
+				err := createStoragePool(storagePool)
+				if err != nil {
+					return nil, err
+				}
+
+				continue
+			}
+
+			// Existing storagePool.
+			err := updateStoragePool(storagePool)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// Apply profile configuration.
+	if config.Profiles != nil && len(config.Profiles) > 0 {
+		// Get the list of profiles.
+		profileNames, err := d.GetProfileNames()
+		if err != nil {
+			return nil, fmt.Errorf("Failed to retrieve list of profiles: %w", err)
+		}
+
+		// Profile creator.
+		createProfile := func(profile api.ProfilesPost) error {
+			// Create the profile if doesn't exist.
+			err := d.CreateProfile(profile)
+			if err != nil {
+				return fmt.Errorf("Failed to create profile %q: %w", profile.Name, err)
+			}
+
+			// Setup reverter.
+			revert.Add(func() { _ = d.DeleteProfile(profile.Name) })
+			return nil
+		}
+
+		// Profile updater.
+		updateProfile := func(profile api.ProfilesPost) error {
+			// Get the current profile.
+			currentProfile, etag, err := d.GetProfile(profile.Name)
+			if err != nil {
+				return fmt.Errorf("Failed to retrieve current profile %q: %w", profile.Name, err)
+			}
+
+			// Setup reverter.
+			revert.Add(func() { _ = d.UpdateProfile(currentProfile.Name, currentProfile.Writable(), "") })
+
+			// Prepare the update.
+			newProfile := api.ProfilePut{}
+			err = shared.DeepCopy(currentProfile.Writable(), &newProfile)
+			if err != nil {
+				return fmt.Errorf("Failed to copy configuration of profile %q: %w", profile.Name, err)
+			}
+
+			// Description override.
+			if profile.Description != "" {
+				newProfile.Description = profile.Description
+			}
+
+			// Config overrides.
+			for k, v := range profile.Config {
+				newProfile.Config[k] = fmt.Sprintf("%v", v)
+			}
+
+			// Device overrides.
+			for k, v := range profile.Devices {
+				// New device.
+				_, ok := newProfile.Devices[k]
+				if !ok {
+					newProfile.Devices[k] = v
+					continue
+				}
+
+				// Existing device.
+				for configKey, configValue := range v {
+					newProfile.Devices[k][configKey] = fmt.Sprintf("%v", configValue)
+				}
+			}
+
+			// Apply it.
+			err = d.UpdateProfile(currentProfile.Name, newProfile, etag)
+			if err != nil {
+				return fmt.Errorf("Failed to update profile %q: %w", profile.Name, err)
+			}
+
+			return nil
+		}
+
+		for _, profile := range config.Profiles {
+			// New profile.
+			if !shared.StringInSlice(profile.Name, profileNames) {
+				err := createProfile(profile)
+				if err != nil {
+					return nil, err
+				}
+
+				continue
+			}
+
+			// Existing profile.
+			err := updateProfile(profile)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	cleanup := revert.Clone().Fail // Clone before calling revert.Success() so we can return the Fail func.
+	revert.Success()
+	return cleanup, nil
+}


### PR DESCRIPTION
This addresses @stgraber's comments from IRC:

* There is now a helper to get the LXD client rather than calling `ConnectLXD` right away.
* Reverts initialization to use the API again. The helper here is basically `initDataNodeApply` from LXD with the project related parts stripped out.
* Uses `zfs` for the storage driver
* Bootstraps LXD with a `lxdfan0` network device