### PR TITLE
Specify lookup interface to mdns handler

### DIFF
--- a/microcloud/cmd/microcloud/add.go
+++ b/microcloud/cmd/microcloud/add.go
@@ -57,7 +57,7 @@ func (c *cmdAdd) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("MicroCloud is uninitialized, run 'microcloud init' first")
 	}
 
-	addr, subnet, err := c.common.askAddress(c.flagAutoSetup, status.Address.Addr().String())
+	addr, iface, subnet, err := c.common.askAddress(c.flagAutoSetup, status.Address.Addr().String())
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func (c *cmdAdd) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	systems := map[string]InitSystem{}
-	err = lookupPeers(s, c.flagAutoSetup, subnet, nil, systems)
+	err = lookupPeers(s, c.flagAutoSetup, iface, subnet, nil, systems)
 	if err != nil {
 		return err
 	}

--- a/microcloud/cmd/microcloud/main_init.go
+++ b/microcloud/cmd/microcloud/main_init.go
@@ -93,7 +93,7 @@ func (c *cmdInit) RunInteractive(cmd *cobra.Command, args []string) error {
 
 	systems := map[string]InitSystem{}
 
-	addr, subnet, err := c.common.askAddress(c.flagAutoSetup, c.flagAddress)
+	addr, iface, subnet, err := c.common.askAddress(c.flagAutoSetup, c.flagAddress)
 	if err != nil {
 		return err
 	}
@@ -126,7 +126,7 @@ func (c *cmdInit) RunInteractive(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = lookupPeers(s, c.flagAutoSetup, subnet, nil, systems)
+	err = lookupPeers(s, c.flagAutoSetup, iface, subnet, nil, systems)
 	if err != nil {
 		return err
 	}
@@ -155,7 +155,7 @@ func (c *cmdInit) RunInteractive(cmd *cobra.Command, args []string) error {
 // - If `autoSetup` is true, all systems found in the first 5s will be recorded, and no other input is required.
 // - `expectedSystems` is a list of expected hostnames. If given, the behaviour is similar to `autoSetup`,
 // except it will wait up to a minute for exclusively these systems to be recorded.
-func lookupPeers(s *service.Handler, autoSetup bool, subnet *net.IPNet, expectedSystems []string, systems map[string]InitSystem) error {
+func lookupPeers(s *service.Handler, autoSetup bool, iface *net.Interface, subnet *net.IPNet, expectedSystems []string, systems map[string]InitSystem) error {
 	header := []string{"NAME", "IFACE", "ADDR"}
 	var table *SelectableTable
 	var answers []string
@@ -214,7 +214,7 @@ func lookupPeers(s *service.Handler, autoSetup bool, subnet *net.IPNet, expected
 				break
 			}
 
-			peers, err := mdns.LookupPeers(context.Background(), mdns.Version, s.Name)
+			peers, err := mdns.LookupPeers(context.Background(), iface, mdns.Version, s.Name)
 			if err != nil {
 				return err
 			}

--- a/microcloud/cmd/microcloud/main_init_preseed.go
+++ b/microcloud/cmd/microcloud/main_init_preseed.go
@@ -24,10 +24,11 @@ import (
 
 // Preseed represents the structure of the supported preseed yaml.
 type Preseed struct {
-	LookupSubnet string        `yaml:"lookup_subnet"`
-	Systems      []System      `yaml:"systems"`
-	OVN          InitNetwork   `yaml:"ovn"`
-	Storage      StorageFilter `yaml:"storage"`
+	LookupSubnet    string        `yaml:"lookup_subnet"`
+	LookupInterface string        `yaml:"lookup_interface"`
+	Systems         []System      `yaml:"systems"`
+	OVN             InitNetwork   `yaml:"ovn"`
+	Storage         StorageFilter `yaml:"storage"`
 }
 
 // System represents the structure of the systems we expect to find in the preseed yaml.
@@ -362,7 +363,19 @@ func (p *Preseed) Parse(s *service.Handler, bootstrap bool) (map[string]InitSyst
 		return nil, err
 	}
 
-	err = lookupPeers(s, true, lookupSubnet, expectedSystems, systems)
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get network interfaces: %w", err)
+	}
+
+	var lookupIface *net.Interface
+	for _, iface := range ifaces {
+		if iface.Name == p.LookupInterface {
+			lookupIface = &iface
+		}
+	}
+
+	err = lookupPeers(s, true, lookupIface, lookupSubnet, expectedSystems, systems)
 	if err != nil {
 		return nil, err
 	}

--- a/microcloud/mdns/lookup.go
+++ b/microcloud/mdns/lookup.go
@@ -58,10 +58,10 @@ func (f forwardingWriter) Write(p []byte) (int, error) {
 }
 
 // LookupPeers finds any broadcasting peers and returns a list of their names.
-func LookupPeers(ctx context.Context, version string, localPeer string) (map[string]ServerInfo, error) {
+func LookupPeers(ctx context.Context, iface *net.Interface, version string, localPeer string) (map[string]ServerInfo, error) {
 	entries := []*mdns.ServiceEntry{}
 	for i := 0; i < ServiceSize; i++ {
-		nextEntries, err := Lookup(ctx, fmt.Sprintf("%s_%d", ClusterService, i), clusterSize)
+		nextEntries, err := Lookup(ctx, iface, fmt.Sprintf("%s_%d", ClusterService, i), clusterSize)
 		if err != nil {
 			return nil, err
 		}
@@ -125,7 +125,7 @@ func LookupPeers(ctx context.Context, version string, localPeer string) (map[str
 }
 
 // Lookup searches for the given service name over mdns.
-func Lookup(ctx context.Context, service string, size int) ([]*mdns.ServiceEntry, error) {
+func Lookup(ctx context.Context, iface *net.Interface, service string, size int) ([]*mdns.ServiceEntry, error) {
 	log.SetOutput(forwardingWriter{})
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -145,6 +145,7 @@ func Lookup(ctx context.Context, service string, size int) ([]*mdns.ServiceEntry
 	}()
 
 	params := mdns.DefaultParams(service)
+	params.Interface = iface
 	params.Entries = entriesCh
 	params.Timeout = 100 * time.Millisecond
 	err := mdns.Query(params)

--- a/microcloud/mdns/lookup.go
+++ b/microcloud/mdns/lookup.go
@@ -28,7 +28,7 @@ type ServerInfo struct {
 
 // NetworkInfo represents information about a network interface broadcast by a MicroCloud peer.
 type NetworkInfo struct {
-	Interface string
+	Interface net.Interface
 	Address   string
 	Subnet    *net.IPNet
 }
@@ -185,7 +185,7 @@ func GetNetworkInfo() ([]NetworkInfo, error) {
 				continue
 			}
 
-			networks = append(networks, NetworkInfo{Interface: iface.Name, Address: ipNet.IP.String(), Subnet: ipNet})
+			networks = append(networks, NetworkInfo{Interface: iface, Address: ipNet.IP.String(), Subnet: ipNet})
 		}
 	}
 

--- a/microcloud/service/service_handler.go
+++ b/microcloud/service/service_handler.go
@@ -120,7 +120,7 @@ func (s *Handler) Broadcast() error {
 	broadcasts := make([][]cloudMDNS.ServerInfo, cloudMDNS.ServiceSize)
 	for i, net := range networks {
 		info.Address = net.Address
-		info.Interface = net.Interface
+		info.Interface = net.Interface.Name
 
 		services := broadcasts[i%cloudMDNS.ServiceSize]
 		if services == nil {

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -457,7 +457,7 @@ reset_system() {
       disks=\$(lsblk -o NAME,SERIAL | grep \"lxd_disk[0-9]\" | cut -d\" \" -f1 | tac)
       count_disks=\$(echo \"\${disks}\" | wc -l)
       for d in \${disks} ; do
-        if [ \${count_disks} -gt \${num_disks} ]; then
+        if [ \${count_disks} -gt ${num_disks} ]; then
           echo 1 > /sys/block/\${d}/device/delete
         else
           wipefs -af /dev/\${d}

--- a/microcloud/test/suites/preseed.sh
+++ b/microcloud/test/suites/preseed.sh
@@ -7,6 +7,7 @@ test_preseed() {
   lxc exec micro01 -- sh -c "
   cat << EOF > /root/preseed.yaml
 lookup_subnet: ${lookup_addr}/24
+lookup_interface: enp5s0
 systems:
 - name: micro01
   ovn_uplink_interface: enp6s0


### PR DESCRIPTION
Additionally adds a `lookup_interface` key to the preseed so that can have the same behaviour.