### PR TITLE
microcloud/cmd/microcloud: Remove dqlite role shift timeouts

### DIFF
--- a/cmd/microcloud/main_init.go
+++ b/cmd/microcloud/main_init.go
@@ -470,9 +470,6 @@ func AddPeers(sh *service.Handler, systems map[string]InitSystem) error {
 		if err != nil {
 			return err
 		}
-
-		// Sleep 3 seconds to give the cluster roles time to reshuffle before adding more members.
-		time.Sleep(3 * time.Second)
 	}
 
 	for peer, cfg := range joinConfig {
@@ -485,9 +482,6 @@ func AddPeers(sh *service.Handler, systems map[string]InitSystem) error {
 		if err != nil {
 			return err
 		}
-
-		// Sleep 3 seconds to give the cluster roles time to reshuffle before adding more members.
-		time.Sleep(3 * time.Second)
 	}
 
 	return nil


### PR DESCRIPTION
After https://github.com/canonical/lxd/pull/12571 was merged, these timeouts are no longer necessary to avoid the join process breaking. 

The 4 system tests should stress-test this enough to capture any issues with removing the timeouts.