### PR TITLE
github: Run push actions on main branch only

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,9 @@
 name: Tests
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
If dependabot creates new PRs, those are not originating from a fork. Instead a new branch is created in the same repository which triggers on both  and .

Limiting the push trigger to the main branch doesn't anymore duplicate the jobs for dependabot PRs.

Check here for reference: https://github.com/canonical/microcloud/pull/189