### PR TITLE
Fix MicroCeph reset in system tests

### DIFF
--- a/microcloud/service/microcloud.go
+++ b/microcloud/service/microcloud.go
@@ -40,7 +40,7 @@ type JoinConfig struct {
 
 // NewCloudService creates a new MicroCloud service with a client attached.
 func NewCloudService(ctx context.Context, name string, addr string, dir string, verbose bool, debug bool) (*CloudService, error) {
-	client, err := microcluster.App(ctx, microcluster.Args{StateDir: dir, ListenPort: strconv.Itoa(CloudPort)})
+	client, err := microcluster.App(ctx, microcluster.Args{StateDir: dir, ListenPort: strconv.Itoa(CloudPort), Debug: debug, Verbose: verbose})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Perhaps due to a recent MicroCeph update, the system tests were failing
to create OSD pools, and OSDs themselves weren't displaying (even though
they were created). This seems to be because cleaning out
`/var/snap/microceph` and restarting the snap doesn't create the
`var/snap/microceph/current/run` directory which is used by
microceph.osd.

Additionally cleans up some redundant OSD removal calls.