### PR TITLE
github: Skip snap build for pushes on branches from dependabot

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
     name: Trigger snap edge build
     runs-on: ubuntu-22.04
     needs: [code-tests, documentation-checks]
-    if: ${{ github.repository == 'canonical/microcloud' && github.event_name == 'push'}}
+    if: ${{ github.repository == 'canonical/microcloud' && github.event_name == 'push' && github.actor != 'dependabot[bot]'}}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
The snap build trigger will fail anyway because of the inaccessible secret. But its clearer to see it skipped.