### PR TITLE
Fix test suite hangs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,7 @@ jobs:
         go: ["1.22.x"]
         suite:
           - "add"
-          - "auto"
+          - "instances"
           - "basic"
           - "interactive"
           - "mismatch"

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -485,15 +485,12 @@ reset_snaps() {
     "
 
     echo "Enabling LXD and MicroCloud for ${name}"
-    lxc exec "${name}" -- sh -c "
-      snap enable lxd > /dev/null 2>&1 || true
-      snap enable microcloud > /dev/null 2>&1 || true
-      snap start lxd > /dev/null 2>&1 || true
-      snap start microcloud > /dev/null 2>&1 || true
-      snap refresh lxd --cohort=+
-
-      lxd waitready
-    "
+    lxc exec "${name}" -- snap enable lxd > /dev/null 2>&1 || true
+    lxc exec "${name}" -- snap enable microcloud > /dev/null 2>&1 || true
+    lxc exec "${name}" -- snap start lxd > /dev/null 2>&1 || true
+    lxc exec "${name}" -- snap start microcloud > /dev/null 2>&1 || true
+    lxc exec "${name}" -- snap refresh lxd --cohort=+ || true
+    lxc exec "${name}" -- lxd waitready
 
     set_debug_binaries "${name}"
   )

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -536,7 +536,14 @@ reset_system() {
 
     reset_snaps "${name}"
 
-    timeout -k 5 10 lxc exec "${name}" -- zpool destroy -f local || true
+    # the `zpool` command seems to get wiped between runs sometimes, potential bug in the LXD snap?
+    lxc exec "${name}" -- sh -c "
+      if ! test -e /usr/sbin/zpool ; then
+        apt-get install zfsutils-linux --no-install-recommends -y
+      fi
+    "
+
+    timeout -k 5 10 lxc exec "${name}" -- /usr/sbin/zpool destroy -f local || true
 
     # Hide any extra disks for this run.
     lxc exec "${name}" -- sh -c "

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -631,6 +631,7 @@ cluster_reset() {
             microceph.ceph osd pool rm \${pool} \${pool} --yes-i-really-really-mean-it
           done
 
+          microceph.ceph osd set noup
           for osd in \$(microceph.ceph osd ls) ; do
             microceph.ceph config set osd.\${osd} osd_pool_default_crush_rule \$(microceph.ceph osd crush rule dump microceph_auto_osd | jq '.rule_id')
             microceph.ceph osd crush reweight osd.\${osd} 0

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -376,6 +376,11 @@ validate_system_lxd() {
       validate_system_lxd_fan "${name}"
     fi
 
+    if [ -n "${local_disk}" ] || [ "${remote_disks}" -gt 0 ] ; then
+      echo "Check LXD resources for disk ordering"
+      lxc exec "local:${name}" -- lxc query "/1.0/resources" | jq -r '.storage.disks[] | {id, device_id, device_path}'
+    fi
+
     if [ -n "${local_disk}" ]; then
       validate_system_lxd_zfs "${name}" "${local_disk}"
     fi

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -105,8 +105,15 @@ set_debug_binaries() {
 
   if [ -n "${MICROCLOUD_DEBUG_PATH}" ] && [ -n "${MICROCLOUDD_DEBUG_PATH}" ]; then
     echo "==> Add debug binaries for MicroCloud."
-    lxc exec "${name}" -- rm -f /var/snap/microcloud/common/microcloudd.debug
-    lxc exec "${name}" -- rm -f /var/snap/microcloud/common/microcloud.debug
+    lxc exec "${name}" -- sh -c "
+      if test -e /var/snap/microcloud/common/microcloudd.debug ; then
+        rm -f /var/snap/microcloud/common/microcloudd.debug
+      fi
+
+      if test -e /var/snap/microcloud/common/microcloud.debug ; then
+        rm -f /var/snap/microcloud/common/microcloud.debug
+      fi
+    "
 
     lxc file push --quiet "${MICROCLOUDD_DEBUG_PATH}" "${name}"/var/snap/microcloud/common/microcloudd.debug
     lxc file push --quiet "${MICROCLOUD_DEBUG_PATH}" "${name}"/var/snap/microcloud/common/microcloud.debug
@@ -116,7 +123,13 @@ set_debug_binaries() {
 
   if [ -n "${LXD_DEBUG_PATH}" ]; then
     echo "==> Add a debug binary for LXD."
-    lxc exec "${name}" -- rm -f /var/snap/lxd/common/lxd.debug
+
+    lxc exec "${name}" -- sh -c "
+      if test -e /var/snap/lxd/common/lxd.debug ; then
+        rm -f /var/snap/lxd/common/lxd.debug
+      fi
+    "
+
     lxc file push --quiet "${LXD_DEBUG_PATH}" "${name}"/var/snap/lxd/common/lxd.debug
     lxc exec "${name}" -- systemctl reload snap.lxd.daemon || true
     lxc exec "${name}" -- lxd waitready

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -536,7 +536,7 @@ reset_system() {
 
     reset_snaps "${name}"
 
-    lxc exec "${name}" -- zpool destroy -f local || true
+    timeout -k 5 10 lxc exec "${name}" -- zpool destroy -f local || true
 
     # Hide any extra disks for this run.
     lxc exec "${name}" -- sh -c "

--- a/microcloud/test/main.sh
+++ b/microcloud/test/main.sh
@@ -155,19 +155,15 @@ new_systems 4 3 3
 run_add_tests() {
   run_test test_add_interactive "add interactive"
   run_test test_add_auto "add auto"
-  run_test test_auto "auto"
 }
 
-run_auto_tests() {
-  run_test test_add_auto "add auto"
-  run_test test_auto "auto"
+run_instances_tests() {
+  run_test test_instances_config "instances config"
+  run_test test_instances_launch "instances launch"
 }
 
 run_basic_tests() {
-  run_test test_instances_config "instances config"
-  run_test test_instances_launch "instances launch"
-  run_test test_service_mismatch "service mismatch"
-  run_test test_disk_mismatch "disk mismatch"
+  run_test test_auto "auto"
 }
 
 run_interactive_tests() {
@@ -187,12 +183,15 @@ run_preseed_tests() {
 # allow for running a specific set of tests
 if [ "${1:-"all"}" = "all" ]; then
   run_add_tests
+  run_instances_tests
   run_basic_tests
+  run_interactive_tests
+  run_mismatch_tests
   run_preseed_tests
 elif [ "${1}" = "add" ]; then
   run_add_tests
-elif [ "${1}" = "auto" ]; then
-  run_auto_tests
+elif [ "${1}" = "instances" ]; then
+  run_instances_tests
 elif [ "${1}" = "basic" ]; then
   run_basic_tests
 elif [ "${1}" = "interactive" ]; then


### PR DESCRIPTION

For the debug binaries and ZFS, I'm not sure exactly why the timeouts are necessary but without them, I pretty consistently run into issues where the action is actually performed, but the command won't let go.