### PR TITLE
Optimize for speed

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -208,12 +208,20 @@ jobs:
           sudo snap install lxd --channel latest/edge || sudo snap refresh lxd --channel latest/edge
           sudo lxd init --auto
 
+      - name: "Prepare for system tests"
+        run: |
+          set -eux
+          chmod +x ~
+          cd microcloud/test
+          sudo --preserve-env=DEBUG,GITHUB_ACTIONS,MICROCLOUD_DEBUG_PATH,MICROCLOUDD_DEBUG_PATH,SKIP_VM_LAUNCH,SNAPSHOT_RESTORE,TEST_STORAGE_SOURCE,TESTBED_READY ./main.sh setup
+          echo "TESTBED_READY=1" >> "${GITHUB_ENV}"
+
       - name: "Run system tests (${{ matrix.go }}, ${{ matrix.suite }})"
         run: |
           set -eux
           chmod +x ~
           cd microcloud/test
-          sudo --preserve-env=DEBUG,GITHUB_ACTIONS,MICROCLOUD_DEBUG_PATH,MICROCLOUDD_DEBUG_PATH,SKIP_VM_LAUNCH,SNAPSHOT_RESTORE,TEST_STORAGE_SOURCE ./main.sh ${{ matrix.suite }}
+          sudo --preserve-env=DEBUG,GITHUB_ACTIONS,MICROCLOUD_DEBUG_PATH,MICROCLOUDD_DEBUG_PATH,SKIP_VM_LAUNCH,SNAPSHOT_RESTORE,TEST_STORAGE_SOURCE,TESTBED_READY ./main.sh ${{ matrix.suite }}
 
   documentation-checks:
     uses: canonical/documentation-workflows/.github/workflows/documentation-checks.yaml@main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,6 +131,16 @@ jobs:
           sudo rm -rf /opt/ghc
           df -h /
 
