### PR TITLE
doc/tutorial/get_started: LXD is not always refresh-able

### DIFF
--- a/doc/tutorial/get_started.rst
+++ b/doc/tutorial/get_started.rst
@@ -225,10 +225,13 @@ Complete the following steps on each VM (``micro1``, ``micro2``, ``micro3``, and
       The ``--cohort="+"`` flag in the command ensures that the same version of the snap is installed on all machines.
       See :ref:`howto-snap-cluster` for more information.
 
-#. The LXD snap is already installed.
-   Refresh it to the latest version::
+#. If the LXD snap is already installed, refresh it to the latest LTS version::
 
      snap refresh lxd --channel=5.21/stable --cohort="+"
+
+   Otherwise, install it::
+
+     snap install lxd --channel=5.21/stable --cohort="+"
 
 6. Initialise MicroCloud
 ------------------------


### PR DESCRIPTION
With 24.04 onward or if using any `minimal` image, the LXD snap won't be there. Also make it clear that we don't get the latest version but the latest LTS.

With that small tweak, I got a microcloud cluster running on 4x 24.04 VMs. While it's a bit early to change the doc to use 24.04 VMs, it's a first step.