### PR TITLE
doc/support: add a basic support page

### DIFF
--- a/doc/how-to/index.rst
+++ b/doc/how-to/index.rst
@@ -11,3 +11,4 @@ These how-to guides cover key operations and processes in MicroCloud.
    Install MicroCloud <install>
    Initialise MicroCloud <initialise>
    Add a machine <add_machine>
+   Get support <support>

--- a/doc/how-to/support.rst
+++ b/doc/how-to/support.rst
@@ -1,0 +1,28 @@
+.. _howto-support:
+
+How to get support
+==================
+
+MicroCloud is not yet ready for production.
+
+To benefit from the latest bug fixes, you should use the ``latest/edge`` snap channel for now.
+
+Support and community
+---------------------
+
+The following channels are available for you to interact with the MicroCloud community:
+
+- You can file bug reports and feature requests as `GitHub issues`_.
+- To ask questions, go to the MicroCloud section of our `discussion forum`_.
+
+Commercial support
+------------------
+
+Commercial support for MicroCloud is available through `Ubuntu Pro`_.
+
+Documentation
+-------------
+
+See the `MicroCloud documentation`_ for official product documentation.
+
+You can find additional resources on the `website`_ and in the `discussion forum`_.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -50,7 +50,7 @@ MicroCloud is a member of the Ubuntu family. It’s an open source project that 
 
 - `MicroCloud snap`_
 - `Contribute <GitHub_>`_
-- `Get support`_
+- `Get support <discussion forum_>`_
 - `Announcement`_
 - `Thinking about using MicroCloud for your next project? Get in touch! <website_>`_
 

--- a/doc/reuse/links.txt
+++ b/doc/reuse/links.txt
@@ -5,10 +5,12 @@
 .. _OVN: https://www.ovn.org/
 .. _MicroCloud snap: https://snapcraft.io/microcloud
 .. _GitHub: https://github.com/canonical/microcloud
-.. _Get support: https://discuss.linuxcontainers.org/tag/microcloud
+.. _Github issues: https://github.com/canonical/microcloud/issues/new
+.. _discussion forum: https://discourse.ubuntu.com/c/lxd/microcloud/
 .. _Announcement: https://discuss.linuxcontainers.org/t/introducing-microcloud/15871
 .. _website: https://microcloud.is
-.. _LXD online demo: https://linuxcontainers.org/lxd/try-it/
 .. _LXD snap: https://snapcraft.io/lxd
 .. _MicroCeph snap: https://snapcraft.io/microceph
 .. _MicroOVN snap: https://snapcraft.io/microovn
+.. _MicroCloud documentation: https://canonical-microcloud.readthedocs-hosted.com/en/latest/
+.. _Ubuntu Pro: https://ubuntu.com/support


### PR DESCRIPTION
MicroCloud isn't GA yet, so there isn't much to say yet - but having a page in place makes it easier to update it later. ;)