### PR TITLE
doc: Update docs for cephfs and dns nameservers

### DIFF
--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -36,3 +36,4 @@ UI
 Jira
 VM
 YAML
+CephFS

--- a/doc/explanation/initialisation.rst
+++ b/doc/explanation/initialisation.rst
@@ -15,9 +15,9 @@ Automatic server detection
 MicroCloud uses :abbr:`mDNS (multicast DNS)` to automatically detect other servers on the network.
 This method works in physical networks, but it is usually not supported in a cloud environment.
 
-By default, the scan is limited to the local subnet.
+The scan can be limited to the default local subnet of the network interface you select.
 
-MicroCloud will display all servers that it detects, and you can then select the ones you want to add to the MicroCloud cluster.
+MicroCloud will display all servers that it detects and periodically update the list. You can select the servers you want to add to the MicroCloud cluster.
 
 .. _bootstrapping-process:
 
@@ -56,13 +56,15 @@ After the initialisation is complete, you can look at the LXD configuration to c
    | micro03 | https://[2001:db8:d:100::171]:8443 | database        | aarch64      | default        |             | ONLINE | Fully operational |
    +---------+------------------------------------+-----------------+--------------+----------------+-------------+--------+-------------------+
    :input: lxc storage list
-   +--------+--------+-----------------------------+---------+---------+
-   |  NAME  | DRIVER |         DESCRIPTION         | USED BY |  STATE  |
-   +--------+--------+-----------------------------+---------+---------+
-   | local  | zfs    | Local storage on ZFS        | 10      | CREATED |
-   +--------+--------+-----------------------------+---------+---------+
-   | remote | ceph   | Distributed storage on Ceph | 7       | CREATED |
-   +--------+--------+-----------------------------+---------+---------+
+   +-----------+--------+--------------------------------------------+---------+---------+
+   |  NAME     | DRIVER |         DESCRIPTION                        | USED BY |  STATE  |
+   +-----------+--------+--------------------------------------------+---------+---------+
+   | local     | zfs    | Local storage on ZFS                       | 10      | CREATED |
+   +-----------+--------+--------------------------------------------+---------+---------+
+   | remote    | ceph   | Distributed storage on Ceph                | 7       | CREATED |
+   +-----------+--------+--------------------------------------------+---------+---------+
+   | remote-fs | cephfs | Distributed file-system storage using Ceph | 7       | CREATED |
+   +-----------+--------+--------------------------------------------+---------+---------+
    :input: lxc network list
    +----------+----------+---------+-----------------+---------------------------+-------------+---------+---------+
    |   NAME   |   TYPE   | MANAGED |      IPV4       |           IPV6            | DESCRIPTION | USED BY |  STATE  |

--- a/doc/how-to/initialise.rst
+++ b/doc/how-to/initialise.rst
@@ -43,7 +43,7 @@ Complete the following steps to initialise MicroCloud:
    See :ref:`automatic-server-detection` for more information.
 #. Select the machines that you want to add to the MicroCloud cluster.
 
-   MicroCloud displays all machines that it detects.
+   MicroCloud displays all machines that it detects. This list will periodically update as new machines are detected.
    Make sure that all machines that you select have the required snaps installed.
 #. Select whether you want to set up local storage.
 
@@ -71,6 +71,8 @@ Complete the following steps to initialise MicroCloud:
       You must select at least three disks.
    #. Select whether you want to wipe any of the disks.
       Wiping a disk will destroy all data on it.
+
+   #. You can choose to optionally set up a CephFS distributed file system.
 #. Select whether you want to set up distributed networking (using MicroOVN).
 
    If you choose ``yes``, configure the distributed networking:

--- a/doc/how-to/preseed.yaml
+++ b/doc/how-to/preseed.yaml
@@ -26,9 +26,10 @@ systems:
 
 # `ovn` is optional and represents the OVN & uplink network configuration for LXD.
 ovn:
-  ipv4_gateway: 10.0.0.1/24
-  ipv4_range: 10.0.0.100-10.0.0.254
-  ipv6_gateway: cafe::1/64
+  ipv4_gateway: 192.0.2.1/24
+  ipv4_range: 192.0.2.100-192.0.2.254
+  ipv6_gateway: 2001:db8:d:200::1/64
+  dns_servers: 192.0.2.1,2001:db8:d:200::1
 
 # `storage` is optional and is used as basic filtering logic for finding disks across all systems.
 # Filters are checked in order of appearance.
