### PR TITLE
lxd: parametrize LXD with `instances.migration.stateful` set to `true`

### DIFF
--- a/microcloud/service/lxd.go
+++ b/microcloud/service/lxd.go
@@ -114,6 +114,9 @@ func (s LXDService) Bootstrap(ctx context.Context) error {
 	newServer := currentServer.Writable()
 	newServer.Config["core.https_address"] = "[::]:8443"
 	newServer.Config["cluster.https_address"] = addr
+	if client.HasExtension("migration_stateful_default") {
+		newServer.Config["instances.migration.stateful"] = "true"
+	}
 
 	// Apply it.
 	err = client.UpdateServer(newServer, etag)


### PR DESCRIPTION
When [this](https://github.com/canonical/lxd/pull/12832) is merged, this PR adds the integration with MicroCloud. After that, all the created VM instances in a MicroCloud deployment should be able to be live migrated with no additional user settings.