### PR TITLE
Notify missing services

### DIFF
--- a/microcloud/cmd/microcloud/add.go
+++ b/microcloud/cmd/microcloud/add.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/canonical/microcluster/microcluster"
 	lxdAPI "github.com/lxc/lxd/shared/api"
@@ -58,13 +57,7 @@ func (c *cmdAdd) Run(cmd *cobra.Command, args []string) error {
 
 	addr := status.Address.Addr().String()
 	services := []types.ServiceType{types.MicroCloud, types.LXD}
-	app, err := microcluster.App(context.Background(), microcluster.Args{StateDir: api.MicroCephDir})
-	if err != nil {
-		return err
-	}
-
-	_, err = os.Stat(app.FileSystem.ControlSocket().URL.Host)
-	if err == nil {
+	if service.ServiceExists(types.MicroCeph, api.MicroCephDir) {
 		services = append(services, types.MicroCeph)
 	} else {
 		logger.Info("Skipping MicroCeph service, could not detect state directory")

--- a/microcloud/cmd/microcloud/add.go
+++ b/microcloud/cmd/microcloud/add.go
@@ -98,10 +98,6 @@ func (c *cmdAdd) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if len(peers) == 0 {
-		return fmt.Errorf("Found no available systems")
-	}
-
 	var localDisks map[string][]lxdAPI.ClusterMemberConfigKey
 	wantsDisks := true
 	if !c.flagAuto {

--- a/microcloud/service/service_handler.go
+++ b/microcloud/service/service_handler.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/canonical/microcluster/state"
@@ -175,4 +177,16 @@ func (s *ServiceHandler) RunConcurrent(microCloudFirst bool, f func(s Service) e
 	}
 
 	return nil
+}
+
+// ServiceExists returns true if we can stat the unix socket in the state directory of the given service.
+func ServiceExists(service types.ServiceType, stateDir string) bool {
+	socketPath := filepath.Join(stateDir, "control.socket")
+	if service == types.LXD {
+		socketPath = filepath.Join(stateDir, "unix.socket")
+	}
+
+	_, err := os.Stat(socketPath)
+
+	return err == nil
 }


### PR DESCRIPTION
Closes #32

Properly notifies the user of `init` and `add` that the server may be missing services. By default (i.e. `--auto`) we will continue anyway. 

In the event that a peer detected over mDNS is missing a service, it will be ignored.