### PR TITLE
Run service actions asynchronously

### DIFF
--- a/microcloud/service/service_handler.go
+++ b/microcloud/service/service_handler.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/canonical/microcluster/state"
@@ -147,6 +148,36 @@ func (s *ServiceHandler) Bootstrap(state *state.State) error {
 	err := s.server.Shutdown()
 	if err != nil {
 		return fmt.Errorf("Failed to shut down %q server: %w", cloudMDNS.ClusterService, err)
+	}
+
+	return nil
+}
+
+// RunAsync runs the given hook asynchronously across all services.
+func (s *ServiceHandler) RunAsync(f func(s Service) error) error {
+	errors := make([]error, 0, len(s.Services))
+	mut := sync.Mutex{}
+	wg := sync.WaitGroup{}
+	for _, s := range s.Services {
+		wg.Add(1)
+		go func(s Service) {
+			defer wg.Done()
+			err := f(s)
+			if err != nil {
+				mut.Lock()
+				errors = append(errors, err)
+				mut.Unlock()
+				return
+			}
+		}(s)
+	}
+
+	// Wait for all queries to complete and check for any errors.
+	wg.Wait()
+	for _, err := range errors {
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Adds  a `RunAsync` function to the service handler that will run the given hook on all services asynchronously. 

Right now this is used for bootstrapping, issuing tokens, and joining all services.