### PR TITLE
Sleep between cluster role reshuffling when sending tokens

### DIFF
--- a/microcloud/cmd/microcloud/main_init.go
+++ b/microcloud/cmd/microcloud/main_init.go
@@ -373,6 +373,8 @@ func askDisks(auto bool, wipe bool, localName string, ceph service.CephService, 
 			}
 
 			fmt.Println("MicroCloud is ready")
+
+			return nil
 		}
 	}
 

--- a/microcloud/mdns/lookup.go
+++ b/microcloud/mdns/lookup.go
@@ -95,6 +95,11 @@ func LookupJoinToken(ctx context.Context, peer string, f func(token map[string]s
 					return
 				}
 
+				if token == nil {
+					logger.Warnf("Peer %q was not found in the token broadcast", peer)
+					continue
+				}
+
 				err = f(token)
 				if err != nil {
 					logger.Error("Failed to handle join token", logger.Ctx{"name": peer, "error": err})
@@ -121,7 +126,7 @@ func parseJoinToken(peer string, entry *mdns.ServiceEntry) (map[string]string, e
 
 	record, ok := tokensByName[peer]
 	if !ok {
-		return nil, fmt.Errorf("Found no token matching the peer %q", peer)
+		return nil, nil
 	}
 
 	return record, nil


### PR DESCRIPTION
On `init`, MicroCloud starts an mdns broadcast with all the join tokens for each service and peer as the text body. What this means is that all peers will attempt to join through that first initial member.

In some cases this can cause issues as a cluster rebalances roles as it grows. So this PR splits the broadcast in two. First we send out a broadcast with just 2 members, and wait for a few seconds before continuing with the rest. 