### PR TITLE
Reuse existing MicroCeph and MicroOVN clusters

### DIFF
--- a/doc/how-to/initialise.rst
+++ b/doc/how-to/initialise.rst
@@ -90,6 +90,35 @@ Complete the following steps to initialise MicroCloud:
 
 See an example of the full initialisation process in the :ref:`Get started with MicroCloud <initialisation-process>` tutorial.
 
+Excluding MicroCeph or MicroOVN from MicroCloud
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the MicroOVN or MicroCeph snap is not installed on the system that runs :command:`microcloud init`, you will be prompted with the following question::
+
+    MicroCeph not found. Continue anyway? (yes/no) [default=yes]:
+
+    MicroOVN not found. Continue anyway? (yes/no) [default=yes]:
+
+If you choose ``yes``,  only existing services will be configured on all systems.
+If you choose ``no``, the setup will be cancelled.
+
+All other systems must have at least the same set of snaps installed as the system that runs :command:`microcloud init`, otherwise they will not be available to select from the list of systems.
+Any questions associated to these systems will be skipped. For example, if MicroCeph is not installed, you will not be prompted for distributed storage configuration.
+
+Reusing an existing MicroCeph or MicroOVN with MicroCloud
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If some of the systems are already part of a MicroCeph or MicroOVN cluster, you can choose to reuse this cluster when initialising MicroCloud when prompted with the following question::
+
+    "micro01" is already part of a MicroCeph cluster. Do you want to add this cluster to MicroCloud? (add/skip) [default=add]:
+
+    "micro01" is already part of a MicroOVN cluster. Do you want to add this cluster to MicroCloud? (add/skip) [default=add]:
+
+If you choose ``add``, MicroCloud will add the remaining systems selected for initialisation to the pre-existing cluster.
+If you choose ``skip``, the respective service will not be set up at all.
+
+If more than one MicroCeph or MicroOVN cluster exists among the systems, the MicroCloud initialisation will be cancelled.
+
 .. _howto-initialise-preseed:
 
 Non-interactive configuration

--- a/microcloud/api/services.go
+++ b/microcloud/api/services.go
@@ -4,12 +4,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/microcluster/rest"
 	"github.com/canonical/microcluster/state"
+	"github.com/gorilla/mux"
 
 	"github.com/canonical/microcloud/microcloud/api/types"
 	"github.com/canonical/microcloud/microcloud/service"
@@ -53,6 +55,47 @@ var ServicesCmd = func(sh *service.Handler) rest.Endpoint {
 
 		Put: rest.EndpointAction{Handler: authHandler(sh, servicesPut), AllowUntrusted: true, ProxyTarget: true},
 	}
+}
+
+// ServiceTokensCmd represents the /1.0/services/serviceType/tokens API on MicroCloud.
+var ServiceTokensCmd = func(sh *service.Handler) rest.Endpoint {
+	return rest.Endpoint{
+		AllowedBeforeInit: true,
+		Name:              "services/{serviceType}/tokens",
+		Path:              "services/{serviceType}/tokens",
+
+		Post: rest.EndpointAction{Handler: authHandler(sh, serviceTokensPost), AllowUntrusted: true, ProxyTarget: true},
+	}
+}
+
+// serviceTokensPost issues a token for service using the MicroCloud proxy.
+// Normally a token request to a service would be restricted to trusted systems,
+// so this endpoint validates the mDNS auth token and then proxies the request to the local unix socket of the remote system.
+func serviceTokensPost(s *state.State, r *http.Request) response.Response {
+	serviceType, err := url.PathUnescape(mux.Vars(r)["serviceType"])
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	// Parse the request.
+	req := types.ServiceTokensPost{}
+
+	err = json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		return response.BadRequest(err)
+	}
+
+	sh, err := service.NewHandler(s.Name(), req.ClusterAddress, s.OS.StateDir, false, false, types.ServiceType(serviceType))
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	token, err := sh.Services[types.ServiceType(serviceType)].IssueToken(s.Context, req.JoinerName)
+	if err != nil {
+		return response.SmartError(fmt.Errorf("Failed to issue %s token for peer %q: %w", serviceType, req.JoinerName, err))
+	}
+
+	return response.SyncResponse(true, token)
 }
 
 // servicesPut updates the cluster status of the MicroCloud peer.

