### PR TITLE
Ensure AuthSecret before restarting broadcaster

### DIFF
--- a/microcloud/cmd/microcloudd/main.go
+++ b/microcloud/cmd/microcloudd/main.go
@@ -85,6 +85,13 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 	// Periodically check if new services have been installed.
 	go func() {
 		for {
+			if s.AuthSecret == "" {
+				logger.Debug("Waiting for initial setup before checking for optional services")
+				time.Sleep(1 * time.Second)
+
+				continue
+			}
+
 			updated := false
 			for serviceName, stateDir := range optionalServices {
 				if s.Services[serviceName] != nil {


### PR DESCRIPTION
Closes #110

Whew, finally caught this one! 🎉

In the end, I still wasn't able to replicate it successfully, but by using a lot of `time.Sleep`, reordering the `snap install` to put `microcloud` in between `microceph` and `microovn`, and abusing `lxc snapshot` to freeze the daemons temporarily, I was able to replicate it often enough to track down the source. 

Turns out the issue was the goroutine that checks for when optional services (MicroOVN and MicroCeph currently) are available. If MicroCloud can't find these services, but then they suddenly appear before the daemon fully sets up, we were attempting to "update" the broadcast message, but it hadn't been set up yet, and so the `AuthSecret` would end up missing. 