### PR TITLE
Sequentially join the cluster

### DIFF
--- a/microcloud/cmd/microcloud/ask.go
+++ b/microcloud/cmd/microcloud/ask.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"sort"
@@ -146,7 +147,7 @@ func (c *CmdControl) askDisks(sh *service.Handler, systems map[string]InitSystem
 	allResources := make(map[string]*api.Resources, len(systems))
 	var err error
 	for peer, system := range systems {
-		allResources[peer], err = sh.Services[types.LXD].(*service.LXDService).GetResources(peer, system.ServerInfo.Address, system.ServerInfo.AuthSecret)
+		allResources[peer], err = sh.Services[types.LXD].(*service.LXDService).GetResources(context.Background(), peer, system.ServerInfo.Address, system.ServerInfo.AuthSecret)
 		if err != nil {
 			return fmt.Errorf("Failed to get system resources of peer %q: %w", peer, err)
 		}
@@ -292,7 +293,7 @@ func askLocalPool(systems map[string]InitSystem, autoSetup bool, wipeAllDisks bo
 	}
 
 	toWipe := map[string]string{}
-	wipeable, err := lxd.HasExtension(lxd.Name(), lxd.Address(), "", "storage_pool_source_wipe")
+	wipeable, err := lxd.HasExtension(context.Background(), lxd.Name(), lxd.Address(), "", "storage_pool_source_wipe")
 	if err != nil {
 		return fmt.Errorf("Failed to check for source.wipe extension: %w", err)
 	}
@@ -523,7 +524,7 @@ func (c *CmdControl) askNetwork(sh *service.Handler, systems map[string]InitSyst
 		infos = append(infos, system.ServerInfo)
 	}
 
-	networks, err := sh.Services[types.LXD].(*service.LXDService).GetUplinkInterfaces(bootstrap, infos)
+	networks, err := sh.Services[types.LXD].(*service.LXDService).GetUplinkInterfaces(context.Background(), bootstrap, infos)
 	if err != nil {
 		return err
 	}

--- a/microcloud/cmd/microcloud/main_init.go
+++ b/microcloud/cmd/microcloud/main_init.go
@@ -498,7 +498,7 @@ func setupCluster(s *service.Handler, systems map[string]InitSystem) error {
 
 	config := map[string]string{"network.ovn.northbound_connection": ovnConfig}
 	lxd := s.Services[types.LXD].(*service.LXDService)
-	lxdClient, err := lxd.Client("")
+	lxdClient, err := lxd.Client(context.Background(), "")
 	if err != nil {
 		return err
 	}
@@ -528,7 +528,7 @@ func setupCluster(s *service.Handler, systems map[string]InitSystem) error {
 
 	// Create preliminary networks & storage pools on each target.
 	for name, system := range systems {
-		lxdClient, err := lxd.Client(system.ServerInfo.AuthSecret)
+		lxdClient, err := lxd.Client(context.Background(), system.ServerInfo.AuthSecret)
 		if err != nil {
 			return err
 		}
@@ -553,7 +553,7 @@ func setupCluster(s *service.Handler, systems map[string]InitSystem) error {
 	system, bootstrap := systems[s.Name]
 	if bootstrap {
 		lxd := s.Services[types.LXD].(*service.LXDService)
-		lxdClient, err := lxd.Client(system.ServerInfo.AuthSecret)
+		lxdClient, err := lxd.Client(context.Background(), system.ServerInfo.AuthSecret)
 		if err != nil {
 			return err
 		}
@@ -600,7 +600,7 @@ func setupCluster(s *service.Handler, systems map[string]InitSystem) error {
 
 	// With storage pools set up, add some volumes for images & backups.
 	for name, system := range systems {
-		lxdClient, err := lxd.Client(system.ServerInfo.AuthSecret)
+		lxdClient, err := lxd.Client(context.Background(), system.ServerInfo.AuthSecret)
 		if err != nil {
 			return err
 		}

--- a/microcloud/cmd/microcloud/main_init.go
+++ b/microcloud/cmd/microcloud/main_init.go
@@ -356,8 +356,6 @@ func AddPeers(sh *service.Handler, systems map[string]InitSystem) error {
 		time.Sleep(3 * time.Second)
 	}
 
-	fmt.Println("Cluster initialization is complete")
-
 	return nil
 }
 
@@ -403,6 +401,8 @@ func setupCluster(s *service.Handler, systems map[string]InitSystem) error {
 	if err != nil {
 		return err
 	}
+
+	fmt.Println("Configuring cluster-wide devices...")
 
 	var ovnConfig string
 	if s.Services[types.MicroOVN] != nil {

--- a/microcloud/cmd/microcloud/main_init.go
+++ b/microcloud/cmd/microcloud/main_init.go
@@ -262,6 +262,61 @@ func lookupPeers(s *service.Handler, autoSetup bool, subnet *net.IPNet, systems 
 	return nil
 }
 
+// waitForJoin issues a token and instructs a system to request a join,
+// and then waits for the request to either complete or time out.
+// If the request was successful, it additionally waits until the cluster appears in the database.
+func waitForJoin(sh *service.Handler, clusterSize int, secret string, peer string, cfg types.ServicesPut) error {
+	mut := sync.Mutex{}
+	err := sh.RunConcurrent(false, false, func(s service.Service) error {
+		token, err := s.IssueToken(context.Background(), peer)
+		if err != nil {
+			return fmt.Errorf("Failed to issue %s token for peer %q: %w", s.Type(), peer, err)
+		}
+
+		mut.Lock()
+		cfg.Tokens = append(cfg.Tokens, types.ServiceToken{Service: s.Type(), JoinToken: token})
+		mut.Unlock()
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	cloud := sh.Services[types.MicroCloud].(*service.CloudService)
+	err = cloud.RequestJoin(context.Background(), secret, peer, cfg)
+	if err != nil {
+		return fmt.Errorf("System %q failed to join the cluster: %w", peer, err)
+	}
+
+	clustered := make(map[types.ServiceType]bool, len(sh.Services))
+	for service := range sh.Services {
+		clustered[service] = false
+	}
+
+	now := time.Now()
+	for len(clustered) != 0 {
+		if time.Since(now) >= time.Second*30 {
+			return fmt.Errorf("Timed out waiting for cluster member %q to appear", peer)
+		}
+
+		for service := range clustered {
+			systems, err := sh.Services[service].ClusterMembers(context.Background())
+			if err != nil {
+				return err
+			}
+
+			if len(systems) == clusterSize+1 {
+				delete(clustered, service)
+			}
+		}
+	}
+
+	fmt.Printf(" Peer %q has joined the cluster\n", peer)
+
+	return nil
+}
+
 func AddPeers(sh *service.Handler, systems map[string]InitSystem) error {
 	joinConfig := make(map[string]types.ServicesPut, len(systems))
 	secrets := make(map[string]string, len(systems))
@@ -280,136 +335,30 @@ func AddPeers(sh *service.Handler, systems map[string]InitSystem) error {
 		secrets[peer] = info.ServerInfo.AuthSecret
 	}
 
-	mut := sync.Mutex{}
-	err := sh.RunConcurrent(false, false, func(s service.Service) error {
-		for peer := range joinConfig {
-			token, err := s.IssueToken(peer)
-			if err != nil {
-				return fmt.Errorf("Failed to issue %s token for peer %q: %w", s.Type(), peer, err)
-			}
-
-			mut.Lock()
-			cfg := joinConfig[peer]
-			cfg.Tokens = append(joinConfig[peer].Tokens, types.ServiceToken{Service: s.Type(), JoinToken: token})
-			joinConfig[peer] = cfg
-			mut.Unlock()
-		}
-
-		return nil
-	})
+	cluster, err := sh.Services[types.MicroCloud].ClusterMembers(context.Background())
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed to inspect existing cluster: %w", err)
 	}
 
+	clusterSize := len(cluster)
+
 	fmt.Println("Awaiting cluster formation ...")
-	// Initially add just 2 peers for each dqlite service to handle issues with role reshuffling while another
-	// node is joining the cluster.
-	initialSize := 2
-	if len(joinConfig) > initialSize {
-		initialCfg := map[string]types.ServicesPut{}
-		for peer, info := range joinConfig {
-			initialCfg[peer] = info
-
-			if len(initialCfg) == initialSize {
-				break
-			}
-		}
-
-		initialSecrets := make(map[string]string, len(initialCfg))
-		for peer := range initialCfg {
-			delete(joinConfig, peer)
-			initialSecrets[peer] = secrets[peer]
-			delete(secrets, peer)
-		}
-
-		err := waitForCluster(sh, initialSecrets, initialCfg)
+	for peer, cfg := range joinConfig {
+		logger.Debug("Initiating sequential request for cluster join", logger.Ctx{"peer": peer})
+		err := waitForJoin(sh, clusterSize, systems[peer].ServerInfo.AuthSecret, peer, cfg)
 		if err != nil {
 			return err
 		}
+
+		clusterSize = clusterSize + 1
 
 		// Sleep 3 seconds to give the cluster roles time to reshuffle before adding more members.
 		time.Sleep(3 * time.Second)
 	}
 
-	err = waitForCluster(sh, secrets, joinConfig)
-	if err != nil {
-		return err
-	}
-
 	fmt.Println("Cluster initialization is complete")
-	cloudService, ok := sh.Services[types.MicroCloud]
-	if !ok {
-		return fmt.Errorf("Missing MicroCloud service")
-	}
-
-	cloudCluster, err := cloudService.ClusterMembers(context.Background())
-	if err != nil {
-		return fmt.Errorf("Failed to get %s service cluster members: %w", cloudService.Type(), err)
-	}
-
-	err = sh.RunConcurrent(false, false, func(s service.Service) error {
-		if s.Type() == types.MicroCloud {
-			return nil
-		}
-
-		cluster, err := s.ClusterMembers(context.Background())
-		if err != nil {
-			return fmt.Errorf("Failed to get %s service cluster members: %w", s.Type(), err)
-		}
-
-		if len(cloudCluster) != len(cluster) {
-			return fmt.Errorf("%s service cluster does not match %s", s.Type(), cloudService.Type())
-		}
-
-		return nil
-	})
-	if err != nil {
-		return err
-	}
 
 	return nil
-}
-
-// waitForCluster will loop until the timeout has passed, or all cluster members for all services have reported that
-// their join process is complete.
-func waitForCluster(sh *service.Handler, secrets map[string]string, peers map[string]types.ServicesPut) error {
-	cloud := sh.Services[types.MicroCloud].(*service.CloudService)
-	joinedChan := cloud.RequestJoin(context.Background(), secrets, peers)
-	timeAfter := time.After(5 * time.Minute)
-	for {
-		select {
-		case <-timeAfter:
-			return fmt.Errorf("Timed out waiting for a response from all cluster members")
-		case entry, ok := <-joinedChan:
-			if !ok {
-				logger.Info("Join response channel has closed")
-
-				if len(peers) != 0 {
-					return fmt.Errorf("%q members failed to join the cluster", len(peers))
-				}
-
-				return nil
-			}
-
-			if entry.Error != nil {
-				return fmt.Errorf("Peer %q failed to join the cluster: %w", entry.Name, entry.Error)
-			}
-
-			_, ok = peers[entry.Name]
-			if !ok {
-				return fmt.Errorf("Unexpected response from unknown server %q", entry.Name)
-			}
-
-			fmt.Printf(" Peer %q has joined the cluster\n", entry.Name)
-
-			delete(peers, entry.Name)
-			if len(peers) == 0 {
-				close(joinedChan)
-
-				return nil
-			}
-		}
-	}
 }
 
 // setupCluster Bootstraps the cluster if necessary, adds all peers to the cluster, and completes any post cluster

--- a/microcloud/service/interface.go
+++ b/microcloud/service/interface.go
@@ -9,7 +9,7 @@ import (
 // Service represents a common interface for all MicroCloud services.
 type Service interface {
 	Bootstrap(ctx context.Context) error
-	IssueToken(peer string) (string, error)
+	IssueToken(ctx context.Context, peer string) (string, error)
 	Join(ctx context.Context, config JoinConfig) error
 	ClusterMembers(ctx context.Context) (map[string]string, error)
 

--- a/microcloud/service/microceph.go
+++ b/microcloud/service/microceph.go
@@ -104,7 +104,7 @@ func (s CephService) Bootstrap(ctx context.Context) error {
 }
 
 // IssueToken issues a token for the given peer.
-func (s CephService) IssueToken(peer string) (string, error) {
+func (s CephService) IssueToken(ctx context.Context, peer string) (string, error) {
 	return s.m.NewJoinToken(peer)
 }
 

--- a/microcloud/service/microcloud.go
+++ b/microcloud/service/microcloud.go
@@ -97,7 +97,7 @@ func (s CloudService) Bootstrap(ctx context.Context) error {
 }
 
 // IssueToken issues a token for the given peer.
-func (s CloudService) IssueToken(peer string) (string, error) {
+func (s CloudService) IssueToken(ctx context.Context, peer string) (string, error) {
 	return s.client.NewJoinToken(peer)
 }
 

--- a/microcloud/service/microcloud.go
+++ b/microcloud/service/microcloud.go
@@ -38,12 +38,6 @@ type JoinConfig struct {
 	CephConfig []cephTypes.DisksPost
 }
 
-// joinResponse is returned in a channel after sending a join request to a peer.
-type joinResponse struct {
-	Name  string
-	Error error
-}
-
 // NewCloudService creates a new MicroCloud service with a client attached.
 func NewCloudService(ctx context.Context, name string, addr string, dir string, verbose bool, debug bool) (*CloudService, error) {
 	client, err := microcluster.App(ctx, microcluster.Args{StateDir: dir, ListenPort: strconv.Itoa(CloudPort)})
@@ -106,37 +100,27 @@ func (s CloudService) Join(ctx context.Context, joinConfig JoinConfig) error {
 	return s.client.JoinCluster(s.name, util.CanonicalNetworkAddress(s.address, s.port), joinConfig.Token, 5*time.Minute)
 }
 
-// RequestJoin notifies the peers that that should begin the join operation.
-func (s CloudService) RequestJoin(ctx context.Context, secrets map[string]string, joinConfig map[string]types.ServicesPut) chan joinResponse {
-	joinedChan := make(chan joinResponse, len(joinConfig))
-	for peer, cfg := range joinConfig {
-		go func(peer string, cfg types.ServicesPut) {
-			if secrets[peer] == "" {
-				joinedChan <- joinResponse{Name: peer, Error: fmt.Errorf("No auth secret found for peer")}
-				return
-			}
+// RequestJoin sends the signal to initiate a join to the remote system, or timeout after a maximum of 5 min.
+func (s CloudService) RequestJoin(ctx context.Context, secret string, name string, joinConfig types.ServicesPut) error {
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*5)
+	defer cancel()
 
-			c, err := s.client.RemoteClient(util.CanonicalNetworkAddress(cfg.Address, CloudPort))
-			if err != nil {
-				joinedChan <- joinResponse{Name: peer, Error: err}
-				return
-			}
-
-			c.Client.Client.Transport = &http.Transport{
-				TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
-				DisableKeepAlives: true,
-				Proxy: func(r *http.Request) (*url.URL, error) {
-					r.Header.Set("X-MicroCloud-Auth", secrets[peer])
-
-					return shared.ProxyFromEnvironment(r)
-				},
-			}
-
-			joinedChan <- joinResponse{Name: peer, Error: client.JoinServices(ctx, c, cfg)}
-		}(peer, cfg)
+	c, err := s.client.RemoteClient(util.CanonicalNetworkAddress(joinConfig.Address, CloudPort))
+	if err != nil {
+		return err
 	}
 
-	return joinedChan
+	c.Client.Client.Transport = &http.Transport{
+		TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+		DisableKeepAlives: true,
+		Proxy: func(r *http.Request) (*url.URL, error) {
+			r.Header.Set("X-MicroCloud-Auth", secret)
+
+			return shared.ProxyFromEnvironment(r)
+		},
+	}
+
+	return client.JoinServices(ctx, c, joinConfig)
 }
 
 // ClusterMembers returns a map of cluster member names and addresses.

--- a/microcloud/service/microovn.go
+++ b/microcloud/service/microovn.go
@@ -82,7 +82,7 @@ func (s OVNService) Bootstrap(ctx context.Context) error {
 }
 
 // IssueToken issues a token for the given peer.
-func (s OVNService) IssueToken(peer string) (string, error) {
+func (s OVNService) IssueToken(ctx context.Context, peer string) (string, error) {
 	return s.m.NewJoinToken(peer)
 }
 


### PR DESCRIPTION
Relies on #138 

his modifies the cluster join logic of MicroCloud to issue a token and instruct a system to join the cluster sequentially, one peer at a time.

This slightly slows down the join process but makes it more resilient as one node will not be overwhelmed with too many token requests, and then each join token won't have only the issuer's address as the target of the join request.

When there are 7 or more nodes left, MicroCloud will fall back to the old concurrent style of joining which issues all tokens for all systems at once, then concurrently instructs them all to join. After 7 peers, we should begin to see spare roles so there is less of a chance of role turnover blocking the cluster completely.