### PR TITLE
doc: fix version error

### DIFF
--- a/doc/.sphinx/requirements.txt
+++ b/doc/.sphinx/requirements.txt
@@ -9,3 +9,4 @@ pyspelling
 sphinxext-opengraph
 lxd-sphinx-extensions
 sphinx-copybutton
+urllib3<2


### PR DESCRIPTION
Read the docs uses an older Python version that cannot deal with urllib3 v2.0.