--- a/microcloud/api/types/services.go
+++ b/microcloud/api/types/services.go
@@ -36,3 +36,9 @@ type ServiceToken struct {
 	Service   ServiceType `json:"service" yaml:"service"`
 	JoinToken string      `json:"join_token" yaml:"join_token"`
 }
+
+// ServiceTokensPost represents a request to issue a join token for a MicroCloud service.
+type ServiceTokensPost struct {
+	ClusterAddress string `json:"cluster_address" yaml:"cluster_address"`
+	JoinerName     string `json:"joiner_name"     yaml:"joiner_name"`
+}

--- a/microcloud/client/client.go
+++ b/microcloud/client/client.go
@@ -23,3 +23,17 @@ func JoinServices(ctx context.Context, c *client.Client, data types.ServicesPut)
 
 	return nil
 }
+
+// RemoteIssueToken issues a token on the remote MicroCloud, trusted by the mDNS auth secret.
+func RemoteIssueToken(ctx context.Context, c *client.Client, serviceType types.ServiceType, data types.ServiceTokensPost) (string, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	var token string
+	err := c.Query(queryCtx, "POST", api.NewURL().Path("services", string(serviceType), "tokens"), data, &token)
+	if err != nil {
+		return "", fmt.Errorf("Failed to issue remote token: %w", err)
+	}
+
+	return token, nil
+}

