### PR TITLE
snapcraft: Add block-devices interface

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -15,6 +15,7 @@ apps:
     command: commands/daemon.start
     daemon: simple
     plugs:
+      - block-devices
       - lxd
       - microceph
       - network


### PR DESCRIPTION
This is needed to allow wiping of disks on MicroCloud servers prior to their addition as a ZFS storage pool into LXD.