### PR TITLE
doc: adjust paths in .readthedocs.yaml

### DIFF
--- a/doc/.readthedocs.yaml
+++ b/doc/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   builder: dirhtml
-  configuration: conf.py
+  configuration: doc/conf.py
   fail_on_warning: true
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
@@ -24,4 +24,4 @@ formats:
 # Optionally declare the Python requirements required to build your docs
 python:
    install:
-   - requirements: .sphinx/requirements.txt
+   - requirements: doc/.sphinx/requirements.txt


### PR DESCRIPTION
Apparently, paths need to be relative to the root directory, not the directory that contains the .readthedocs.yaml file.