--- a/microcloud/cmd/microcloud/main_init.go
+++ b/microcloud/cmd/microcloud/main_init.go
@@ -30,6 +30,8 @@ import (
 type InitSystem struct {
 	ServerInfo mdns.ServerInfo // Data reported by mDNS about this system.
 
+	InitializedServices map[types.ServiceType]map[string]string // A map of services and their cluster members, if initialized.
+
 	AvailableDisks []lxdAPI.ResourcesStorageDisk // Disks as reported by LXD.
 
 	MicroCephDisks     []cephTypes.DisksPost                  // Disks intended to be passed to MicroCeph.
@@ -128,6 +130,11 @@ func (c *cmdInit) RunInteractive(cmd *cobra.Command, args []string) error {
 	}
 
 	err = lookupPeers(s, c.flagAutoSetup, iface, subnet, nil, systems)
+	if err != nil {
+		return err
+	}
+
+	err = c.common.askClustered(s, c.flagAutoSetup, systems)
 	if err != nil {
 		return err
 	}
@@ -530,6 +537,83 @@ func validateSystems(s *service.Handler, systems map[string]InitSystem) (err err
 	}
 
 	return nil
+}
+
+// checkClustered checks whether any of the selected systems have already initialized a service.
+// Returns the first system we find that is initialized for the given service, along with all of that system's existing cluster members.
+func checkClustered(s *service.Handler, autoSetup bool, serviceType types.ServiceType, systems map[string]InitSystem) (firstInitializedSystem string, existingMembers map[string]string, err error) {
+	// LXD should always be uninitialized at this point, so we can just return default values that consider LXD uninitialized.
+	if serviceType == types.LXD {
+		return "", nil, nil
+	}
+
+	for peer, system := range systems {
+		var remoteClusterMembers map[string]string
+		var err error
+
+		// If the peer in question is ourselves, we can just use the unix socket.
+		if peer == s.Name {
+			remoteClusterMembers, err = s.Services[serviceType].ClusterMembers(context.Background())
+		} else {
+			remoteClusterMembers, err = s.Services[serviceType].RemoteClusterMembers(context.Background(), system.ServerInfo.AuthSecret, system.ServerInfo.Address)
+		}
+
+		if err != nil && err.Error() != "Daemon not yet initialized" {
+			return "", nil, fmt.Errorf("Failed to reach %s on system %q: %w", serviceType, peer, err)
+		}
+
+		// If we failed to retrieve cluster members due to the system not being initialized, we can ignore it.
+		if err != nil {
+			continue
+		}
+
+		clusterMembers := map[string]string{}
+		for k, v := range remoteClusterMembers {
+			host, _, err := net.SplitHostPort(v)
+			if err != nil {
+				return "", nil, err
+			}
+
+			clusterMembers[k] = host
+		}
+
+		if autoSetup {
+			return "", nil, fmt.Errorf("System %q is already clustered on %s", peer, serviceType)
+		}
+
+		// If this is the first clustered system we found, then record its cluster members.
+		if firstInitializedSystem == "" {
+			// Record that this system has initialized the service.
+			existingMembers = clusterMembers
+			if system.InitializedServices == nil {
+				system.InitializedServices = map[types.ServiceType]map[string]string{}
+			}
+
+			system.InitializedServices[serviceType] = clusterMembers
+			systems[peer] = system
+			firstInitializedSystem = peer
+
+			if clusterMembers[peer] != systems[peer].ServerInfo.Address && clusterMembers[peer] != "" {
+				return "", nil, fmt.Errorf("%s is already set up on %q on a different network", serviceType, peer)
+			}
+
+			continue
+		}
+
+		// If we've already encountered a clustered system, check if there's a mismatch in cluster members.
+		for k, v := range existingMembers {
+			if clusterMembers[k] != v {
+				return "", nil, fmt.Errorf("%q and %q are already part of different %s clusters. Aborting initialization", firstInitializedSystem, peer, serviceType)
+			}
+		}
+
+		// Ensure the maps are identical.
+		if len(clusterMembers) != len(existingMembers) {
+			return "", nil, fmt.Errorf("Some systems are already part of different %s clusters. Aborting initialization", serviceType)
+		}
+	}
+
+	return firstInitializedSystem, existingMembers, nil
 }
 
 // setupCluster Bootstraps the cluster if necessary, adds all peers to the cluster, and completes any post cluster

--- a/microcloud/cmd/microcloud/preseed_test.go
+++ b/microcloud/cmd/microcloud/preseed_test.go
@@ -316,3 +316,15 @@ func (s *preseedSuite) Test_preseedMatchDisksMemory() {
 	s.Equal(len(results), 1)
 	s.Equal(results[0], disks[0])
 }
+
+// Tests that ReuseExistingClusters only works when initializing, not when growing the cluster.
+func (s *preseedSuite) Test_restrictClusterReuse() {
+	p := Preseed{ReuseExistingClusters: true, LookupSubnet: "10.0.0.1/24", LookupInterface: "enp5s0", Systems: []System{{Name: "B"}, {Name: "C"}}}
+
+	s.NoError(p.validate("B", true))
+
+	s.Error(p.validate("A", false))
+
+	p.ReuseExistingClusters = false
+	s.NoError(p.validate("A", false))
+}

--- a/microcloud/cmd/microcloudd/main.go
+++ b/microcloud/cmd/microcloudd/main.go
@@ -131,6 +131,7 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 
 	endpoints := []rest.Endpoint{
 		api.ServicesCmd(s),
+		api.ServiceTokensCmd(s),
 		api.LXDProxy(s),
 		api.CephProxy(s),
 		api.OVNProxy(s),

--- a/microcloud/service/interface.go
+++ b/microcloud/service/interface.go
@@ -11,7 +11,9 @@ type Service interface {
 	Bootstrap(ctx context.Context) error
 	IssueToken(ctx context.Context, peer string) (string, error)
 	Join(ctx context.Context, config JoinConfig) error
+
 	ClusterMembers(ctx context.Context) (map[string]string, error)
+	RemoteClusterMembers(ctx context.Context, secret string, address string) (map[string]string, error)
 
 	Type() types.ServiceType
 	Name() string

--- a/microcloud/service/lxd.go
+++ b/microcloud/service/lxd.go
@@ -225,13 +225,28 @@ func (s LXDService) IssueToken(ctx context.Context, peer string) (string, error)
 	return joinToken.String(), nil
 }
 
-// ClusterMembers returns a map of cluster member names and addresses.
+// RemoteClusterMembers returns a map of cluster member names and addresses from the MicroCloud at the given address, authenticated with the given secret.
+func (s LXDService) RemoteClusterMembers(ctx context.Context, secret string, address string) (map[string]string, error) {
+	client, err := s.remoteClient(secret, address, CloudPort)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.clusterMembers(client)
+}
+
+// ClusterMembers returns a map of cluster member names.
 func (s LXDService) ClusterMembers(ctx context.Context) (map[string]string, error) {
 	client, err := s.Client(ctx, "")
 	if err != nil {
 		return nil, err
 	}
 
+	return s.clusterMembers(client)
+}
+
+// clusterMembers returns a map of cluster member names and addresses.
+func (s LXDService) clusterMembers(client lxd.InstanceServer) (map[string]string, error) {
 	members, err := client.GetClusterMembers()
 	if err != nil {
 		return nil, err

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -13,26 +13,28 @@ unset_interactive_vars() {
 # The lines that are output are based on the values passed to the listed environment variables.
 # Any unset variables will be omitted.
 microcloud_interactive() {
-  LOOKUP_IFACE=${LOOKUP_IFACE:-}                 # filter string for the lookup interface table.
-  LIMIT_SUBNET=${LIMIT_SUBNET:-}                 # (yes/no) input for limiting lookup of systems to the above subnet.
-  SKIP_SERVICE=${SKIP_SERVICE:-}                 # (yes/no) input to skip any missing services. Should be unset if all services are installed.
-  EXPECT_PEERS=${EXPECT_PEERS:-}                 # wait for this number of systems to be available to join the cluster.
-  SETUP_ZFS=${SETUP_ZFS:-}                       # (yes/no) input for initiating ZFS storage pool setup.
-  ZFS_FILTER=${ZFS_FILTER:-}                     # filter string for ZFS disks.
-  ZFS_WIPE=${ZFS_WIPE:-}                         # (yes/no) to wipe all disks.
-  SETUP_CEPH=${SETUP_CEPH:-}                     # (yes/no) input for initiating CEPH storage pool setup.
-  SETUP_CEPHFS=${SETUP_CEPHFS:-}                 # (yes/no) input for initialising CephFS storage pool setup.
-  CEPH_WARNING=${CEPH_WARNING:-}                 # (yes/no) input for warning about eligible disk detection.
-  CEPH_FILTER=${CEPH_FILTER:-}                   # filter string for CEPH disks.
-  CEPH_WIPE=${CEPH_WIPE:-}                       # (yes/no) to wipe all disks.
-  SETUP_OVN=${SETUP_OVN:-}                       # (yes/no) input for initiating OVN network setup.
-  OVN_WARNING=${OVN_WARNING:-}                   # (yes/no) input for warning about eligible interface detection.
-  OVN_FILTER=${OVN_FILTER:-}                     # filter string for OVN interfaces.
-  IPV4_SUBNET=${IPV4_SUBNET:-}                   # OVN ipv4 gateway subnet.
-  IPV4_START=${IPV4_START:-}                     # OVN ipv4 range start.
-  IPV4_END=${IPV4_END:-}                         # OVN ipv4 range end.
-  DNS_ADDRESSES=${DNS_ADDRESSES:-}               # OVN custom DNS addresses.
-  IPV6_SUBNET=${IPV6_SUBNET:-}                   # OVN ipv6 range.
+  LOOKUP_IFACE=${LOOKUP_IFACE:-}                  # filter string for the lookup interface table.
+  LIMIT_SUBNET=${LIMIT_SUBNET:-}                  # (yes/no) input for limiting lookup of systems to the above subnet.
+  SKIP_SERVICE=${SKIP_SERVICE:-}                  # (yes/no) input to skip any missing services. Should be unset if all services are installed.
+  EXPECT_PEERS=${EXPECT_PEERS:-}                  # wait for this number of systems to be available to join the cluster.
+  REUSE_EXISTING=${REUSE_EXISTING:-}              # (yes/no) incorporate an existing clustered service.
+  REUSE_EXISTING_COUNT=${REUSE_EXISTING_COUNT:-0} # (number) number of existing clusters to incorporate.
+  SETUP_ZFS=${SETUP_ZFS:-}                        # (yes/no) input for initiating ZFS storage pool setup.
+  ZFS_FILTER=${ZFS_FILTER:-}                      # filter string for ZFS disks.
+  ZFS_WIPE=${ZFS_WIPE:-}                          # (yes/no) to wipe all disks.
+  SETUP_CEPH=${SETUP_CEPH:-}                      # (yes/no) input for initiating CEPH storage pool setup.
+  SETUP_CEPHFS=${SETUP_CEPHFS:-}                  # (yes/no) input for initialising CephFS storage pool setup.
+  CEPH_WARNING=${CEPH_WARNING:-}                  # (yes/no) input for warning about eligible disk detection.
+  CEPH_FILTER=${CEPH_FILTER:-}                    # filter string for CEPH disks.
+  CEPH_WIPE=${CEPH_WIPE:-}                        # (yes/no) to wipe all disks.
+  SETUP_OVN=${SETUP_OVN:-}                        # (yes/no) input for initiating OVN network setup.
+  OVN_WARNING=${OVN_WARNING:-}                    # (yes/no) input for warning about eligible interface detection.
+  OVN_FILTER=${OVN_FILTER:-}                      # filter string for OVN interfaces.
+  IPV4_SUBNET=${IPV4_SUBNET:-}                    # OVN ipv4 gateway subnet.
+  IPV4_START=${IPV4_START:-}                      # OVN ipv4 range start.
+  IPV4_END=${IPV4_END:-}                          # OVN ipv4 range end.
+  DNS_ADDRESSES=${DNS_ADDRESSES:-}                # OVN custom DNS addresses.
+  IPV6_SUBNET=${IPV6_SUBNET:-}                    # OVN ipv6 range.
 
   setup="
 ${LOOKUP_IFACE}                                         # filter the lookup interface

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -2,7 +2,7 @@
 
 # unset_interactive_vars: Unsets all variables related to the test console.
 unset_interactive_vars() {
-  unset LOOKUP_IFACE LIMIT_SUBNET SKIP_SERVICE EXPECT_PEERS \
+  unset LOOKUP_IFACE LIMIT_SUBNET SKIP_SERVICE EXPECT_PEERS REUSE_EXISTING REUSE_EXISTING_COUNT \
     SETUP_ZFS ZFS_FILTER ZFS_WIPE \
     SETUP_CEPH CEPH_WARNING CEPH_FILTER CEPH_WIPE SETUP_CEPHFS \
     SETUP_OVN OVN_WARNING OVN_FILTER IPV4_SUBNET IPV4_START IPV4_END DNS_ADDRESSES IPV6_SUBNET
@@ -45,6 +45,16 @@ select-all                                                  # select all the sys
 ---
 $(true)                                                 # workaround for set -e
 "
+
+if [ -n "${REUSE_EXISTING}" ]; then
+  for i in $(seq 1 "${REUSE_EXISTING_COUNT}") ; do
+    setup=$(cat << EOF
+${setup}
+${REUSE_EXISTING}
+EOF
+)
+  done
+fi
 
 if [ -n "${SETUP_ZFS}" ]; then
   setup="${setup}

--- a/microcloud/test/main.sh
+++ b/microcloud/test/main.sh
@@ -188,6 +188,7 @@ run_basic_tests() {
   run_test test_instances_launch "instances launch"
   run_test test_service_mismatch "service mismatch"
   run_test test_disk_mismatch "disk mismatch"
+  run_test test_reuse_cluster "reuse_cluster"
 }
 
 run_interactive_tests() {


### PR DESCRIPTION
Closes #145

This PR allows initializing a new MicroCloud with some nodes that have already set up MicroCeph or MicroOVN in the past. This can be useful if you already have a MicroCeph cluster for example, that you want to "upgrade" into a MicroCloud.

Just after confirming the list of systems to use for the MicroCloud, we will try to grab a list of cluster members from each system. The underlying microcluster package will either return the list or report that the database is not initialized. We will record the first list that we obtain for each of MicroOVN and MicroCeph, and if the list is either non-existent or identical across any other systems, we can try to reuse those clusters.

The reuse process basically amounts to asking the system that has an existing cluster to generate join tokens and send them to the node orchestrating the initialization. Normally you have to be trusted to make such a request, so instead we can use the auth secret that we got from finding the systems over mDNS to send a request using the MicroCloud proxy, which will initiate the request from the unix socket on the clustered system.


The behaviour is as follows:
* If two systems belong to different clusters for the same service, we will error out as they wouldn't be able to join each other.
* If a cluster contains more nodes than what will end up in the MicroCloud, we will proceed as normal and ignore those nodes. Perhaps a user might want a larger MicroCeph cluster than their LXD cluster, for example.
* If `--auto` is specified, we will strictly require no clustered systems.
* The preseed file will have a new key `reuse_existing_clusters` which can be set to true or false. If true, we will reuse any clusters we find, and if false, we will skip that service entirely and set up as normal.
* In interactive mode, we will prompt the user for each service whether they want to reuse the existing cluster or setup MicroCloud without that service.
