### PR TITLE
microcloud/service: Properly broadcast available interfaces over those interfaces

### DIFF
--- a/microcloud/mdns/mdns.go
+++ b/microcloud/mdns/mdns.go
@@ -17,7 +17,7 @@ const ServiceSize = 10
 const clusterSize = 1000
 
 // NewBroadcast returns a running mdns.Server which broadcasts the service at the given name and address.
-func NewBroadcast(name string, addr string, port int, service string, txt []byte) (*mdns.Server, error) {
+func NewBroadcast(name string, iface *net.Interface, addr string, port int, service string, txt []byte) (*mdns.Server, error) {
 	var sendTXT []string
 	if txt != nil {
 		sendTXT = dnsTXTSlice(txt)
@@ -28,7 +28,7 @@ func NewBroadcast(name string, addr string, port int, service string, txt []byte
 		return nil, fmt.Errorf("Failed to create configuration for broadcast: %w", err)
 	}
 
-	server, err := mdns.NewServer(&mdns.Config{Zone: config})
+	server, err := mdns.NewServer(&mdns.Config{Zone: config, Iface: iface})
 	if err != nil {
 		return nil, fmt.Errorf("Failed to begin broadcast: %w", err)
 	}

--- a/microcloud/service/service_handler.go
+++ b/microcloud/service/service_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"sync"
@@ -142,7 +143,12 @@ func (s *Handler) Broadcast() error {
 				return fmt.Errorf("Failed to marshal server info: %w", err)
 			}
 
-			server, err := cloudMDNS.NewBroadcast(info.LookupKey(), info.Address, s.Port, service, bytes)
+			iface, err := net.InterfaceByName(info.Interface)
+			if err != nil {
+				return err
+			}
+
+			server, err := cloudMDNS.NewBroadcast(info.LookupKey(), iface, info.Address, s.Port, service, bytes)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION

Lookup was recently updated to lookup mDNS records via a particular interface, but the mDNS broadcasts were always coming from the default interface, even when advertising a different interface, so the lookup would ignore these records as they aren't coming from an interface that it expected.