### PR TITLE
microcloud/cmd/microcloud/main/init: Apply remote pool to all peers

### DIFF
--- a/microcloud/cmd/microcloud/main_init.go
+++ b/microcloud/cmd/microcloud/main_init.go
@@ -412,8 +412,14 @@ func waitForCluster(sh *service.Handler, secrets map[string]string, peers map[st
 
 func postClusterSetup(bootstrap bool, sh *service.Handler, peers map[string]mdns.ServerInfo, lxdDisks map[string][]lxdAPI.ClusterMemberConfigKey, cephDisks map[string][]cephTypes.DisksPost, uplinkNetworks map[string]string, networkConfig map[string]string) error {
 	cephTargets := map[string]string{}
-	for target := range cephDisks {
-		cephTargets[target] = peers[target].AuthSecret
+	if len(cephDisks) > 0 {
+		for target := range peers {
+			cephTargets[target] = peers[target].AuthSecret
+		}
+
+		if bootstrap {
+			cephTargets[sh.Name] = ""
+		}
 	}
 
 	networkTargets := map[string]string{}


### PR DESCRIPTION
Fixes a bug where only peers that added disks to `microceph` would create a pending remote storage pool. Now all peers will create the pending remote storage pool if any disks across all peers are added to `microceph`.

It's not too pretty but this will be refactored out by #138 soon anyway.