### PR TITLE
MicroOVN support

### DIFF
--- a/microcloud/cmd/microcloud/main_init.go
+++ b/microcloud/cmd/microcloud/main_init.go
@@ -94,6 +94,18 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 		services = append(services, *ceph)
 	}
 
+	_, err = microcluster.App(context.Background(), microcluster.Args{StateDir: api.MicroOVNDir})
+	if err != nil {
+		logger.Info("Skipping MicroOVN service, could not detect state directory")
+	} else {
+		ovn, err := service.NewOVNService(context.Background(), name, addr, c.common.FlagMicroCloudDir)
+		if err != nil {
+			return err
+		}
+
+		services = append(services, *ovn)
+	}
+
 	s := service.NewServiceHandler(name, addr, services...)
 	peers, err := lookupPeers(s, c.flagAuto)
 	if err != nil {

--- a/microcloud/cmd/microcloudd/main.go
+++ b/microcloud/cmd/microcloudd/main.go
@@ -86,6 +86,18 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 		services = append(services, *ceph)
 	}
 
+	_, err = microcluster.App(context.Background(), microcluster.Args{StateDir: api.MicroOVNDir})
+	if err != nil {
+		logger.Info("Skipping MicroOVN service, could not detect state directory")
+	} else {
+		ovn, err := service.NewOVNService(context.Background(), name, addr, c.flagMicroCloudDir)
+		if err != nil {
+			return err
+		}
+
+		services = append(services, *ovn)
+	}
+
 	service := service.NewServiceHandler(name, addr, services...)
 	return cloud.StartCloud(service)
 }

--- a/microcloud/service/microcloud.go
+++ b/microcloud/service/microcloud.go
@@ -42,6 +42,7 @@ func (s *CloudService) StartCloud(service *ServiceHandler) error {
 		api.Disks,
 		api.LXDProxy,
 		api.CephProxy,
+		api.OVNProxy,
 	}
 
 	return s.client.Start(endpoints, nil, &config.Hooks{

--- a/microcloud/service/microovn.go
+++ b/microcloud/service/microovn.go
@@ -1,0 +1,106 @@
+package service
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/canonical/microcluster/client"
+	"github.com/canonical/microcluster/microcluster"
+	"github.com/lxc/lxd/lxd/util"
+	"github.com/lxc/lxd/shared"
+)
+
+// OVNService is a MicroOVN service.
+type OVNService struct {
+	m *microcluster.MicroCluster
+
+	name    string
+	address string
+	port    int
+}
+
+// NewOVNService creates a new MicroOVN service with a client attached.
+func NewOVNService(ctx context.Context, name string, addr string, cloudDir string) (*OVNService, error) {
+	proxy := func(r *http.Request) (*url.URL, error) {
+		if !strings.HasPrefix(r.URL.Path, "/1.0/services/microovn") {
+			r.URL.Path = "/1.0/services/microovn" + r.URL.Path
+		}
+
+		return shared.ProxyFromEnvironment(r)
+	}
+
+	client, err := microcluster.App(ctx, microcluster.Args{StateDir: cloudDir, Proxy: proxy})
+	if err != nil {
+		return nil, err
+	}
+
+	return &OVNService{
+		m:       client,
+		name:    name,
+		address: addr,
+		port:    OVNPort,
+	}, nil
+}
+
+// client returns a client to the OVN unix socket.
+func (s OVNService) Client() (*client.Client, error) {
+	return s.m.LocalClient()
+}
+
+// Bootstrap bootstraps the MicroOVN daemon on the default port.
+func (s OVNService) Bootstrap() error {
+	return s.m.NewCluster(s.name, util.CanonicalNetworkAddress(s.address, s.port), time.Second*120)
+}
+
+// IssueToken issues a token for the given peer.
+func (s OVNService) IssueToken(peer string) (string, error) {
+	return s.m.NewJoinToken(peer)
+}
+
+// Join joins a cluster with the given token.
+func (s OVNService) Join(token string) error {
+	return s.m.JoinCluster(s.name, util.CanonicalNetworkAddress(s.address, s.port), token, 5*time.Minute)
+}
+
+// ClusterMembers returns a map of cluster member names and addresses.
+func (s OVNService) ClusterMembers() (map[string]string, error) {
+	client, err := s.Client()
+	if err != nil {
+		return nil, err
+	}
+
+	members, err := client.GetClusterMembers(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	genericMembers := make(map[string]string, len(members))
+	for _, member := range members {
+		genericMembers[member.Name] = member.Address.String()
+	}
+
+	return genericMembers, nil
+}
+
+// Type returns the type of Service.
+func (s OVNService) Type() ServiceType {
+	return MicroOVN
+}
+
+// Name returns the name of this Service instance.
+func (s OVNService) Name() string {
+	return s.name
+}
+
+// Address returns the address of this Service instance.
+func (s OVNService) Address() string {
+	return s.address
+}
+
+// Port returns the port of this Service instance.
+func (s OVNService) Port() int {
+	return s.port
+}

--- a/microcloud/service/service_handler.go
+++ b/microcloud/service/service_handler.go
@@ -14,6 +14,9 @@ import (
 )
 
 const (
+	// OVNPort is the efault MicroOVN port.
+	OVNPort int = 6443
+
 	// CephPort is the efault MicroCeph port.
 	CephPort int = 7443
 
@@ -44,6 +47,9 @@ const (
 
 	// MicroCeph represents a MicroCeph service.
 	MicroCeph ServiceType = "MicroCeph"
+
+	// MicroOVN represents a MicroOVN service.
+	MicroOVN ServiceType = "MicroOVN"
 
 	// LXD represents a LXD service.
 	LXD ServiceType = "LXD"


### PR DESCRIPTION
Adds MicroOVN support.

All this really took was a copy/paste of `services/microceph.go` to `services/microovn.go` with the names changed. The default port for MicroOVN will be `:6443`

Also reworked the MicroCeph proxy to be a more general MicroCluster proxy, expecting a service name and a state directory. 