### PR TITLE
microcloud/api/services/proxy: Don't use whole path for request URL

### DIFF
--- a/microcloud/api/services_proxy.go
+++ b/microcloud/api/services_proxy.go
@@ -94,7 +94,7 @@ func lxdHandler(s *state.State, r *http.Request) response.Response {
 	r.RequestURI = ""
 	r.URL.Path = path
 	r.URL.Scheme = "http"
-	r.URL.Host = filepath.Join(LXDDir, "unix.socket")
+	r.URL.Host = "unix.socket"
 	r.Host = r.URL.Host
 	client, err := lxd.ConnectLXDUnix(filepath.Join(LXDDir, "unix.socket"), nil)
 	if err != nil {
@@ -121,7 +121,7 @@ func microHandler(service string, stateDir string) func(*state.State, *http.Requ
 		r.RequestURI = ""
 		r.URL.Path = path
 		r.URL.Scheme = "http"
-		r.URL.Host = filepath.Join(stateDir, "control.socket")
+		r.URL.Host = "control.socket"
 		r.Host = r.URL.Host
 		client, err := microcluster.App(s.Context, microcluster.Args{StateDir: stateDir})
 		if err != nil {


### PR DESCRIPTION
Closes #140 

Looks like this started happening due to https://github.com/golang/go/commit/312920c00aac9897b2a0693e752390b5b0711a5a#diff-58d1202218e4b5db623ceb4abddb3c166adc4c34a327c1c9df106191edc370d2R589-R590

Instead of using the whole path, this changes the proxy to use the unix socket filenames in keeping with how LXD does it.