### PR TITLE
CephFS support

### DIFF
--- a/microcloud/cmd/microcloud/ask.go
+++ b/microcloud/cmd/microcloud/ask.go
@@ -222,7 +222,7 @@ func (c *CmdControl) askDisks(sh *service.Handler, systems map[string]InitSystem
 
 			if wantsDisks {
 				c.askRetry("Retry selecting disks?", autoSetup, func() error {
-					return askRemotePool(systems, autoSetup, wipeAllDisks, sh)
+					return c.askRemotePool(systems, autoSetup, wipeAllDisks, sh)
 				})
 			} else {
 				// Add a space between the CLI and the response.
@@ -401,7 +401,7 @@ func askLocalPool(systems map[string]InitSystem, autoSetup bool, wipeAllDisks bo
 	return nil
 }
 
-func askRemotePool(systems map[string]InitSystem, autoSetup bool, wipeAllDisks bool, sh *service.Handler) error {
+func (c *CmdControl) askRemotePool(systems map[string]InitSystem, autoSetup bool, wipeAllDisks bool, sh *service.Handler) error {
 	header := []string{"LOCATION", "MODEL", "CAPACITY", "TYPE", "PATH"}
 	data := [][]string{}
 	for peer, system := range systems {

--- a/microcloud/cmd/microcloud/main_init_preseed.go
+++ b/microcloud/cmd/microcloud/main_init_preseed.go
@@ -236,6 +236,10 @@ func (p *Preseed) validate(name string, bootstrap bool) error {
 		return err
 	}
 
+	if p.LookupInterface == "" {
+		return fmt.Errorf("Missing interface name for machine lookup")
+	}
+
 	usingOVN := p.OVN.IPv4Gateway != "" || p.OVN.IPv6Gateway != "" || containsUplinks
 	if bootstrap && usingOVN && len(p.Systems) < 3 {
 		return fmt.Errorf("At least 3 systems are required to configure distributed networking")
@@ -374,7 +378,12 @@ func (p *Preseed) Parse(s *service.Handler, bootstrap bool) (map[string]InitSyst
 	for _, iface := range ifaces {
 		if iface.Name == p.LookupInterface {
 			lookupIface = &iface
+			break
 		}
+	}
+
+	if lookupIface == nil {
+		return nil, fmt.Errorf("Failed to find lookup interface %q", p.LookupInterface)
 	}
 
 	err = lookupPeers(s, true, lookupIface, lookupSubnet, expectedSystems, systems)

--- a/microcloud/service/lxd_config.go
+++ b/microcloud/service/lxd_config.go
@@ -188,3 +188,45 @@ func (s LXDService) DefaultCephStoragePoolJoinConfig() api.ClusterMemberConfigKe
 		Value:  "lxd_remote",
 	}
 }
+
+// DefaultPendingCephFSStoragePool returns the default cephfs storage configuration when
+// creating a pending pool on a specific cluster member target.
+func (s LXDService) DefaultPendingCephFSStoragePool() api.StoragePoolsPost {
+	return api.StoragePoolsPost{
+		Name:   "remote-fs",
+		Driver: "cephfs",
+		StoragePoolPut: api.StoragePoolPut{
+			Config: map[string]string{
+				"source": "lxd_cephfs",
+			},
+		},
+	}
+}
+
+// DefaultCephFSStoragePool returns the default cephfs storage configuration when
+// creating the finalized pool.
+func (s LXDService) DefaultCephFSStoragePool() api.StoragePoolsPost {
+	return api.StoragePoolsPost{
+		Name:   "remote-fs",
+		Driver: "cephfs",
+		StoragePoolPut: api.StoragePoolPut{
+			Config: map[string]string{
+				"cephfs.create_missing": "true",
+				"cephfs.meta_pool":      "lxd_cephfs_meta",
+				"cephfs.data_pool":      "lxd_cephfs_data",
+			},
+			Description: "Distributed file-system storage using CephFS",
+		},
+	}
+}
+
+// DefaultCephFSStoragePoolJoinConfig returns the default cephfs storage configuration when
+// joining an existing cluster.
+func (s LXDService) DefaultCephFSStoragePoolJoinConfig() api.ClusterMemberConfigKey {
+	return api.ClusterMemberConfigKey{
+		Entity: "storage-pool",
+		Name:   "remote-fs",
+		Key:    "source",
+		Value:  "lxd_cephfs",
+	}
+}

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -539,6 +539,10 @@ cluster_reset() {
           microceph.ceph tell mon.\* injectargs '--mon-allow-pool-delete=true'
           lxc storage rm remote || true
           microceph.rados purge lxd_remote --yes-i-really-really-mean-it --force
+          microceph.ceph fs fail lxd_cephfs || true
+          microceph.ceph fs rm lxd_cephfs  --yes-i-really-mean-it || true
+          microceph.rados purge lxd_cephfs_meta --yes-i-really-really-mean-it --force || true
+          microceph.rados purge lxd_cephfs_data --yes-i-really-really-mean-it --force || true
           microceph.rados purge .mgr --yes-i-really-really-mean-it --force
 
           for pool in \$(microceph.ceph osd pool ls) ; do

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -511,6 +511,10 @@ reset_system() {
 
     lxc exec "${name}" -- ip link del lxdfan0 || true
 
+    # Resync the time in case it got out of sync with the other VMs.
+    lxc exec "${name}" --  timedatectl set-ntp off
+    lxc exec "${name}" --  timedatectl set-ntp on
+
     # Rescan for any disks we hid from the previous run.
     lxc exec "${name}" -- sh -c "
       for h in /sys/class/scsi_host/host*; do

--- a/microcloud/test/main.sh
+++ b/microcloud/test/main.sh
@@ -94,6 +94,18 @@ set +u
 if [ -z "${MICROCLOUD_SNAP_PATH}" ] || ! [ -e "${MICROCLOUD_SNAP_PATH}" ]; then
   MICROCLOUD_SNAP_PATH=""
 fi
+
+if [ -z "${MICROCLOUD_DEBUG_PATH}" ] || ! [ -e "${MICROCLOUD_DEBUG_PATH}" ]; then
+  MICROCLOUD_DEBUG_PATH=""
+fi
+
+if [ -z "${MICROCLOUDD_DEBUG_PATH}" ] || ! [ -e "${MICROCLOUDD_DEBUG_PATH}" ]; then
+  MICROCLOUDD_DEBUG_PATH=""
+fi
+
+if [ -z "${LXD_DEBUG_PATH}" ] || ! [ -e "${LXD_DEBUG_PATH}" ]; then
+  LXD_DEBUG_PATH=""
+fi
 set -u
 
 export MICROCLOUD_SNAP_PATH

--- a/microcloud/test/suites/add.sh
+++ b/microcloud/test/suites/add.sh
@@ -92,8 +92,8 @@ test_add_auto() {
   lxc exec micro01 -- tail -1 out | grep "MicroCloud is ready" -q
 
   for m in micro01 micro02 micro03 micro04 ; do
-    validate_system_lxd "${m}" 4 disk1 1
-    validate_system_microceph "${m}" disk2
+    validate_system_lxd "${m}" 4 disk1 1 0
+    validate_system_microceph "${m}" 0 disk2
     validate_system_microovn "${m}"
   done
 }
@@ -116,6 +116,7 @@ test_add_interactive() {
   export ZFS_FILTER="lxd_disk1"
   export ZFS_WIPE="yes"
   export SETUP_CEPH="yes"
+  export SETUP_CEPHFS="yes"
   export CEPH_WIPE="yes"
   export SETUP_OVN="yes"
   export OVN_FILTER="enp6s0"
@@ -148,8 +149,8 @@ test_add_interactive() {
   lxc exec micro01 -- tail -1 out | grep "MicroCloud is ready" -q
 
   for m in micro01 micro02 micro03 micro04 ; do
-    validate_system_lxd "${m}" 4 disk1 1 enp6s0 10.1.123.1/24 10.1.123.100-10.1.123.254 fd42:1:1234:1234::1/64
-    validate_system_microceph "${m}" disk2
+    validate_system_lxd "${m}" 4 disk1 1 1 enp6s0 10.1.123.1/24 10.1.123.100-10.1.123.254 fd42:1:1234:1234::1/64
+    validate_system_microceph "${m}" 1 disk2
     validate_system_microovn "${m}"
   done
 

--- a/microcloud/test/suites/basic.sh
+++ b/microcloud/test/suites/basic.sh
@@ -48,15 +48,16 @@ test_interactive() {
   done
 
   echo "Creating a MicroCloud with ZFS and Ceph storage"
-  SETUP_CEPH="yes"
-  CEPH_FILTER="lxd_disk2"
-  CEPH_WIPE="yes"
+  export SETUP_CEPH="yes"
+  export SETUP_CEPHFS="yes"
+  export CEPH_FILTER="lxd_disk2"
+  export CEPH_WIPE="yes"
   microcloud_interactive | lxc exec micro01 -- sh -c "microcloud init > out"
 
   lxc exec micro01 -- tail -1 out | grep "MicroCloud is ready" -q
   for m in micro01 micro02 micro03 ; do
-    validate_system_lxd "${m}" 3 disk1 1
-    validate_system_microceph "${m}" disk2
+    validate_system_lxd "${m}" 3 disk1 1 1
+    validate_system_microceph "${m}" 1 disk2
   done
 
   # Reset the systems and install microovn.
@@ -68,7 +69,7 @@ test_interactive() {
   done
 
   echo "Creating a MicroCloud with ZFS storage and OVN network"
-  unset SETUP_CEPH CEPH_FILTER CEPH_WIPE
+  unset SETUP_CEPH CEPH_FILTER CEPH_WIPE SETUP_CEPHFS
 
   export SETUP_OVN="yes"
   export OVN_FILTER="enp6s0"
@@ -80,7 +81,7 @@ test_interactive() {
 
   lxc exec micro01 -- tail -1 out | grep "MicroCloud is ready" -q
   for m in micro01 micro02 micro03 ; do
-    validate_system_lxd "${m}" 3 disk1 0 "${OVN_FILTER}" "${IPV4_SUBNET}" "${IPV4_START}"-"${IPV4_END}" "${IPV6_SUBNET}"
+    validate_system_lxd "${m}" 3 disk1 0 0 "${OVN_FILTER}" "${IPV4_SUBNET}" "${IPV4_START}"-"${IPV4_END}" "${IPV6_SUBNET}"
     validate_system_microovn "${m}"
   done
 
@@ -90,14 +91,15 @@ test_interactive() {
   echo "Creating a MicroCloud with ZFS and Ceph storage, and OVN network"
   unset SKIP_SERVICE
   export SETUP_CEPH="yes"
+  export SETUP_CEPHFS="yes"
   export CEPH_FILTER="lxd_disk2"
   export CEPH_WIPE="yes"
   microcloud_interactive | lxc exec micro01 -- sh -c "microcloud init > out"
 
   lxc exec micro01 -- tail -1 out | grep "MicroCloud is ready" -q
   for m in micro01 micro02 micro03 ; do
-    validate_system_lxd "${m}" 3 disk1 3 "${OVN_FILTER}" "${IPV4_SUBNET}" "${IPV4_START}"-"${IPV4_END}" "${IPV6_SUBNET}"
-    validate_system_microceph "${m}" disk2
+    validate_system_lxd "${m}" 3 disk1 3 1 "${OVN_FILTER}" "${IPV4_SUBNET}" "${IPV4_START}"-"${IPV4_END}" "${IPV6_SUBNET}"
+    validate_system_microceph "${m}" 1 disk2
     validate_system_microovn "${m}"
   done
 }
@@ -202,6 +204,8 @@ ovn:
   ipv4_gateway: 10.1.123.1/24
   ipv4_range: 10.1.123.100-10.1.123.254
   ipv6_gateway: fd42:1:1234:1234::1/64
+storage:
+  cephfs: true
 "
 
   lxc exec micro01 -- sh -c "cat /root/preseed.yaml | TEST_CONSOLE=0 microcloud init --preseed"
@@ -222,6 +226,13 @@ config:
           exec curl --unix-socket /dev/lxd/sock lxd/1.0 -X PATCH -d '{\"state\": \"Ready\"}'
         path: /var/lib/cloud/scripts/per-boot/ready.sh
         permissions: \"0755\"
+devices:
+  fs:
+    ceph.cluster_name: ceph
+    ceph.user_name: admin
+    path: /cephfs
+    source: cephfs:lxd_cephfs/
+    type: disk
 EOF
 "
 
@@ -235,6 +246,8 @@ EOF
     lxc exec micro01 -- sh -ceu "
     for round in \$(seq 300); do
       if lxc info ${m} | grep -qF \"Status: READY\" ; then
+         lxc exec ${m} -- stat /cephfs
+
          lxc rm ${m} -f
 
          return 0
@@ -271,6 +284,7 @@ test_case() {
 
     expected_zfs_disk=""
     expected_ceph_disks=0
+    expected_cephfs=0
     expected_ovn_iface=""
 
     unset_interactive_vars
@@ -313,10 +327,15 @@ test_case() {
         echo "Insufficient disks"
       elif [ -z "${force_no_ceph}" ]; then
         SETUP_CEPH="yes"
+        SETUP_CEPHFS="yes"
         CEPH_WIPE="yes"
         expected_ceph_disks="${num_disks}"
         if [ -n "${expected_zfs_disk}" ]; then
           expected_ceph_disks="$((num_disks - 1))"
+        fi
+
+        if [ "${expected_ceph_disks}" -gt 0 ]; then
+          expected_cephfs=1
         fi
       else
         SETUP_CEPH="no"
@@ -346,9 +365,9 @@ test_case() {
       name="$(printf "micro%02d" "${i}")"
 
       if [ -n "${expected_ovn_iface}" ]; then
-        validate_system_lxd "${name}" "${num_systems}" "${expected_zfs_disk}" "${expected_ceph_disks}" "${expected_ovn_iface}" "${IPV4_SUBNET}" "${IPV4_START}"-"${IPV4_END}" "${IPV6_SUBNET}"
+        validate_system_lxd "${name}" "${num_systems}" "${expected_zfs_disk}" "${expected_ceph_disks}" "${expected_cephfs}" "${expected_ovn_iface}" "${IPV4_SUBNET}" "${IPV4_START}"-"${IPV4_END}" "${IPV6_SUBNET}"
       else
-        validate_system_lxd "${name}" "${num_systems}" "${expected_zfs_disk}" "${expected_ceph_disks}" "${expected_ovn_iface}"
+        validate_system_lxd "${name}" "${num_systems}" "${expected_zfs_disk}" "${expected_ceph_disks}" "${expected_cephfs}" "${expected_ovn_iface}"
       fi
 
       start_disk=1
@@ -364,7 +383,7 @@ test_case() {
         done
       fi
 
-      validate_system_microceph "${name}" "${ceph_disks}"
+      validate_system_microceph "${name}" "${expected_cephfs}" "${ceph_disks}"
       validate_system_microovn "${name}"
     done
   }
@@ -515,18 +534,19 @@ test_disk_mismatch() {
   export ZFS_FILTER="lxd_disk1"
   export ZFS_WIPE="yes"
   export SETUP_CEPH="yes"
+  export SETUP_CEPHFS="yes"
   export CEPH_WARNING="yes"
   export CEPH_WIPE="yes"
   export SETUP_OVN="no"
   microcloud_interactive | lxc exec micro01 -- sh -c "microcloud init > out"
   lxc exec micro01 -- tail -1 out | grep "MicroCloud is ready" -q
   for m in micro01 micro02 micro03 micro04 ; do
-    validate_system_lxd "${m}" 4 disk1 6
+    validate_system_lxd "${m}" 4 disk1 6 1
     validate_system_microovn "${m}"
   done
 
   for m in micro01 micro02 micro03 ; do
-    validate_system_microceph "${m}" disk2 disk3
+    validate_system_microceph "${m}" 1 disk2 disk3
   done
 
   validate_system_microceph "micro04"
@@ -631,8 +651,8 @@ test_auto() {
   echo Auto-create a MicroCloud with 3 systems with 1 disk and 1 interface each.
   lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --auto > out"
   for m in micro01 micro02 micro03; do
-    validate_system_lxd "${m}" 3 "" 1
-    validate_system_microceph "${m}" disk1
+    validate_system_lxd "${m}" 3 "" 1 0
+    validate_system_microceph "${m}" 0 disk1
     validate_system_microovn "${m}"
 
     # Ensure we didn't create any other network devices.
@@ -648,8 +668,8 @@ test_auto() {
   echo Auto-create a MicroCloud with 3 systems with 3 disks and 1 interface each.
   lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --auto > out"
   for m in micro01 micro02 micro03 ; do
-    validate_system_lxd "${m}" 3 disk1 2
-    validate_system_microceph "${m}" disk2 disk3
+    validate_system_lxd "${m}" 3 disk1 2 0
+    validate_system_microceph "${m}" 0 disk2 disk3
     validate_system_microovn "${m}"
 
     # Ensure we didn't create any other network devices.

--- a/microcloud/test/suites/basic.sh
+++ b/microcloud/test/suites/basic.sh
@@ -112,6 +112,7 @@ test_instances() {
   lxc exec micro01 -- sh -c "
   cat << EOF > /root/preseed.yaml
 lookup_subnet: ${addr}/24
+lookup_interface: enp5s0
 systems:
 - name: micro01
   storage:
@@ -178,6 +179,7 @@ EOF
   lxc exec micro01 -- sh -c "
   cat << EOF > /root/preseed.yaml
 lookup_subnet: ${addr}/24
+lookup_interface: enp5s0
 systems:
 - name: micro01
   storage:

--- a/microcloud/test/suites/preseed.sh
+++ b/microcloud/test/suites/preseed.sh
@@ -67,6 +67,7 @@ EOF
   lxc exec micro01 -- sh -c "
   cat << EOF > /root/preseed.yaml
 lookup_subnet: ${lookup_addr}/24
+lookup_interface: enp5s0
 systems:
 - name: micro04
   ovn_uplink_interface: enp6s0
@@ -97,6 +98,7 @@ EOF
   lxc exec micro01 -- sh -c "
   cat << EOF > /root/preseed.yaml
 lookup_subnet: ${lookup_addr}/24
+lookup_interface: enp5s0
 systems:
 - name: micro01
 - name: micro02
@@ -123,6 +125,7 @@ EOF
 
   cat << EOF > /root/preseed.yaml
 lookup_subnet: ${lookup_addr}/24
+lookup_interface: enp5s0
 systems:
 - name: micro01
 - name: micro02

--- a/microcloud/test/suites/preseed.sh
+++ b/microcloud/test/suites/preseed.sh
@@ -32,6 +32,7 @@ ovn:
   dns_servers: 10.1.123.1,8.8.8.8,fd42:1:1234:1234::1
 
 storage:
+  cephfs: true
   local:
     - find: id == sdb
       find_min: 2
@@ -52,14 +53,14 @@ EOF
   lxc exec micro01 -- sh -c "cat /root/preseed.yaml | TEST_CONSOLE=0 microcloud init --preseed"
 
   for m in micro01 micro03 ; do
-    validate_system_lxd ${m} 3 disk1 2 enp6s0 10.1.123.1/24 10.1.123.100-10.1.123.254 fd42:1:1234:1234::1/64 10.1.123.1,8.8.8.8,fd42:1:1234:1234::1
-    validate_system_microceph ${m} disk2 disk3
+    validate_system_lxd ${m} 3 disk1 2 1 enp6s0 10.1.123.1/24 10.1.123.100-10.1.123.254 fd42:1:1234:1234::1/64 10.1.123.1,8.8.8.8,fd42:1:1234:1234::1
+    validate_system_microceph ${m} 1 disk2 disk3
     validate_system_microovn ${m}
   done
 
   # Disks on micro02 should have been manually selected.
-  validate_system_lxd micro02 3 sdc 2 enp6s0 10.1.123.1/24 10.1.123.100-10.1.123.254 fd42:1:1234:1234::1/64
-  validate_system_microceph micro02 disk1 disk3
+  validate_system_lxd micro02 3 sdc 2 1 enp6s0 10.1.123.1/24 10.1.123.100-10.1.123.254 fd42:1:1234:1234::1/64
+  validate_system_microceph micro02 1 disk1 disk3
   validate_system_microovn micro02
 
   # Grow the MicroCloud with a new node, with filter-based storage selection.
@@ -70,6 +71,7 @@ systems:
 - name: micro04
   ovn_uplink_interface: enp6s0
 storage:
+  cephfs: true
   local:
     - find: id == sdb
       find_min: 1
@@ -84,8 +86,8 @@ EOF
 "
 
   lxc exec micro01 -- sh -c "cat /root/preseed.yaml | TEST_CONSOLE=0 microcloud add --preseed"
-  validate_system_lxd micro04 4 disk1 1 enp6s0 10.1.123.1/24 10.1.123.100-10.1.123.254 fd42:1:1234:1234::1/64
-  validate_system_microceph micro04 disk2
+  validate_system_lxd micro04 4 disk1 1 1 enp6s0 10.1.123.1/24 10.1.123.100-10.1.123.254 fd42:1:1234:1234::1/64
+  validate_system_microceph micro04 1 disk2
   validate_system_microovn micro04
 
   reset_systems 3 3 2


### PR DESCRIPTION
Adds a step in the interactive setup after selecting disks for MicroCeph that asks if the user also wants CephFS.

This is also included in the preseed support with a boolean flag in the `storage` section.