### PR TITLE
Fix double check-unit target in Makefile

### DIFF
--- a/microcloud/Makefile
+++ b/microcloud/Makefile
@@ -19,10 +19,6 @@ check-unit:
 check-system:
 	cd test && ./main.sh
 
-.PHONY: check-unit
-check-unit:
-	go test ./... -tags test
-
 .PHONY: check-static
 check-static:
 ifeq ($(shell command -v golangci-lint 2> /dev/null),)


### PR DESCRIPTION
Fixes #193