### PR TITLE
test/includes/microcloud: don't use wrapper shell+cat heredocs for setup

### DIFF
--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -95,8 +95,8 @@ EOF
 )
 fi
 
-# clear comments and empty lines.
-echo "${setup}" | sed -e '/^\s*#/d' -e '/^\s*$/d'
+  # clear comments and empty lines.
+  echo "${setup}" | sed '/^\s*#/d; s/\s*#.*//; /^$/d'
 }
 
 # set_debug_binaries: Adds {app}.debug binaries if the corresponding {APP}_DEBUG_PATH environment variable is set.

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -43,6 +43,7 @@ $([ "${SKIP_SERVICE}" = "yes" ] && printf "%s" "${SKIP_SERVICE}")  # skip MicroO
 expect ${EXPECT_PEERS}                                      # wait until the systems show up
 select-all                                                  # select all the systems
 ---
+$(true)                                                 # workaround for set -e
 "
 
 if [ -n "${SETUP_ZFS}" ]; then
@@ -54,6 +55,7 @@ $([ "${SETUP_ZFS}" = "yes" ] && printf "select-all")    # select all disk matchi
 $([ "${SETUP_ZFS}" = "yes" ] && printf -- "---" )
 $([ "${ZFS_WIPE}"  = "yes" ] && printf "select-all")    # wipe all disks
 $([ "${SETUP_ZFS}" = "yes" ] && printf -- "---")
+$(true)                                                 # workaround for set -e
 "
 fi
 
@@ -68,6 +70,7 @@ $([ "${SETUP_CEPH}" = "yes" ] && printf -- "---")
 $([ "${CEPH_WIPE}"  = "yes" ] && printf "select-all")   # wipe all disks
 $([ "${SETUP_CEPH}" = "yes" ] && printf -- "---")
 ${SETUP_CEPHFS}
+$(true)                                                 # workaround for set -e
 "
 fi
 
@@ -85,6 +88,7 @@ ${IPV4_START}
 ${IPV4_END}
 ${IPV6_SUBNET}
 ${DNS_ADDRESSES}
+$(true)                                                 # workaround for set -e
 "
 fi
 

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -39,7 +39,7 @@ ${LOOKUP_IFACE}                                         # filter the lookup inte
 $([ -n "${LOOKUP_IFACE}" ] && printf "select")          # select the interface
 $([ -n "${LOOKUP_IFACE}" ] && printf -- "---")
 ${LIMIT_SUBNET}                                             # limit lookup subnet (yes/no)
-$([ "yes" = "${SKIP_SERVICE}" ] && printf "%s" "${SKIP_SERVICE}")  # skip MicroOVN/MicroCeph (yes/no)
+$([ "${SKIP_SERVICE}" = "yes" ] && printf "%s" "${SKIP_SERVICE}")  # skip MicroOVN/MicroCeph (yes/no)
 expect ${EXPECT_PEERS}                                      # wait until the systems show up
 select-all                                                  # select all the systems
 ---

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -34,7 +34,7 @@ microcloud_interactive() {
   DNS_ADDRESSES=${DNS_ADDRESSES:-}               # OVN custom DNS addresses.
   IPV6_SUBNET=${IPV6_SUBNET:-}                   # OVN ipv6 range.
 
-  setup=$(cat << EOF
+  setup="
 ${LOOKUP_IFACE}                                         # filter the lookup interface
 $([ -n "${LOOKUP_IFACE}" ] && printf "select")          # select the interface
 $([ -n "${LOOKUP_IFACE}" ] && printf -- "---")
@@ -43,12 +43,10 @@ $([ "yes" = "${SKIP_SERVICE}" ] && printf "%s" "${SKIP_SERVICE}")  # skip MicroO
 expect ${EXPECT_PEERS}                                      # wait until the systems show up
 select-all                                                  # select all the systems
 ---
-EOF
-)
+"
 
 if [ -n "${SETUP_ZFS}" ]; then
-  setup=$(cat << EOF
-${setup}
+  setup="${setup}
 ${SETUP_ZFS}                                            # add local disks (yes/no)
 $([ "${SETUP_ZFS}" = "yes" ] && printf "wait 300ms")    # wait for the table to populate
 ${ZFS_FILTER}                                           # filter zfs disks
@@ -56,13 +54,11 @@ $([ "${SETUP_ZFS}" = "yes" ] && printf "select-all")    # select all disk matchi
 $([ "${SETUP_ZFS}" = "yes" ] && printf -- "---" )
 $([ "${ZFS_WIPE}"  = "yes" ] && printf "select-all")    # wipe all disks
 $([ "${SETUP_ZFS}" = "yes" ] && printf -- "---")
-EOF
-)
+"
 fi
 
 if [ -n "${SETUP_CEPH}" ]; then
-  setup=$(cat << EOF
-${setup}
+  setup="${setup}
 ${SETUP_CEPH}                                           # add remote disks (yes/no)
 ${CEPH_WARNING}                                         # continue with some peers missing disks? (yes/no)
 $([ "${SETUP_CEPH}" = "yes" ] && printf "wait 300ms")   # wait for the table to populate
@@ -72,14 +68,12 @@ $([ "${SETUP_CEPH}" = "yes" ] && printf -- "---")
 $([ "${CEPH_WIPE}"  = "yes" ] && printf "select-all")   # wipe all disks
 $([ "${SETUP_CEPH}" = "yes" ] && printf -- "---")
 ${SETUP_CEPHFS}
-EOF
-)
+"
 fi
 
 
 if [ -n "${SETUP_OVN}" ]; then
-  setup=$(cat << EOF
-${setup}
+  setup="${setup}
 ${SETUP_OVN}                                           # agree to setup OVN
 ${OVN_WARNING}                                         # continue with some peers missing an interface? (yes/no)
 $([ "${SETUP_OVN}" = "yes" ] && printf "wait 300ms")   # wait for the table to populate
@@ -91,8 +85,7 @@ ${IPV4_START}
 ${IPV4_END}
 ${IPV6_SUBNET}
 ${DNS_ADDRESSES}
-EOF
-)
+"
 fi
 
   # clear comments and empty lines.


### PR DESCRIPTION
The reason for this style change is that it produces less debug (`set -x`) noise as we can see is this short example:

```
$ sh -x
$ setup=""
+ setup=
$ setup="${setup}
> foo"
+ setup=
foo
$ setup="${setup}
> bar"
+ setup=
foo
bar
$ 
```

Versus:

```
$ sh -x
$ setup=""   
+ setup=
$ setup=$(cat << EOF
> ${setup}
> foo
> EOF
> )
+ cat
+ setup=
foo
$ setup=$(cat << EOF
> ${setup}
> bar
> EOF
> )
+ cat
+ setup=
foo
bar
$ 
```