### PR TITLE
test/suites/basic: don't explicitely pull `curl`

### DIFF
--- a/microcloud/test/suites/basic.sh
+++ b/microcloud/test/suites/basic.sh
@@ -140,8 +140,6 @@ systems:
 config:
   cloud-init.user-data: |
     #cloud-config
-    packages:
-      - curl
     write_files:
       - content: |
           #!/bin/sh
@@ -218,8 +216,6 @@ ovn:
 config:
   cloud-init.user-data: |
     #cloud-config
-    packages:
-      - curl
     write_files:
       - content: |
           #!/bin/sh


### PR DESCRIPTION
The images used all include `curl` and pulling it explicitly cause slow `apt-get update` step that's not needed. The other cloud-config we have was already fixed to the same extent.