### PR TITLE
Apply network to all peers without OVN

### DIFF
--- a/microcloud/cmd/microcloud/main_init.go
+++ b/microcloud/cmd/microcloud/main_init.go
@@ -417,7 +417,7 @@ func postClusterSetup(bootstrap bool, sh *service.ServiceHandler, peers map[stri
 		cephTargets[target] = peers[target].AuthSecret
 	}
 
-	ovnTargets := map[string]string{}
+	networkTargets := map[string]string{}
 	var ovnConfig string
 	if sh.Services[types.MicroOVN] != nil {
 		ovn := sh.Services[types.MicroOVN].(*service.OVNService)
@@ -444,9 +444,10 @@ func postClusterSetup(bootstrap bool, sh *service.ServiceHandler, peers map[stri
 		}
 
 		ovnConfig = strings.Join(conns, ",")
-		for peer, info := range peers {
-			ovnTargets[peer] = info.AuthSecret
-		}
+	}
+
+	for peer, info := range peers {
+		networkTargets[peer] = info.AuthSecret
 	}
 
 	lxdTargets := map[string]string{}
@@ -454,5 +455,5 @@ func postClusterSetup(bootstrap bool, sh *service.ServiceHandler, peers map[stri
 		lxdTargets[peer] = peers[peer].AuthSecret
 	}
 
-	return sh.Services[types.LXD].(*service.LXDService).Configure(bootstrap, lxdTargets, cephTargets, ovnConfig, ovnTargets, uplinkNetworks, networkConfig)
+	return sh.Services[types.LXD].(*service.LXDService).Configure(bootstrap, lxdTargets, cephTargets, ovnConfig, networkTargets, uplinkNetworks, networkConfig)
 }

--- a/microcloud/service/lxd.go
+++ b/microcloud/service/lxd.go
@@ -539,7 +539,7 @@ func (s LXDService) SetupNetwork(uplinkNetworks map[string]string, networkConfig
 
 // Configure sets up the LXD storage pool (either remote ceph or local zfs), and adds the root and network devices to
 // the default profile.
-func (s *LXDService) Configure(bootstrap bool, localPoolTargets map[string]string, remotePoolTargets map[string]string, ovnConfig string, ovnTargets map[string]string, uplinkNetworks map[string]string, networkConfig map[string]string) error {
+func (s *LXDService) Configure(bootstrap bool, localPoolTargets map[string]string, remotePoolTargets map[string]string, ovnConfig string, networkTargets map[string]string, uplinkNetworks map[string]string, networkConfig map[string]string) error {
 	c, err := s.client("")
 	if err != nil {
 		return err
@@ -558,7 +558,7 @@ func (s *LXDService) Configure(bootstrap bool, localPoolTargets map[string]strin
 			return err
 		}
 
-		for peer, secret := range ovnTargets {
+		for peer, secret := range networkTargets {
 			err = s.SetConfig(peer, secret, map[string]string{"network.ovn.northbound_connection": ovnConfig})
 			if err != nil {
 				return err


### PR DESCRIPTION
Just found (and fixed) a bug where if `MicroOVN` doesn't exist, `MicroCloud` doesn't properly create the `lxdfan0` network on all peers. 