### PR TITLE
Clustering by subnet & selectable peers

### DIFF
--- a/microcloud/api/services.go
+++ b/microcloud/api/services.go
@@ -83,23 +83,7 @@ func servicesPut(s *state.State, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	// Join MicroCloud first.
-	err = sh.Services[types.MicroCloud].Join(joinConfigs[types.MicroCloud])
-	if err != nil {
-		return response.SmartError(fmt.Errorf("Failed to join %q cluster: %w", types.MicroCloud, err))
-	}
-
-	// Join MicroCeph next to set up disks.
-	err = sh.Services[types.MicroCeph].Join(joinConfigs[types.MicroCeph])
-	if err != nil {
-		return response.SmartError(fmt.Errorf("Failed to join %q cluster: %w", types.MicroCeph, err))
-	}
-
-	err = sh.RunConcurrent(false, func(s service.Service) error {
-		if s.Type() == types.MicroCeph || s.Type() == types.MicroCloud {
-			return nil
-		}
-
+	err = sh.RunConcurrent(true, true, func(s service.Service) error {
 		err = s.Join(joinConfigs[s.Type()])
 		if err != nil {
 			return fmt.Errorf("Failed to join %q cluster: %w", s.Type(), err)

--- a/microcloud/cmd/microcloud/add.go
+++ b/microcloud/cmd/microcloud/add.go
@@ -17,6 +17,7 @@ type cmdAdd struct {
 
 	flagAutoSetup     bool
 	flagWipe          bool
+	flagClusterSubnet string
 }
 
 func (c *cmdAdd) Command() *cobra.Command {
@@ -28,6 +29,7 @@ func (c *cmdAdd) Command() *cobra.Command {
 
 	cmd.Flags().BoolVar(&c.flagAutoSetup, "auto", false, "Automatic setup with default configuration")
 	cmd.Flags().BoolVar(&c.flagWipe, "wipe", false, "Wipe disks to add to MicroCeph")
+	cmd.Flags().StringVar(&c.flagClusterSubnet, "subnet", "", "Subnet to look for cluster members in")
 
 	return cmd
 }
@@ -68,7 +70,7 @@ func (c *cmdAdd) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	peers, err := lookupPeers(s, c.flagAuto)
+	peers, err := lookupPeers(s, c.flagAutoSetup, c.flagClusterSubnet)
 	if err != nil {
 		return err
 	}

--- a/microcloud/cmd/microcloud/add.go
+++ b/microcloud/cmd/microcloud/add.go
@@ -15,8 +15,8 @@ import (
 type cmdAdd struct {
 	common *CmdControl
 
-	flagAuto bool
-	flagWipe bool
+	flagAutoSetup     bool
+	flagWipe          bool
 }
 
 func (c *cmdAdd) Command() *cobra.Command {
@@ -26,7 +26,7 @@ func (c *cmdAdd) Command() *cobra.Command {
 		RunE:  c.Run,
 	}
 
-	cmd.Flags().BoolVar(&c.flagAuto, "auto", false, "Automatic setup with default configuration")
+	cmd.Flags().BoolVar(&c.flagAutoSetup, "auto", false, "Automatic setup with default configuration")
 	cmd.Flags().BoolVar(&c.flagWipe, "wipe", false, "Wipe disks to add to MicroCeph")
 
 	return cmd
@@ -58,7 +58,7 @@ func (c *cmdAdd) Run(cmd *cobra.Command, args []string) error {
 		types.MicroOVN:  api.MicroOVNDir,
 	}
 
-	services, err = askMissingServices(services, optionalServices, c.flagAuto)
+	services, err = askMissingServices(services, optionalServices, c.flagAutoSetup)
 	if err != nil {
 		return err
 	}
@@ -73,7 +73,7 @@ func (c *cmdAdd) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	lxdDisks, cephDisks, err := askDisks(s, peers, false, c.flagAuto, c.flagWipe)
+	lxdDisks, cephDisks, err := askDisks(s, peers, false, c.flagAutoSetup, c.flagWipe)
 	if err != nil {
 		return err
 	}

--- a/microcloud/cmd/microcloud/ask.go
+++ b/microcloud/cmd/microcloud/ask.go
@@ -213,6 +213,10 @@ func askLocalPool(peerDisks map[string][]lxdAPI.ResourcesStorageDisk, autoSetup 
 			return nil, nil, fmt.Errorf("Failed to confirm local LXD disk selection: %w", err)
 		}
 
+		if len(selectedRows) == 0 {
+			return nil, nil, fmt.Errorf("No disks selected")
+		}
+
 		for _, entry := range selectedRows {
 			target := table.SelectionValue(entry, "LOCATION")
 			path := table.SelectionValue(entry, "PATH")

--- a/microcloud/cmd/microcloud/ask.go
+++ b/microcloud/cmd/microcloud/ask.go
@@ -114,6 +114,15 @@ func askDisks(sh *service.ServiceHandler, peers map[string]mdns.ServerInfo, boot
 		})
 	}
 
+	for peer, path := range reservedDisks {
+		fmt.Printf(" Using %q on %q for local storage pool\n", path, peer)
+	}
+
+	if len(reservedDisks) > 0 {
+		// Add a space between the CLI and the response.
+		fmt.Println("")
+	}
+
 	var cephDisks map[string][]cephTypes.DisksPost
 	if sh.Services[types.MicroCeph] != nil {
 		ceph := sh.Services[types.MicroCeph].(*service.CephService)
@@ -131,6 +140,18 @@ func askDisks(sh *service.ServiceHandler, peers map[string]mdns.ServerInfo, boot
 
 				return err
 			})
+		} else {
+			// Add a space between the CLI and the response.
+			fmt.Println("")
+		}
+
+		for peer, disks := range cephDisks {
+			fmt.Printf(" Using %d disk(s) on %q for remote storage pool\n", len(disks), peer)
+		}
+
+		if len(cephDisks) > 0 {
+			// Add a space between the CLI and the response.
+			fmt.Println("")
 		}
 	}
 

--- a/microcloud/cmd/microcloud/main_init.go
+++ b/microcloud/cmd/microcloud/main_init.go
@@ -27,8 +27,8 @@ import (
 type cmdInit struct {
 	common *CmdControl
 
-	flagAutoSetup    bool
-	flagWipeAllDisks bool
+	flagAutoSetup     bool
+	flagWipeAllDisks  bool
 }
 
 func (c *cmdInit) Command() *cobra.Command {

--- a/microcloud/cmd/microcloud/main_init.go
+++ b/microcloud/cmd/microcloud/main_init.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"strings"
 	"sync"
@@ -29,6 +30,8 @@ type cmdInit struct {
 
 	flagAutoSetup     bool
 	flagWipeAllDisks  bool
+	flagAddress       string
+	flagClusterSubnet string
 }
 
 func (c *cmdInit) Command() *cobra.Command {
@@ -41,6 +44,8 @@ func (c *cmdInit) Command() *cobra.Command {
 
 	cmd.Flags().BoolVar(&c.flagAutoSetup, "auto", false, "Automatic setup with default configuration")
 	cmd.Flags().BoolVar(&c.flagWipeAllDisks, "wipe", false, "Wipe disks to add to MicroCeph")
+	cmd.Flags().StringVar(&c.flagClusterSubnet, "subnet", "", "Subnet to look for cluster members in")
+	cmd.Flags().StringVar(&c.flagAddress, "address", "", "Address to use for MicroCloud")
 
 	return cmd
 }
@@ -50,13 +55,17 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 		return cmd.Help()
 	}
 
-	addr := util.NetworkInterfaceAddress()
+	addr := c.flagAddress
+	if addr == "" {
+		addr = util.NetworkInterfaceAddress()
+	}
+
 	name, err := os.Hostname()
 	if err != nil {
 		return fmt.Errorf("Failed to retrieve system honame: %w", err)
 	}
 
-	if !c.flagAutoSetup {
+	if !c.flagAutoSetup && c.flagAddress == "" {
 		addr, err = cli.AskString(fmt.Sprintf("Please choose the address MicroCloud will be listening on [default=%s]: ", addr), addr, nil)
 		if err != nil {
 			return err
@@ -85,7 +94,7 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	peers, err := lookupPeers(s, c.flagAutoSetup)
+	peers, err := lookupPeers(s, c.flagAutoSetup, c.flagClusterSubnet)
 	if err != nil {
 		return err
 	}
@@ -139,7 +148,42 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func lookupPeers(s *service.ServiceHandler, autoSetup bool) (map[string]mdns.ServerInfo, error) {
+func lookupPeers(s *service.ServiceHandler, autoSetup bool, givenSubnet string) (map[string]mdns.ServerInfo, error) {
+	var subnet *net.IPNet
+	var err error
+	if givenSubnet != "" {
+		_, subnet, err = net.ParseCIDR(givenSubnet)
+		if err != nil {
+			return nil, fmt.Errorf("Invalid subnet: %q", err)
+		}
+	} else {
+		if net.ParseIP(s.Address).To4() != nil {
+			_, subnet, err = net.ParseCIDR(s.Address + "/24")
+		} else {
+			_, subnet, err = net.ParseCIDR(s.Address + "/64")
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("Failed to determine subnet from IP: %w", err)
+		}
+	}
+
+	if !autoSetup && givenSubnet == "" {
+		subnetStr, err := cli.AskString(fmt.Sprintf("Please choose the subnet for MicroCloud (all/[subnet]) [default=%s]: ", subnet.String()), subnet.String(), nil)
+		if err != nil {
+			return nil, err
+		}
+
+		if subnetStr == "all" {
+			subnet = nil
+		} else if subnetStr != subnet.String() {
+			_, subnet, err = net.ParseCIDR(subnetStr)
+			if err != nil {
+				return nil, fmt.Errorf("Invalid subnet: %q", err)
+			}
+		}
+	}
+
 	stdin := bufio.NewReader(os.Stdin)
 	totalPeers := map[string]mdns.ServerInfo{}
 	skipPeers := map[string]bool{}

--- a/microcloud/cmd/microcloud/main_init.go
+++ b/microcloud/cmd/microcloud/main_init.go
@@ -104,7 +104,7 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println("Initializing a new cluster")
-	err = s.RunConcurrent(true, func(s service.Service) error {
+	err = s.RunConcurrent(true, false, func(s service.Service) error {
 		err := s.Bootstrap()
 		if err != nil {
 			return fmt.Errorf("Failed to bootstrap local %s: %w", s.Type(), err)
@@ -314,7 +314,7 @@ func AddPeers(sh *service.ServiceHandler, peers map[string]mdns.ServerInfo, loca
 	}
 
 	mut := sync.Mutex{}
-	err := sh.RunConcurrent(false, func(s service.Service) error {
+	err := sh.RunConcurrent(false, false, func(s service.Service) error {
 		for peer := range peers {
 			token, err := s.IssueToken(peer)
 			if err != nil {
@@ -380,7 +380,7 @@ func AddPeers(sh *service.ServiceHandler, peers map[string]mdns.ServerInfo, loca
 		return fmt.Errorf("Failed to get %s service cluster members: %w", cloudService.Type(), err)
 	}
 
-	err = sh.RunConcurrent(false, func(s service.Service) error {
+	err = sh.RunConcurrent(false, false, func(s service.Service) error {
 		if s.Type() == types.MicroCloud {
 			return nil
 		}

--- a/microcloud/cmd/microcloud/main_init.go
+++ b/microcloud/cmd/microcloud/main_init.go
@@ -291,11 +291,18 @@ func lookupPeers(s *service.ServiceHandler, autoSetup bool, givenSubnet string) 
 	if autoSetup {
 		for _, info := range totalPeers {
 			selectedPeers[info.Name] = info
-			fmt.Printf("  Found %q at %q\n", info.Name, info.Address)
 		}
 
+		// Add a space between the CLI and the response.
+		fmt.Println("")
 	}
 
+	for _, info := range selectedPeers {
+		fmt.Printf("  Selected %q at %q\n", info.Name, info.Address)
+	}
+
+	// Add a space between the CLI and the response.
+	fmt.Println("")
 	return selectedPeers, nil
 }
 

--- a/microcloud/cmd/microcloud/selection_table.go
+++ b/microcloud/cmd/microcloud/selection_table.go
@@ -5,17 +5,27 @@ import (
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/olekukonko/tablewriter"
 )
 
 // SelectableTable represents a CLI table with selectable rows.
 type SelectableTable struct {
-	header     string
-	currentRow string
-	rows       []string
-	border     string
+	askChan chan error
+	prompt  *survey.MultiSelect
+	writer  *tablewriter.Table
 
+	rows         []string
+	header       string
+	currentRow   string
+	border       string
 	writtenLines int
+
+	rawRows   [][]string
+	rawHeader []string
+
+	answers []string
+	data    map[string]map[string]string
 }
 
 // Write lets SelectableTable implement io.Writer so we can compartmentalize the header, borders, and rows from the
@@ -61,10 +71,15 @@ func (t *SelectableTable) Write(p []byte) (int, error) {
 }
 
 // NewSelectableTable creates a new Selectable table from the given header and rows.
-func NewSelectableTable(header []string, data [][]string) SelectableTable {
+// Additionall returns a map representing each row by its content, and each column therein.
+func NewSelectableTable(header []string, data [][]string) *SelectableTable {
 	table := SelectableTable{rows: make([]string, 0, len(data))}
+	table.rawRows = data
+	table.rawHeader = header
+	table.askChan = make(chan error)
 
 	t := tablewriter.NewWriter(&table)
+	table.writer = t
 	t.SetAutoWrapText(false)
 	t.SetAlignment(tablewriter.ALIGN_LEFT)
 	t.SetHeader(header)
@@ -74,7 +89,16 @@ func NewSelectableTable(header []string, data [][]string) SelectableTable {
 
 	t.Render()
 
-	return table
+	// map the rows (as strings) to the associated row.
+	table.data = make(map[string]map[string]string, len(data))
+	for i, row := range table.rows {
+		table.data[row] = make(map[string]string, len(data[i]))
+		for j, h := range header {
+			table.data[row][h] = data[i][j]
+		}
+	}
+
+	return &table
 }
 
 // multiSelectQuestionTemplate overwrites the default survey package template to accommodate table rows as selectable options.
@@ -110,21 +134,137 @@ const multiSelectQuestionTemplate = `
 {{- end}}
 `
 
+// DefaultAskOptions is the default options on ask, using the OS stdio.
+func defaultPromptConfig() *survey.PromptConfig {
+	return &survey.PromptConfig{
+		PageSize:     7,
+		HelpInput:    "?",
+		SuggestInput: "tab",
+		Icons: survey.IconSet{
+			Error: survey.Icon{
+				Text:   "X",
+				Format: "red",
+			},
+			Help: survey.Icon{
+				Text:   "?",
+				Format: "cyan",
+			},
+			Question: survey.Icon{
+				Text:   "?",
+				Format: "green+hb",
+			},
+			MarkedOption: survey.Icon{
+				Text:   "[x]",
+				Format: "green",
+			},
+			UnmarkedOption: survey.Icon{
+				Text:   "[ ]",
+				Format: "default+hb",
+			},
+			SelectFocus: survey.Icon{
+				Text:   ">",
+				Format: "cyan+b",
+			},
+		},
+		Filter: func(filter string, value string, index int) (include bool) {
+			filter = strings.ToLower(filter)
+
+			// include this option if it matches
+			return strings.Contains(strings.ToLower(value), filter)
+		},
+		KeepFilter:       false,
+		ShowCursor:       false,
+		RemoveSelectAll:  false,
+		RemoveSelectNone: false,
+	}
+}
+
 // Render outputs the SelectableTable and returns a slice of selected rows.
-func (t *SelectableTable) Render(entries []string) ([]string, error) {
+func (t *SelectableTable) Render(entries []string) {
 	survey.MultiSelectQuestionTemplate = fmt.Sprintf(multiSelectQuestionTemplate, t.border, t.border, t.header, t.border)
-	prompt := &survey.MultiSelect{
+	t.prompt = &survey.MultiSelect{
 		Message: `Space to select; Enter to confirm; Esc to exit; Type to filter results.
 Up/Down to move; Right to select all; Left to select none.`,
 		Options:  entries,
 		PageSize: 15,
 	}
 
-	selected := []string{}
-	err := survey.AskOne(prompt, &selected)
+	t.answers = []string{}
+
+	go func() {
+		err := survey.AskOne(t.prompt, &t.answers)
+		if err != nil && err.Error() != "please provide options to select from" {
+
+			t.askChan <- fmt.Errorf("Failed to confirm selection: %w", err)
+			return
+		}
+
+		t.askChan <- nil
+	}()
+}
+
+// GetSelections blocks until the user selections are made, and returns them once available.
+func (t *SelectableTable) GetSelections() ([]string, error) {
+	err := <-t.askChan
 	if err != nil {
-		return nil, fmt.Errorf("Failed to confirm selection: %w", err)
+		return nil, err
 	}
 
-	return selected, nil
+	if t.answers == nil {
+		return nil, fmt.Errorf("Failed to find any answers")
+	}
+
+	return t.answers, nil
+}
+
+// SelectionValue returns the value of a selection by its row and column.
+// - The row is the key returned by the list of selections
+// - The column is the name of the corresponding column header.
+func (t *SelectableTable) SelectionValue(selectionRow string, columnName string) string {
+	return t.data[selectionRow][columnName]
+}
+
+// Update redraws the table with the new row added at the end.
+func (t *SelectableTable) Update(row []string) {
+	// Save the old rows so we can update the entries in the actual selection table.
+	oldRows := t.rows
+
+	// Clear the entire table so there's no artifacts.
+	t.writer.ClearRows()
+	t.rows = []string{}
+	t.currentRow = ""
+	t.header = ""
+	t.border = ""
+	t.writtenLines = 0
+	t.rawRows = append(t.rawRows, row)
+	t.writer.AppendBulk(t.rawRows)
+	t.writer.Render()
+
+	// Build the subset of rows to show from the old list.
+	newEntries := make([]string, 0, len(t.prompt.Options)+1)
+	for _, entry := range t.prompt.Options {
+		for i := range oldRows {
+			if oldRows[i] != entry {
+				continue
+			}
+
+			newEntries = append(newEntries, t.rows[i])
+		}
+	}
+
+	// Add the new entry to the displayed rows.
+	newEntries = append(newEntries, t.rows[len(t.rows)-1])
+
+	// Update the map of answers with new keys.
+	for i, row := range t.rows {
+		t.data[row] = map[string]string{}
+		for j, h := range t.rawHeader {
+			t.data[row][h] = t.rawRows[i][j]
+		}
+	}
+
+	// Update the template as the size of the header and borders may have changed.
+	survey.MultiSelectQuestionTemplate = fmt.Sprintf(multiSelectQuestionTemplate, t.border, t.border, t.header, t.border)
+	t.prompt.Options = newEntries
+	t.prompt.OnChange(terminal.IgnoreKey, defaultPromptConfig())
 }

--- a/microcloud/cmd/microcloud/selection_table.go
+++ b/microcloud/cmd/microcloud/selection_table.go
@@ -242,7 +242,7 @@ func (t *SelectableTable) prepareTemplate() {
 // Render outputs the SelectableTable and returns a slice of selected rows.
 func (t *SelectableTable) Render(entries []string) {
 	t.prompt = &survey.MultiSelect{
-		Message: `Space to select; Enter to confirm; Esc to exit; Type to filter results.
+		Message: `Space to select; Enter to confirm; Type to filter results.
 Up/Down to move; Right to select all; Left to select none.`,
 		Options:  entries,
 		PageSize: 15,

--- a/microcloud/mdns/mdns.go
+++ b/microcloud/mdns/mdns.go
@@ -10,16 +10,19 @@ import (
 // ClusterService is the service name used for broadcasting willingness to join a cluster.
 const ClusterService = "_microcloud"
 
+// serviceSize is the maximum number of simultaneous broadcasts of the same mDNS service.
+const ServiceSize = 10
+
 // clusterSize is the maximum number of cluster members we can find.
 const clusterSize = 1000
 
-func NewBroadcast(name string, addr string, port int, txt []byte) (*mdns.Server, error) {
+func NewBroadcast(name string, addr string, port int, service string, txt []byte) (*mdns.Server, error) {
 	var sendTXT []string
 	if txt != nil {
 		sendTXT = dnsTXTSlice(txt)
 	}
 
-	config, err := mdns.NewMDNSService(name, ClusterService, "", "", port, []net.IP{net.ParseIP(addr)}, sendTXT)
+	config, err := mdns.NewMDNSService(name, service, "", "", port, []net.IP{net.ParseIP(addr)}, sendTXT)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create configuration for broadcast: %w", err)
 	}


### PR DESCRIPTION
Closes https://github.com/canonical/microcloud/issues/34
Closes #35
Closes #74

* By default, all uninitialized machines will now broadcast their info using every network interface.

The mDNS lookup requires checking against the `service`(`_microcloud`) field of the mDNS broadcast, and overlapping requests will block each other, making the lookup very slow. To remedy this, there is now a `ServiceSize` constant that will be used to generate as many `service` variations, before falling back to overlapping. The constant is currently set to 10, with a lookup performed every 100ms (so 1s for a whole lookup of up to 10 addresses on each peer). 

* On init, the user will be prompted to select from an updating list of available systems. By default this list will only show results in the same subnet. 

To facilitate this, there are some new flags in the CLI

* `--address` can be used to specify a listen address right away and avoid either the interactive step, or used with --auto instead of the default result of `NetworkInterfaceAddress()`.
*  `--subnet` works similarly. If a subnet is not otherwise given either with the flag or in the interactive CLI, a default /24 or /64 subnet will be used for whichever address is chosen.

* Also fixes a few misc bugs at the end.
