### PR TITLE
Only restart LXD if version is less than 5.21

### DIFF
--- a/microcloud/service/lxd_config.go
+++ b/microcloud/service/lxd_config.go
@@ -8,6 +8,9 @@ import (
 	"github.com/canonical/lxd/shared/api"
 )
 
+// lxdMinVersion is the minimum version of LXD that fully supports all MicroCloud features.
+const lxdMinVersion = "5.21"
+
 // DefaultPendingFanNetwork returns the default Ubuntu Fan network configuration when
 // creating a pending network on a specific cluster member target.
 func (s LXDService) DefaultPendingFanNetwork() api.NetworksPost {


### PR DESCRIPTION
With the content interfaces in places in LXD to detect MicroOVN and MicroCeph, we don't need to restart LXD to pick them up anymore. 

However, if we don't restart, this breaks support for versions of LXD prior to 5.21 when the content interface was introduced. We can't directly fetch the snap version or the available interfaces of LXD due to the snap confinement, so the best I came up with was to hard-code `5.21` into MicroCloud, and compare it to the server version reported from `/1.0` in LXD. 

If LXD is not at least version 5.21, then we need to restart the LXD daemon to pick up MicroOVN and MicroCeph integration. Otherwise we can just expect it to be there.