### PR TITLE
Skip GetServer on calls to LXD

### DIFF
--- a/microcloud/cmd/microcloud/ask.go
+++ b/microcloud/cmd/microcloud/ask.go
@@ -151,7 +151,7 @@ func askDisks(sh *service.ServiceHandler, peers map[string]mdns.ServerInfo, boot
 	allResources := make(map[string]*lxdAPI.Resources, len(peers))
 	var err error
 	for peer, info := range peers {
-		allResources[peer], err = sh.Services[types.LXD].(*service.LXDService).GetResources(sh.Name != peer, peer, info.Address, info.AuthSecret)
+		allResources[peer], err = sh.Services[types.LXD].(*service.LXDService).GetResources(peer, info.Address, info.AuthSecret)
 		if err != nil {
 			return nil, nil, fmt.Errorf("Failed to get system resources of peer %q: %w", peer, err)
 		}
@@ -304,7 +304,7 @@ func askLocalPool(peerDisks map[string][]lxdAPI.ResourcesStorageDisk, autoSetup 
 	}
 
 	toWipe := map[string]string{}
-	wipeable, err := lxd.HasExtension(false, lxd.Name(), lxd.Address(), "", "storage_pool_source_wipe")
+	wipeable, err := lxd.HasExtension(lxd.Name(), lxd.Address(), "", "storage_pool_source_wipe")
 	if err != nil {
 		return nil, nil, fmt.Errorf("Failed to check for source.wipe extension: %w", err)
 	}

--- a/microcloud/service/lxd.go
+++ b/microcloud/service/lxd.go
@@ -322,17 +322,13 @@ func (s *LXDService) AddRemotePools(targets map[string]string) error {
 }
 
 // HasExtension checks if the server supports the API extension.
-func (s *LXDService) HasExtension(useRemote bool, target string, address string, secret string, apiExtension string) (bool, error) {
+func (s *LXDService) HasExtension(target string, address string, secret string, apiExtension string) (bool, error) {
 	var err error
 	var client lxd.InstanceServer
-	if !useRemote {
+	if s.Name() == target {
 		client, err = s.client(secret)
 		if err != nil {
 			return false, err
-		}
-
-		if target != s.Name() {
-			client = client.UseTarget(target)
 		}
 	} else {
 		client, err = s.remoteClient(secret, address, CloudPort)
@@ -347,17 +343,13 @@ func (s *LXDService) HasExtension(useRemote bool, target string, address string,
 // GetResources returns the system resources for the LXD target.
 // As we cannot guarantee that LXD is available on this machine, the request is
 // forwarded through MicroCloud on via the ListenPort argument.
-func (s *LXDService) GetResources(useRemote bool, target string, address string, secret string) (*api.Resources, error) {
+func (s *LXDService) GetResources(target string, address string, secret string) (*api.Resources, error) {
 	var err error
 	var client lxd.InstanceServer
-	if !useRemote {
+	if s.Name() == target {
 		client, err = s.client(secret)
 		if err != nil {
 			return nil, err
-		}
-
-		if target != s.Name() {
-			client = client.UseTarget(target)
 		}
 	} else {
 		client, err = s.remoteClient(secret, address, CloudPort)

--- a/microcloud/service/lxd.go
+++ b/microcloud/service/lxd.go
@@ -52,7 +52,8 @@ func (s LXDService) client(secret string) (lxd.InstanceServer, error) {
 	}
 
 	return lxd.ConnectLXDUnix(s.m.FileSystem.ControlSocket().URL.Host, &lxd.ConnectionArgs{
-		HTTPClient: c.Client.Client,
+		HTTPClient:    c.Client.Client,
+		SkipGetServer: true,
 		Proxy: func(r *http.Request) (*url.URL, error) {
 			r.Header.Set("X-MicroCloud-Auth", secret)
 			if !strings.HasPrefix(r.URL.Path, "/1.0/services/lxd") {
@@ -75,6 +76,7 @@ func (s LXDService) remoteClient(secret string, address string, port int) (lxd.I
 	client, err := lxd.ConnectLXD(remoteURL.String(), &lxd.ConnectionArgs{
 		HTTPClient:         c.Client.Client,
 		InsecureSkipVerify: true,
+		SkipGetServer:      true,
 		Proxy: func(r *http.Request) (*url.URL, error) {
 			r.Header.Set("X-MicroCloud-Auth", secret)
 			if !strings.HasPrefix(r.URL.Path, "/1.0/services/lxd") {


### PR DESCRIPTION
I'm still not able to replicate the `no auth secret in response` error, but one potential cause may be the `GetServer` on every call to LXD. 

In order to get that error, it means we're sending a request that isn't going through the proxy specified to `ConnectLXD` for whatever reason. Since every call from MicroCloud does this, that means it might be something internal in LXD like this `GetServer` call.