+      - name: Reclaim some memory
+        run: |
+          set -eux
+
+          free -mt
+          sudo systemctl stop dpkg-db-backup.timer e2scrub_all.timer fstrim.timer logrotate.timer man-db.timer motd-news.timer phpsessionclean.timer update-notifier-download.timer update-notifier-motd.timer
+          sudo systemctl stop iscsid.socket multipathd.socket
+          sudo systemctl stop cron.service irqbalance.service mono-xsp4.service multipathd.service networkd-dispatcher.service php8.1-fpm.service
+          free -mt
+
       - name: Remove docker
         run: |
           set -eux

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -950,6 +950,10 @@ setup_system() {
 
     lxc exec "${name}" -- snap install snapd
 
+    # Free disk blocks
+    lxc exec "${name}" -- apt-get clean
+    lxc exec "${name}" -- systemctl start fstrim.service
+
     # Snaps can occasionally fail to install properly, so repeatedly try.
     lxc exec "${name}" -- sh -c "
       while ! test -e /snap/bin/microceph ; do

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -986,15 +986,15 @@ setup_system() {
     set_debug_binaries "${name}"
   )
 
-  # Sleep some time so the snaps are fully set up.
-  sleep 3
-
   # Create a snapshot so we can restore to this point.
   if [ "${SNAPSHOT_RESTORE}" = 1 ]; then
     lxc stop "${name}"
     lxc snapshot "${name}" snap0
     lxc start "${name}"
     lxd_wait_vm "${name}"
+  else
+    # Sleep some time so the snaps are fully set up.
+    sleep 3
   fi
 
   echo "==> ${name} Finished Setting up"

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -335,9 +335,6 @@ validate_system_lxd() {
 
     lxc remote switch local
 
-    # Call lxc list once to supress the welcome message.
-    lxc exec "${name}" -- lxc list > /dev/null 2>&1
-
     # Add the peer as a remote.
     set_remote microcloud-test "${name}"
 
@@ -975,6 +972,9 @@ setup_system() {
         sleep 1
       done
     "
+
+    # Call lxc list once to supress the welcome message.
+    lxc exec "${name}" -- lxc list > /dev/null 2>&1
 
     if [ -n "${MICROCLOUD_SNAP_PATH}" ]; then
       lxc file push --quiet "${MICROCLOUD_SNAP_PATH}" "${name}"/root/microcloud.snap

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -984,8 +984,6 @@ setup_system() {
   if [ "${SNAPSHOT_RESTORE}" = 1 ]; then
     lxc stop "${name}"
     lxc snapshot "${name}" snap0
-    lxc start "${name}"
-    lxd_wait_vm "${name}"
   else
     # Sleep some time so the snaps are fully set up.
     sleep 3

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -934,6 +934,9 @@ setup_system() {
     echo 'GRUB_CMDLINE_LINUX_DEFAULT="quiet debugfs=off mitigations=off"' | lxc exec "${name}" -- tee /etc/default/grub.d/zz-lxd-speed.cfg
     lxc exec "${name}" -- update-grub
 
+    # Faster apt
+    echo "force-unsafe-io" | lxc exec "${name}" -- tee /etc/dpkg/dpkg.cfg.d/force-unsafe-io
+
     # Install the snaps.
     lxc exec "${name}" -- apt-get update
     if [ -n "${CLOUD_INSPECT:-}" ]; then

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -400,9 +400,9 @@ reset_snaps() {
     # These are set to always pass in case the snaps are already disabled.
     echo "Disabling LXD and MicroCloud for ${name}"
     lxc exec "${name}" -- sh -c "
-      rm -rf /var/snap/lxd/common/lxd.debug
-      rm -rf /var/snap/microcloud/common/microcloudd.debug
-      rm -rf /var/snap/microcloud/common/microcloud.debug
+      rm -f /var/snap/lxd/common/lxd.debug
+      rm -f /var/snap/microcloud/common/microcloudd.debug
+      rm -f /var/snap/microcloud/common/microcloud.debug
 
       for app in lxd lxd.debug microcloud microcloud.debug microcloudd microcloudd.debug ; do
         if pidof -q \${app} > /dev/null; then

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -924,6 +924,12 @@ setup_system() {
       exec > /dev/null
     fi
 
+    # Disable unneeded services/timers/sockets/mounts (source of noise/slowdown)
+    lxc exec "${name}" -- systemctl mask --now apport.service cron.service e2scrub_reap.service grub-common.service grub-initrd-fallback.service lvm2-monitor.service networkd-dispatcher.service polkit.service secureboot-db.service serial-getty@ttyS0.service ssh.service systemd-journald.service systemd-journal-flush.service unattended-upgrades.service
+    lxc exec "${name}" -- systemctl mask --now apt-daily-upgrade.timer apt-daily.timer dpkg-db-backup.timer e2scrub_all.timer fstrim.timer motd-news.timer update-notifier-download.timer update-notifier-motd.timer
+    lxc exec "${name}" -- systemctl mask --now cloud-init-hotplugd.socket lvm2-lvmpolld.socket lxd-installer.socket iscsid.socket systemd-journald-dev-log.socket
+    lxc exec "${name}" -- systemctl mask --now dev-hugepages.mount sys-kernel-debug.mount sys-kernel-tracing.mount
+
     # Install the snaps.
     lxc exec "${name}" -- apt-get update
     if [ -n "${CLOUD_INSPECT:-}" ]; then

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -423,8 +423,8 @@ reset_snaps() {
     "
 
     echo "Resetting MicroCeph for ${name}"
-    lxc exec "${name}" -- sh -c "
-      if snap list microceph; then
+    if lxc exec "${name}" -- snap list microceph > /dev/null 2>&1; then
+      lxc exec "${name}" -- sh -c "
         snap disable microceph > /dev/null 2>&1 || true
 
         # Kill any remaining processes.
@@ -443,12 +443,12 @@ reset_snaps() {
         # OSDs won't show up and ceph will freeze creating volumes without it, so make it here.
         mkdir -p /var/snap/microceph/current/run
         snap run --shell microceph -c 'snapctl restart microceph.osd' || true
-      fi
-    "
+      "
+    fi
 
     echo "Resetting MicroOVN for ${name}"
-    lxc exec "${name}" -- sh -c "
-      if snap list microovn; then
+    if lxc exec "${name}" -- snap list microovn > /dev/null 2>&1; then
+      lxc exec "${name}" -- sh -c "
         microovn.ovn-appctl exit || true
         microovn.ovs-appctl exit --cleanup || true
         microovn.ovs-dpctl del-dp system@ovs-system || true
@@ -462,8 +462,8 @@ reset_snaps() {
         # Wipe the snap state so we can start fresh.
         rm -rf /var/snap/microovn/*/*
         snap enable microovn > /dev/null 2>&1 || true
-      fi
-    "
+      "
+    fi
 
     echo "Enabling LXD and MicroCloud for ${name}"
     lxc exec "${name}" -- sh -c "

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -586,8 +586,8 @@ cluster_reset() {
       lxc storage rm local || true
     "
 
-    lxc exec "${name}" -- sh -c "
-      if snap list microceph; then
+    if lxc exec "${name}" -- snap list microceph > /dev/null 2>&1; then
+      lxc exec "${name}" -- sh -c "
         # Ceph might not be responsive if we haven't set it up yet.
         microceph_setup=0
         if timeout -k 3 3 microceph cluster list ; then
@@ -619,8 +619,8 @@ cluster_reset() {
             rm -rf /var/snap/microceph/common/data/osd/ceph-\${osd}
           done
         fi
-      fi
-    "
+      "
+    fi
   )
 }
 

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -901,6 +901,9 @@ create_system() {
 
     lxc init ubuntu-minimal:22.04 "${name}" --vm -c limits.cpu=2 -c limits.memory=4GiB
 
+    # Disable vGPU to save RAM
+    lxc config set "${name}" raw.qemu.conf='[device "qemu_gpu"]'
+
     for n in $(seq 1 "${num_disks}") ; do
       disk="${name}-disk${n}"
       lxc storage volume create zpool "${disk}" size=5GiB --type=block

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -424,7 +424,7 @@ reset_snaps() {
 
     echo "Resetting MicroCeph for ${name}"
     lxc exec "${name}" -- sh -c "
-      if snap list | grep -q microceph ; then
+      if snap list microceph; then
         snap disable microceph > /dev/null 2>&1 || true
 
         # Kill any remaining processes.
@@ -448,7 +448,7 @@ reset_snaps() {
 
     echo "Resetting MicroOVN for ${name}"
     lxc exec "${name}" -- sh -c "
-      if snap list | grep -q microovn ; then
+      if snap list microovn; then
         microovn.ovn-appctl exit || true
         microovn.ovs-appctl exit --cleanup || true
         microovn.ovs-dpctl del-dp system@ovs-system || true
@@ -587,7 +587,7 @@ cluster_reset() {
     "
 
     lxc exec "${name}" -- sh -c "
-      if snap list | grep -q microceph ; then
+      if snap list microceph; then
         # Ceph might not be responsive if we haven't set it up yet.
         microceph_setup=0
         if timeout -k 3 3 microceph cluster list ; then

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -568,19 +568,13 @@ cluster_reset() {
     fi
 
     lxc exec "${name}" -- sh -c "
-      if lxc ls -f csv -c n > /dev/null
-      then
-        for m in \$(lxc ls -f csv -c n) ; do
-          lxc rm \$m -f
-        done
-      fi
+      for m in \$(lxc ls -f csv -c n) ; do
+        lxc rm \$m -f
+      done
 
-      if lxc image ls -f csv -c f > /dev/null
-      then
-        for f in \$(lxc image ls -f csv -c f) ; do
-          lxc image rm \$f
-        done
-      fi
+      for f in \$(lxc image ls -f csv -c f) ; do
+        lxc image rm \$f
+      done
 
       echo 'config: {}' | lxc profile edit default || true
       lxc storage rm local || true

--- a/microcloud/test/includes/microcloud.sh
+++ b/microcloud/test/includes/microcloud.sh
@@ -930,6 +930,10 @@ setup_system() {
     lxc exec "${name}" -- systemctl mask --now cloud-init-hotplugd.socket lvm2-lvmpolld.socket lxd-installer.socket iscsid.socket systemd-journald-dev-log.socket
     lxc exec "${name}" -- systemctl mask --now dev-hugepages.mount sys-kernel-debug.mount sys-kernel-tracing.mount
 
+    # Turn off debugfs and mitigations
+    echo 'GRUB_CMDLINE_LINUX_DEFAULT="quiet debugfs=off mitigations=off"' | lxc exec "${name}" -- tee /etc/default/grub.d/zz-lxd-speed.cfg
+    lxc exec "${name}" -- update-grub
+
     # Install the snaps.
     lxc exec "${name}" -- apt-get update
     if [ -n "${CLOUD_INSPECT:-}" ]; then


### PR DESCRIPTION
Here are some boot time and memory usage for the **2nd boot** (1st one being ignored due to cloud-init does its thing) of a guest VM.

From:

```
# systemd-analyze 
Startup finished in 780ms (kernel) + 7.248s (userspace) = 8.029s 
graphical.target reached after 5.743s in userspace
```

```
root@u22:~# free -mt
               total        used        free      shared  buff/cache   available
Mem:            3932          94        3614          16         222        3777
Swap:              0           0           0
Total:          3932          94        3614
```

To:

```
# systemd-analyze 
Startup finished in 522ms (kernel) + 2.729s (userspace) = 3.252s 
graphical.target reached after 2.709s in userspace
```

```
# free -mt
               total        used        free      shared  buff/cache   available
Mem:            3932          82        3674          16         175        3792
Swap:              0           0           0
Total:          3932          82        3674
```

This helps speeding up the boot of the nested `micro0X` VMs even if the total test runtime seems only slightly reduced.

The biggest test runtime gain is from `test/includes/microcloud: don't start VMs after snapshot, reset_systems will`'s commit that speeds up the `setup` phase (~9.5 minutes down to ~7.5 minutes).