### PR TITLE
Restart LXD on MicroCloud start to refresh symlinks

### DIFF
--- a/microcloud/cmd/microcloud/main_init.go
+++ b/microcloud/cmd/microcloud/main_init.go
@@ -51,6 +51,18 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 		return cmd.Help()
 	}
 
+	// Initially restart LXD so that the correct MicroCloud service related state is set by the LXD snap.
+	fmt.Println("Waiting for LXD to start...")
+	lxdService, err := service.NewLXDService(context.Background(), "", "", c.common.FlagMicroCloudDir)
+	if err != nil {
+		return err
+	}
+
+	err = lxdService.Restart(30)
+	if err != nil {
+		return err
+	}
+
 	addr, subnet, err := askAddress(c.flagAutoSetup, c.flagAddress)
 	if err != nil {
 		return err

--- a/microcloud/service/lxd.go
+++ b/microcloud/service/lxd.go
@@ -152,6 +152,11 @@ func (s LXDService) Bootstrap() error {
 
 // Join joins a cluster with the given token.
 func (s LXDService) Join(joinConfig JoinConfig) error {
+	err := s.Restart(30)
+	if err != nil {
+		return err
+	}
+
 	config, err := s.configFromToken(joinConfig.Token)
 	if err != nil {
 		return err

--- a/microcloud/service/service_handler.go
+++ b/microcloud/service/service_handler.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"sync"
 
-	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/microcluster/state"
 	"github.com/hashicorp/mdns"
 
@@ -84,10 +84,9 @@ func (s *Handler) Start(state *state.State) error {
 		return nil
 	}
 
-	// Attempt to wake up LXD so it can generate certificates already.
-	d, err := lxd.ConnectLXDUnix("/var/snap/lxd/common/lxd/unix.socket", nil)
-	if err == nil {
-		_, _, _ = d.GetServer()
+	err := s.Services[types.LXD].(*LXDService).Restart(30)
+	if err != nil {
+		logger.Error("Failed to restart LXD", logger.Ctx{"error": err})
 	}
 
 	s.AuthSecret, err = shared.RandomCryptoString()


### PR DESCRIPTION
Adds a hook that restarts LXD on uninitialized MicroCloud systems when MicroCloud starts.

I'm not sure if immediately calling `GetServer` like I'm doing here will cause issues on slower machines, it seems to work fine on my machine.

This still has the caveat of requiring a `snap restart microcloud` to force LXD to restart. I'm open to also putting this restart on run on an execution of `microcloud init` although I'm concerned that have some odd effects on slower machines again.