### PR TITLE
Preseed support fix for FAN networks

### DIFF
--- a/microcloud/cmd/microcloud/main_init_preseed.go
+++ b/microcloud/cmd/microcloud/main_init_preseed.go
@@ -387,8 +387,8 @@ func (p *Preseed) Parse(s *service.Handler, bootstrap bool) (map[string]InitSyst
 		}
 	}
 
-	// If we gave OVN config, implicitly assume we want interfaces and pick the first one.
-	usingOVN := p.OVN.IPv4Gateway != "" || p.OVN.IPv6Gateway != ""
+	// If we have specified any part of OVN config, implicitly assume we want to set it up.
+	usingOVN := p.OVN.IPv4Gateway != "" || p.OVN.IPv6Gateway != "" || len(ifaceByPeer) != 0
 	if usingOVN {
 		// Only select systems not explicitly picked above.
 		infos := make([]mdns.ServerInfo, 0, len(systems))
@@ -398,6 +398,7 @@ func (p *Preseed) Parse(s *service.Handler, bootstrap bool) (map[string]InitSyst
 			}
 		}
 
+		// Pick the first interface for any system without an explicitly chosen one.
 		networks, err := lxd.GetUplinkInterfaces(context.Background(), bootstrap, infos)
 		if err != nil {
 			return nil, err
@@ -410,7 +411,7 @@ func (p *Preseed) Parse(s *service.Handler, bootstrap bool) (map[string]InitSyst
 		}
 	}
 
-	if bootstrap && len(ifaceByPeer) < 3 {
+	if usingOVN && bootstrap && len(ifaceByPeer) < 3 {
 		return nil, fmt.Errorf("Failed to find at least 3 interfaces on 3 machines for OVN configuration")
 	}
 

--- a/microcloud/cmd/microcloud/main_init_preseed.go
+++ b/microcloud/cmd/microcloud/main_init_preseed.go
@@ -232,10 +232,6 @@ func (p *Preseed) validate(name string, bootstrap bool) error {
 		return err
 	}
 
-	if (InitNetwork{} != p.OVN) && !containsUplinks {
-		return fmt.Errorf("OVN uplink configuration found, but no uplink interfaces selected")
-	}
-
 	usingOVN := p.OVN.IPv4Gateway != "" || p.OVN.IPv6Gateway != "" || containsUplinks
 	if bootstrap && usingOVN && len(p.Systems) < 3 {
 		return fmt.Errorf("At least 3 systems are required to configure distributed networking")

--- a/microcloud/cmd/microcloud/preseed_test.go
+++ b/microcloud/cmd/microcloud/preseed_test.go
@@ -186,19 +186,6 @@ func (s *preseedSuite) Test_preseedValidateInvalid() {
 			err:    errors.New("At least 3 systems are required to configure distributed networking"),
 		},
 		{
-			desc:    "All systems missing interface, but uplink config given",
-			subnet:  "10.0.0.1/24",
-			systems: []System{{Name: "n1"}, {Name: "n2"}, {Name: "n3"}},
-			ovn:     InitNetwork{IPv4Gateway: "10.0.0.1/24", IPv4Range: "10.0.0.100-10.0.0.254", IPv6Gateway: "cafe::1/64"},
-			storage: StorageFilter{
-				Local: []DiskFilter{{Find: "abc", FindMin: 0, FindMax: 3, Wipe: false}},
-				Ceph:  []DiskFilter{{Find: "def", FindMin: 0, FindMax: 3, Wipe: false}},
-			},
-
-			addErr: true,
-			err:    errors.New("OVN uplink configuration found, but no uplink interfaces selected"),
-		},
-		{
 			desc:    "OVN IPv4 Ranges with no gateway",
 			subnet:  "10.0.0.1/24",
 			systems: []System{{Name: "n1", UplinkInterface: "eth0"}, {Name: "n2", UplinkInterface: "eth0"}, {Name: "n3", UplinkInterface: "eth0"}},

--- a/microcloud/test/suites/preseed.sh
+++ b/microcloud/test/suites/preseed.sh
@@ -83,4 +83,47 @@ EOF
   validate_system_lxd micro04 4 disk1 1 enp6s0 10.1.123.1/24 10.1.123.100-10.1.123.254 fd42:1:1234:1234::1/64
   validate_system_microceph micro04 disk2
   validate_system_microovn micro04
+
+  reset_systems 3 3 2
+  addr=$(lxc ls micro01 -f csv -c4 | grep enp5s0 | cut -d' ' -f1)
+
+  lxc exec micro01 -- sh -c "
+  cat << EOF > /root/preseed.yaml
+lookup_subnet: ${addr}/24
+systems:
+- name: micro01
+- name: micro02
+- name: micro03
+EOF
+"
+
+  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --preseed /root/preseed.yaml"
+  for m in micro01 micro02 micro03 ; do
+    validate_system_lxd ${m} 3
+    validate_system_microceph ${m}
+    validate_system_microovn ${m}
+  done
+
+  reset_systems 3 3 2
+  addr=$(lxc ls micro01 -f csv -c4 | grep enp5s0 | cut -d' ' -f1)
+
+  lxc exec micro01 -- sh -c "
+  snap disable microceph
+  snap disable microovn
+
+  sleep 1
+
+  cat << EOF > /root/preseed.yaml
+lookup_subnet: ${addr}/24
+systems:
+- name: micro01
+- name: micro02
+- name: micro03
+EOF
+"
+
+  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --preseed /root/preseed.yaml"
+  for m in micro01 micro02 micro03 ; do
+    validate_system_lxd ${m} 3
+  done
 }


### PR DESCRIPTION
If no part of the OVN configuration is specified, MicroCloud should try to set up a FAN network instead. 

If even one system has a specified interface, or if uplink addresses are given, then MicroCloud will try to find defaults for the other systems and set up OVN.