### PR TITLE
Fix MicroOVN config

### DIFF
--- a/microcloud/cmd/microcloud/ask.go
+++ b/microcloud/cmd/microcloud/ask.go
@@ -134,6 +134,19 @@ func askDisks(sh *service.ServiceHandler, peers map[string]mdns.ServerInfo, boot
 		}
 	}
 
+	if !bootstrap {
+		sourceTemplate := lxdAPI.ClusterMemberConfigKey{
+			Entity: "storage-pool",
+			Name:   "remote",
+			Key:    "source",
+			Value:  "lxd_remote",
+		}
+
+		for peer := range cephDisks {
+			diskConfig[peer] = append(diskConfig[peer], sourceTemplate)
+		}
+	}
+
 	return diskConfig, cephDisks, nil
 }
 

--- a/microcloud/cmd/microcloud/main_init.go
+++ b/microcloud/cmd/microcloud/main_init.go
@@ -394,7 +394,12 @@ func postClusterSetup(bootstrap bool, sh *service.ServiceHandler, peers map[stri
 		conns := []string{}
 		for _, service := range services {
 			if service.Service == "central" {
-				conns = append(conns, fmt.Sprintf("tcp:%s", util.CanonicalNetworkAddress(peers[service.Location].Address, 6641)))
+				addr := sh.Address
+				if service.Location != sh.Name {
+					addr = peers[service.Location].Address
+				}
+
+				conns = append(conns, fmt.Sprintf("tcp:%s", util.CanonicalNetworkAddress(addr, 6641)))
 			}
 		}
 


### PR DESCRIPTION
Also adds `source: lxd_remote` on the remote storage pool when adding a peer, even though it's currently not handled properly on the LXD side.