### PR TITLE
mdns: Replace CutSuffix with HasSuffix and TrimSuffix.

### DIFF
--- a/microcloud/mdns/lookup.go
+++ b/microcloud/mdns/lookup.go
@@ -78,11 +78,11 @@ func LookupPeers(ctx context.Context, version string, localPeer string) (map[str
 			return nil, fmt.Errorf("Received empty record")
 		}
 
-		serviceStr, ok := strings.CutSuffix(entry.Name, ".local.")
-		if !ok {
+		if !strings.HasSuffix(entry.Name, ".local.") {
 			continue
 		}
 
+		serviceStr := strings.TrimSuffix(entry.Name, ".local.")
 		parts := strings.SplitN(serviceStr, fmt.Sprintf(".%s_", ClusterService), 2)
 		if len(parts) != 2 {
 			continue


### PR DESCRIPTION
CutSuffix was added in go1.20. The go module for microcloud specifies go1.18 so we should only use what is availabile in that go version.

Closes #132 