### PR TITLE
feat: Give option to specify custom DNS addresses for OVN uplink

### DIFF
--- a/microcloud/cmd/microcloud/main_init_preseed.go
+++ b/microcloud/cmd/microcloud/main_init_preseed.go
@@ -55,6 +55,7 @@ type InitNetwork struct {
 	IPv4Gateway string `yaml:"ipv4_gateway"`
 	IPv4Range   string `yaml:"ipv4_range"`
 	IPv6Gateway string `yaml:"ipv6_gateway"`
+	DNSServers  string `yaml:"dns_servers"`
 }
 
 // StorageFilter separates the filters used for local and ceph disks.
@@ -430,7 +431,7 @@ func (p *Preseed) Parse(s *service.Handler, bootstrap bool) (map[string]InitSyst
 		if bootstrap {
 			system.TargetNetworks = append(system.TargetNetworks, lxd.DefaultPendingOVNNetwork(iface))
 			if s.Name == peer {
-				uplink, ovn := lxd.DefaultOVNNetwork(p.OVN.IPv4Gateway, p.OVN.IPv4Range, p.OVN.IPv6Gateway)
+				uplink, ovn := lxd.DefaultOVNNetwork(p.OVN.IPv4Gateway, p.OVN.IPv4Range, p.OVN.IPv6Gateway, p.OVN.DNSServers)
 				system.Networks = append(system.Networks, uplink, ovn)
 			}
 		} else {

--- a/microcloud/service/lxd_config.go
+++ b/microcloud/service/lxd_config.go
@@ -67,7 +67,7 @@ func (s LXDService) DefaultOVNNetworkJoinConfig(parent string) api.ClusterMember
 // creating the finalized network.
 // Returns both the finalized uplink configuration as the first argument,
 // and the default OVN network configuration as the second argument.
-func (s LXDService) DefaultOVNNetwork(ipv4Gateway string, ipv4Range string, ipv6Gateway string) (api.NetworksPost, api.NetworksPost) {
+func (s LXDService) DefaultOVNNetwork(ipv4Gateway string, ipv4Range string, ipv6Gateway string, dnsServers string) (api.NetworksPost, api.NetworksPost) {
 	finalUplinkCfg := api.NetworksPost{
 		NetworkPut: api.NetworkPut{
 			Config:      map[string]string{},
@@ -83,6 +83,10 @@ func (s LXDService) DefaultOVNNetwork(ipv4Gateway string, ipv4Range string, ipv6
 
 	if ipv6Gateway != "" {
 		finalUplinkCfg.Config["ipv6.gateway"] = ipv6Gateway
+	}
+
+	if dnsServers != "" {
+		finalUplinkCfg.Config["dns.nameservers"] = dnsServers
 	}
 
 	ovnNetwork := api.NetworksPost{

--- a/microcloud/test/suites/add.sh
+++ b/microcloud/test/suites/add.sh
@@ -122,6 +122,7 @@ test_add_interactive() {
   export IPV4_SUBNET="10.1.123.1/24"
   export IPV4_START="10.1.123.100"
   export IPV4_END="10.1.123.254"
+  export CUSTOM_DNS_ADDRESSES="10.1.123.1,8.8.8.8" # comma-separated list of custom DNS addresses to be set for the OVN uplink.
   export IPV6_SUBNET="fd42:1:1234:1234::1/64"
   microcloud_interactive | lxc exec micro01 -- sh -c "microcloud init > out"
   lxc exec micro01 -- tail -1 out | grep "MicroCloud is ready" -q

--- a/microcloud/test/suites/preseed.sh
+++ b/microcloud/test/suites/preseed.sh
@@ -29,6 +29,7 @@ ovn:
   ipv4_gateway: 10.1.123.1/24
   ipv4_range: 10.1.123.100-10.1.123.254
   ipv6_gateway: fd42:1:1234:1234::1/64
+  dns_servers: 10.1.123.1,8.8.8.8,fd42:1:1234:1234::1
 
 storage:
   local:
@@ -51,7 +52,7 @@ EOF
   lxc exec micro01 -- sh -c "cat /root/preseed.yaml | TEST_CONSOLE=0 microcloud init --preseed"
 
   for m in micro01 micro03 ; do
-    validate_system_lxd ${m} 3 disk1 2 enp6s0 10.1.123.1/24 10.1.123.100-10.1.123.254 fd42:1:1234:1234::1/64
+    validate_system_lxd ${m} 3 disk1 2 enp6s0 10.1.123.1/24 10.1.123.100-10.1.123.254 fd42:1:1234:1234::1/64 10.1.123.1,8.8.8.8,fd42:1:1234:1234::1
     validate_system_microceph ${m} disk2 disk3
     validate_system_microovn ${m}
   done


### PR DESCRIPTION
Introduces a new feature that allows users to specify the DNS servers for the UPLINK network during the MicroCloud initialization process. Previously, MicroCloud configured the instances to use the gateway IP as the DNS server by default. Now you can set these values interactively like so:

```bash
Specify the default DNS addresses (comma-separated IPv4 addresses) for this OVN network instead of using the default gateway address? (empty to skip): <COMMA_SEPARATED_IPV4_ADDR>
```

You can also add this behaviour in the preseed file like so:

```yaml
...
ovn:
  ipv4_gateway: 10.1.123.1/24
  ipv4_range: 10.1.123.100-10.1.123.254
  ipv6_gateway: fd42:1:1234:1234::1/64
  dns_servers: 10.1.123.1,8.8.8.8 # now we can add custom DNS addresses to the OVN network like so
```