### PR TITLE
doc: remove recommendation of edge

### DIFF
--- a/doc/how-to/snaps.rst
+++ b/doc/how-to/snaps.rst
@@ -19,9 +19,7 @@ See `Channels and tracks`_ in the snap documentation for detailed information.
 MicroCloud currently provides only the ``latest`` track.
 
 .. tip::
-   In general, you should use the ``latest/stable`` channel for all snaps required to run MicroCloud.
-
-   However, since MicroCloud is not ready for production yet, you might want to use the ``latest/edge`` channel of the MicroCloud snap to benefit from the latest bug fixes.
+   In general, you should use the default channels for all snaps required to run MicroCloud.
 
 When installing a snap, specify the channel as follows::
 

--- a/doc/how-to/support.rst
+++ b/doc/how-to/support.rst
@@ -5,7 +5,7 @@ How to get support
 
 MicroCloud is not yet ready for production.
 
-To benefit from the latest bug fixes, you should use the ``latest/edge`` snap channel for now.
+We recommend using the default channels for all snaps required to run MicroCloud.
 
 Support and community
 ---------------------


### PR DESCRIPTION
We recommended using the edge channel, but now the default channels work, so we should recommend to use those.