### PR TITLE
Fix ceph disk validation

### DIFF
--- a/microcloud/cmd/microcloud/main_init_preseed.go
+++ b/microcloud/cmd/microcloud/main_init_preseed.go
@@ -214,8 +214,8 @@ func (p *Preseed) validate(name string, bootstrap bool) error {
 	}
 
 	containsCephStorage = directCephCount > 0
-	if containsCephStorage && directCephCount < len(p.Systems) && len(p.Storage.Ceph) == 0 {
-		return fmt.Errorf("Some systems are missing ceph storage disks")
+	if containsCephStorage && directCephCount < 3 && len(p.Storage.Ceph) == 0 && bootstrap {
+		return fmt.Errorf("At least 3 systems must specify ceph storage disks")
 	}
 
 	containsLocalStorage = directLocalCount > 0

--- a/microcloud/cmd/microcloud/preseed_test.go
+++ b/microcloud/cmd/microcloud/preseed_test.go
@@ -94,14 +94,14 @@ func (s *preseedSuite) Test_preseedValidateInvalid() {
 			subnet:  "10.0.0.1/24",
 			systems: []System{{Name: "n1", Storage: InitStorage{Ceph: []DirectStorage{{Path: "def"}}}}, {Name: "n2", Storage: InitStorage{Ceph: []DirectStorage{{Path: "def"}}}}},
 			addErr:  false,
-			err:     errors.New("At least 3 systems are required to configure distributed storage"),
+			err:     errors.New("At least 3 systems must specify ceph storage disks"),
 		},
 		{
 			desc:    "Incomplete ceph direct selection",
 			subnet:  "10.0.0.1/24",
 			systems: []System{{Name: "n1", Storage: InitStorage{Ceph: []DirectStorage{{Path: "def"}}}}, {Name: "n2", Storage: InitStorage{Ceph: []DirectStorage{{Path: "def"}}}}, {Name: "n3"}},
-			addErr:  true,
-			err:     errors.New("Some systems are missing ceph storage disks"),
+			addErr:  false,
+			err:     errors.New("At least 3 systems must specify ceph storage disks"),
 		},
 		{
 			desc:    "Incomplete zfs direct selection",


### PR DESCRIPTION
Closes #226 

Currently when directly specifying disks for ceph, MicroCloud will require all systems to specify a disk unless a filter is also specified. 

Instead, we should only require 3 systems to specify a disk, and only during bootstrap.