### PR TITLE
doc: add a link to the landing page

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -59,6 +59,7 @@ MicroCloud is a member of the Ubuntu family. It’s an open source project that 
    :hidden:
    :maxdepth: 2
 
+   self
    tutorial/index
    how-to/index
    reference/index


### PR DESCRIPTION
It's hard to find back to the documentation start page at the moment.