### PR TITLE
Limit cluster formation to within a subnet

### DIFF
--- a/microcloud/cmd/microcloud/add.go
+++ b/microcloud/cmd/microcloud/add.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/canonical/microcluster/microcluster"
@@ -20,8 +21,9 @@ import (
 type cmdAdd struct {
 	common *CmdControl
 
-	flagAuto bool
-	flagWipe bool
+	flagAutoSetup     bool
+	flagWipe          bool
+	flagClusterSubnet string
 }
 
 func (c *cmdAdd) Command() *cobra.Command {
@@ -31,8 +33,9 @@ func (c *cmdAdd) Command() *cobra.Command {
 		RunE:  c.Run,
 	}
 
-	cmd.Flags().BoolVar(&c.flagAuto, "auto", false, "Automatic setup with default configuration")
+	cmd.Flags().BoolVar(&c.flagAutoSetup, "auto", false, "Automatic setup with default configuration")
 	cmd.Flags().BoolVar(&c.flagWipe, "wipe", false, "Wipe disks to add to MicroCeph")
+	cmd.Flags().StringVar(&c.flagClusterSubnet, "subnet", "", "Subnet to look for cluster members in")
 
 	return cmd
 }
@@ -74,7 +77,7 @@ func (c *cmdAdd) Run(cmd *cobra.Command, args []string) error {
 
 	if len(missingServices) > 0 {
 		serviceStr := strings.Join(missingServices, ",")
-		if !c.flagAuto {
+		if !c.flagAutoSetup {
 			skip, err := cli.AskBool(fmt.Sprintf("%s not found. Continue anyway? (yes/no) [default=yes]: ", serviceStr), "yes")
 			if err != nil {
 				return err
@@ -88,19 +91,27 @@ func (c *cmdAdd) Run(cmd *cobra.Command, args []string) error {
 		logger.Infof("Skipping %s (could not detect service state directory)", serviceStr)
 	}
 
+	var subnet *net.IPNet
+	if c.flagClusterSubnet != "" {
+		_, subnet, err = net.ParseCIDR(c.flagClusterSubnet)
+		if err != nil {
+			return fmt.Errorf("Invalid subnet: %q", err)
+		}
+	}
+
 	s, err := service.NewServiceHandler(status.Name, addr, c.common.FlagMicroCloudDir, c.common.FlagLogDebug, c.common.FlagLogVerbose, services...)
 	if err != nil {
 		return err
 	}
 
-	peers, err := lookupPeers(s, c.flagAuto)
+	peers, err := lookupPeers(s, c.flagAutoSetup)
 	if err != nil {
 		return err
 	}
 
 	var localDisks map[string][]lxdAPI.ClusterMemberConfigKey
 	wantsDisks := true
-	if !c.flagAuto {
+	if !c.flagAutoSetup {
 		wantsDisks, err = cli.AskBool("Would you like to add a local LXD storage pool? (yes/no) [default=yes]: ", "yes")
 		if err != nil {
 			return err
@@ -108,9 +119,9 @@ func (c *cmdAdd) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if wantsDisks {
-		askRetry("Retry selecting disks?", c.flagAuto, func() error {
+		askRetry("Retry selecting disks?", c.flagAutoSetup, func() error {
 			lxd := s.Services[types.LXD].(*service.LXDService)
-			localDisks, err = askLocalPool(peers, c.flagAuto, c.flagWipe, *lxd)
+			localDisks, err = askLocalPool(peers, c.flagAutoSetup, c.flagWipe, *lxd)
 
 			return err
 		})
@@ -128,7 +139,7 @@ func (c *cmdAdd) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		wantsDisks = true
-		if !c.flagAuto {
+		if !c.flagAutoSetup {
 			wantsDisks, err = cli.AskBool("Would you like to add additional local disks to MicroCeph? (yes/no) [default=yes]: ", "yes")
 			if err != nil {
 				return err
@@ -146,12 +157,12 @@ func (c *cmdAdd) Run(cmd *cobra.Command, args []string) error {
 				}
 			}
 
-			askRetry("Retry selecting disks?", c.flagAuto, func() error {
+			askRetry("Retry selecting disks?", c.flagAutoSetup, func() error {
 				peers[status.Name] = mdns.ServerInfo{Name: status.Name, Address: addr}
 				defer delete(peers, status.Name)
 
 				lxd := s.Services[types.LXD].(*service.LXDService)
-				_, err = askRemotePool(peers, c.flagAuto, c.flagWipe, *ceph, *lxd, reservedDisks, false)
+				_, err = askRemotePool(peers, c.flagAutoSetup, c.flagWipe, *ceph, *lxd, reservedDisks, false)
 
 				return err
 			})

--- a/microcloud/cmd/microcloud/main_init.go
+++ b/microcloud/cmd/microcloud/main_init.go
@@ -340,7 +340,7 @@ func lookupPeers(s *service.ServiceHandler, autoSetup bool) (map[string]mdns.Ser
 			}
 
 			// Sleep for a few seconds before retrying.
-			time.Sleep(5 * time.Second)
+			time.Sleep(time.Second)
 		}
 	}
 


### PR DESCRIPTION
Closes https://github.com/canonical/microcloud/issues/34

By default, all uninitialized machines will now include every address on every interface in their broadcast payload. They will also broadcast this over every one of those addresses. These are stored in a `NetworkInfo` slice in the payload.

On the init side, we take the first record of a peer that we detect, and check if it is in a default or otherwise supplied subnet. The cluster will then be formed using these addresses for the peers. 

To facilitate this, there are some new flags and interactive bits in the CLI
* `--address` can be used to specify a listen address right away and avoid either the interactive step, or used with `--auto` instead of the default result of `NetworkInterfaceAddress()`. 
* `--subnet` works similarly. If a subnet is not otherwise given either with the flag or in the interactive CLI, a default `/24` or `/64` subnet will be used for whichever address is chosen.

The `mDNS` lookup stage now checks once per second, and at first only reports the names of detected systems. After user input, the scan is ended and if the used didn't supply `--subnet`, the user is prompted to do so, or use the default subnet. The user can also specify `all` to show all entries. The user will still be limited to just 1 selection for each peer, but the built-in table filtering can make it pretty easy to match on an interface or part of an IP.