@@ -39,7 +40,9 @@ ovn:
 # String values must not be in quotes unless the string contains a space.
 # Single quotes are fine, but double quotes must be escaped.
 # `find_min` and `find_max` can be used to validate the number of disks each filter finds.
+# `cephfs: true` can be used to optionally set up a CephFS file system alongside Ceph distributed storage.
 storage:
+  cephfs: true
   local:
     - find: size > 10GiB && size < 50GiB && type == nvme
       find_min: 1

--- a/doc/tutorial/get_started.rst
+++ b/doc/tutorial/get_started.rst
@@ -271,6 +271,7 @@ Complete the following steps:
    #. Select ``yes`` to confirm that there are fewer disks available than machines.
    #. Select all listed disks (these should be ``remote1``, ``remote2``, and ``remote3``).
    #. You don't need to wipe any disks (because we just created them).
+   #. Select ``yes`` to optionally configure the CephFS distributed file system.
    #. Select ``yes`` to configure distributed networking.
    #. Select all listed network interfaces (these should be ``enp6s0`` on the four different VMs).
    #. Specify the IPv4 address that you noted down for your ``microbr0`` network as the IPv4 gateway.
@@ -383,6 +384,7 @@ See the full initialisation process here:
     Using 1 disk(s) on "micro2" for remote storage pool
     Using 1 disk(s) on "micro3" for remote storage pool
 
+   Would you like to set up CephFS remote storage? (yes/no) [default=yes]:  yes
    Configure distributed networking? (yes/no) [default=yes]:  yes
    Select an available interface per system to provide external connectivity for distributed network(s):
    Space to select; enter to confirm; type to filter results.
@@ -405,6 +407,7 @@ See the full initialisation process here:
    Specify the first IPv4 address in the range to use on the uplink network: 192.0.2.100
    Specify the last IPv4 address in the range to use on the uplink network: 192.0.2.254
    Specify the IPv6 gateway (CIDR) on the uplink network (empty to skip IPv6): 2001:db8:d:200::1/64
+   Specify the DNS addresses (comma-separated IPv4 / IPv6 addresses) for the distributed network (default: 192.0.2.1,2001:db8:d:200::1):
 
    Initializing a new cluster
     Local MicroCloud is ready
@@ -492,13 +495,15 @@ You can now inspect your cluster setup.
       :host: micro1
       :scroll:
 
-      +--------+--------+-----------------------------+---------+---------+
-      |  NAME  | DRIVER |         DESCRIPTION         | USED BY |  STATE  |
-      +--------+--------+-----------------------------+---------+---------+
-      | local  | zfs    | Local storage on ZFS        | 8       | CREATED |
-      +--------+--------+-----------------------------+---------+---------+
-      | remote | ceph   | Distributed storage on Ceph | 1       | CREATED |
-      +--------+--------+-----------------------------+---------+---------+
+      +-----------+--------+--------------------------------------------+---------+---------+
+      |  NAME     | DRIVER |         DESCRIPTION                        | USED BY |  STATE  |
+      +-----------+--------+--------------------------------------------+---------+---------+
+      | local     | zfs    | Local storage on ZFS                       | 8       | CREATED |
+      +-----------+--------+--------------------------------------------+---------+---------+
+      | remote    | ceph   | Distributed storage on Ceph                | 1       | CREATED |
+      +-----------+--------+--------------------------------------------+---------+---------+
+      | remote-fs | cephfs | Distributed file-system storage using Ceph | 1       | CREATED |
+      +-----------+--------+--------------------------------------------+---------+---------+
       :input: lxc storage info local
       info:
         description: Local storage on ZFS
@@ -526,6 +531,14 @@ You can now inspect your cluster setup.
       used by:
         profiles:
         - default
+      :input: lxc storage info remote-fs
+      info:
+        description: Distributed file-system storage using CephFS
+        driver: cephfs
+        name: remote-fs
+        space used: 0B
+        total space: 29.67GiB
+      used by: {}
 
 #. Inspect the network setup:
 


### PR DESCRIPTION
Should be merged after #269 because I wrote it based on that.

Updates the docs for the newer features (cephfs and dns nameservers), and also mentions that the mDNS lookup list updates as new machines are found periodically.