### PR TITLE
Use both IPv4 and IPv6 chosen addresses for default DNS addresses

### DIFF
--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -87,8 +87,8 @@ $([ "${SETUP_OVN}" = "yes" ] && printf -- "---")
 ${IPV4_SUBNET}                                         # setup ipv4/ipv6 gateways and ranges
 ${IPV4_START}
 ${IPV4_END}
-${CUSTOM_DNS_ADDRESSES}
 ${IPV6_SUBNET}
+${CUSTOM_DNS_ADDRESSES}
 EOF
 )
 fi


### PR DESCRIPTION
This PR does 2 things:

* Moves the DNS question to be after both the ipv4 and ipv6 questions. Right now it's in the middle, which feels awkward.
* Because of the above, when choosing the default DNS nameservers, we only have the user's chosen IPv4 address at that point. By moving the question to the end, we can include both the chosen IPv4 and IPv6 addresses by default.