### PR TITLE
Single node support

### DIFF
--- a/cmd/microcloud/add.go
+++ b/cmd/microcloud/add.go
@@ -45,6 +45,7 @@ func (c *cmdAdd) Run(cmd *cobra.Command, args []string) error {
 
 	cfg := initConfig{
 		bootstrap:    false,
+		setupMany:    true,
 		autoSetup:    c.flagAutoSetup,
 		wipeAllDisks: c.flagWipe,
 		common:       c.common,

--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -192,7 +192,7 @@ func (c *initConfig) askAddress() error {
 		return fmt.Errorf("Cloud not find valid subnet for address %q", listenAddr)
 	}
 
-	if !c.autoSetup {
+	if !c.autoSetup && c.setupMany {
 		filter, err := c.asker.AskBool(fmt.Sprintf("Limit search for other MicroCloud servers to %s? (yes/no) [default=yes]: ", subnet.String()), "yes")
 		if err != nil {
 			return err
@@ -1296,6 +1296,10 @@ func (c *initConfig) askCephNetwork(sh *service.Handler) error {
 // In auto setup, we will expect no initialized services so that we can be opinionated about how we configure the cluster without user input.
 // This works by deleting the record for the service from the `service.Handler`, thus ignoring it for the remainder of the setup.
 func (c *initConfig) askClustered(s *service.Handler, expectedServices []types.ServiceType) error {
+	if !c.setupMany {
+		return nil
+	}
+
 	for _, serviceType := range expectedServices {
 		for name, info := range c.state {
 			_, newSystem := c.systems[name]

--- a/cmd/microcloud/main_init.go
+++ b/cmd/microcloud/main_init.go
@@ -81,6 +81,9 @@ type initConfig struct {
 	// autoSetup indicates whether questions should automatically choose defaults.
 	autoSetup bool
 
+	// setupMany indicates whether we are setting up remote nodes concurrently, or just a single cluster member.
+	setupMany bool
+
 	// lookupTimeout is the duration to wait for mDNS records to appear during system lookup.
 	lookupTimeout time.Duration
 
@@ -139,6 +142,7 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 
 	cfg := initConfig{
 		bootstrap:       true,
+		setupMany:       true,
 		address:         c.flagAddress,
 		autoSetup:       c.flagAutoSetup,
 		wipeAllDisks:    c.flagWipeAllDisks,
@@ -174,6 +178,13 @@ func (c *initConfig) RunInteractive(cmd *cobra.Command, args []string) error {
 	err = lxdService.Restart(context.Background(), 30)
 	if err != nil {
 		return err
+	}
+
+	if !c.autoSetup {
+		c.setupMany, err = c.common.asker.AskBool("Do you want to set up more than one cluster member? (yes/no) [default=yes]: ", "yes")
+		if err != nil {
+			return err
+		}
 	}
 
 	err = c.askAddress()

--- a/cmd/microcloud/main_init.go
+++ b/cmd/microcloud/main_init.go
@@ -294,6 +294,10 @@ func (c *initConfig) RunInteractive(cmd *cobra.Command, args []string) error {
 // - `expectedSystems` is a list of expected hostnames. If given, the behaviour is similar to `autoSetup`,
 // except it will wait up to a minute for exclusively these systems to be recorded.
 func (c *initConfig) lookupPeers(s *service.Handler, expectedSystems []string) error {
+	if !c.setupMany {
+		return nil
+	}
+
 	header := []string{"NAME", "IFACE", "ADDR"}
 	var table *SelectableTable
 	var answers []string

--- a/cmd/microcloud/preseed_test.go
+++ b/cmd/microcloud/preseed_test.go
@@ -44,7 +44,7 @@ func (s *preseedSuite) Test_preseedValidateInvalid() {
 			err:    errors.New("No systems given"),
 		},
 		{
-			desc:    "Not enough systems",
+			desc:    "Single node preseed",
 			subnet:  "10.0.0.1/24",
 			iface:   "enp5s0",
 			systems: []System{{Name: "n1", UplinkInterface: "eth0", Storage: InitStorage{}}},
@@ -55,7 +55,7 @@ func (s *preseedSuite) Test_preseedValidateInvalid() {
 			},
 
 			addErr: false,
-			err:    errors.New("At least 2 systems are required to set up MicroCloud"),
+			err:    nil,
 		},
 		{
 			desc:    "Missing lookup subnet",

--- a/cmd/microcloud/services.go
+++ b/cmd/microcloud/services.go
@@ -209,6 +209,7 @@ func (c *cmdServiceAdd) Run(cmd *cobra.Command, args []string) error {
 	cfg := initConfig{
 		// Set bootstrap to true because we are setting up a new cluster for new services.
 		bootstrap: true,
+		setupMany: true,
 		common:    c.common,
 		asker:     &c.common.asker,
 		systems:   map[string]InitSystem{},

--- a/test/main.sh
+++ b/test/main.sh
@@ -218,6 +218,7 @@ run_instances_tests() {
 
 run_basic_tests() {
   run_test test_reuse_cluster "reuse_cluster"
+  run_test test_add_services "add_services"
   run_test test_auto "auto"
   run_test test_remove_cluster_member "remove_cluster_member"
   run_test test_non_ha "non_ha"

--- a/test/suites/add.sh
+++ b/test/suites/add.sh
@@ -119,6 +119,7 @@ test_add_interactive() {
 
   echo "Test growing a MicroCloud with all services and devices set up"
   unset_interactive_vars
+  export MULTI_NODE="yes"
   export LOOKUP_IFACE="enp5s0"
   export LIMIT_SUBNET="yes"
   export EXPECT_PEERS=2
@@ -200,6 +201,7 @@ test_add_interactive() {
   reset_systems 4 2 1
   echo "Test growing a MicroCloud when storage & networks were not already set up"
   unset_interactive_vars
+  export MULTI_NODE="yes"
   export LOOKUP_IFACE="enp5s0"
   export LIMIT_SUBNET="yes"
   export EXPECT_PEERS=2

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -6,6 +6,7 @@ test_interactive() {
   microcloud_internal_net_addr="$(ip_config_to_netaddr lxdbr0)"
 
   echo "Creating a MicroCloud with all services but no devices"
+  export MULTI_NODE="yes"
   export LOOKUP_IFACE="enp5s0"
   export LIMIT_SUBNET="yes"
   export EXPECT_PEERS=2
@@ -658,6 +659,7 @@ _test_case() {
 
     microcloud_internal_net_addr="$(ip_config_to_netaddr lxdbr0)"
 
+    export MULTI_NODE="yes"
     export LOOKUP_IFACE="enp5s0" # filter string for the lookup interface table.
     export LIMIT_SUBNET="yes" # (yes/no) input for limiting lookup of systems to the above subnet.
     export CEPH_CLUSTER_NETWORK="${microcloud_internal_net_addr}"
@@ -805,6 +807,7 @@ test_interactive_combinations() {
 test_service_mismatch() {
   unset_interactive_vars
   # Selects all available systems, adds 1 local disk per system, skips ceph and ovn setup.
+  export MULTI_NODE="yes"
   export LOOKUP_IFACE="enp5s0"
   export LIMIT_SUBNET="yes"
   export EXPECT_PEERS=2
@@ -890,6 +893,7 @@ test_disk_mismatch() {
 
   echo "Creating a MicroCloud with fully remote ceph on one node"
   unset_interactive_vars
+  export MULTI_NODE="yes"
   export LOOKUP_IFACE="enp5s0"
   export LIMIT_SUBNET="yes"
   export EXPECT_PEERS=3
@@ -1056,6 +1060,7 @@ test_reuse_cluster() {
   unset_interactive_vars
 
   # Set the default config for interactive setup.
+  export MULTI_NODE="yes"
   export LOOKUP_IFACE="enp5s0"
   export LIMIT_SUBNET="yes"
   export EXPECT_PEERS=2
@@ -1182,6 +1187,7 @@ test_remove_cluster_member() {
   microcloud_internal_net_addr="$(ip_config_to_netaddr lxdbr0)"
 
   # Set the default config for interactive setup.
+  export MULTI_NODE="yes"
   export LOOKUP_IFACE="enp5s0"
   export LIMIT_SUBNET="yes"
   export EXPECT_PEERS=2
@@ -1329,6 +1335,7 @@ test_add_services() {
 
   ceph_cluster_subnet_prefix="10.0.1"
   ceph_cluster_subnet_iface="enp7s0"
+  export MULTI_NODE="yes"
   export LOOKUP_IFACE="enp5s0"
   export LIMIT_SUBNET="yes"
   export EXPECT_PEERS=2
@@ -1358,6 +1365,7 @@ test_add_services() {
   lxc exec micro01 -- snap enable microceph
   export SETUP_CEPH="yes"
   export SKIP_LOOKUP=1
+  unset MULTI_NODE
   unset SETUP_ZFS
   unset SETUP_OVN
   export REPLACE_PROFILE="no"
@@ -1370,11 +1378,13 @@ test_add_services() {
   lxc exec micro01 -- snap disable microceph
   unset SETUP_CEPH
   unset REPLACE_PROFILE
+  export MULTI_NODE="yes"
   export SKIP_SERVICE="yes"
   microcloud_interactive | lxc exec micro01 -- sh -c "microcloud init > out"
   lxc exec micro01 -- snap enable microceph
   export SETUP_CEPH="yes"
   export SKIP_LOOKUP=1
+  unset MULTI_NODE
   unset SETUP_ZFS
   unset SETUP_OVN
   export REPLACE_PROFILE="yes"
@@ -1386,12 +1396,14 @@ test_add_services() {
 
   echo Add MicroOVN to MicroCloud that was set up without it, and setup ovn network
   lxc exec micro01 -- snap disable microovn
+  export MULTI_NODE="yes"
   export SETUP_ZFS="yes"
   unset SKIP_LOOKUP
   microcloud_interactive | lxc exec micro01 -- sh -c "microcloud init > out"
   lxc exec micro01 -- snap enable microovn
   export SETUP_OVN="yes"
   export SKIP_LOOKUP=1
+  unset MULTI_NODE
   unset SETUP_ZFS
   unset SETUP_CEPH
   microcloud_interactive | lxc exec micro01 -- sh -c "microcloud service add > out"
@@ -1403,6 +1415,7 @@ test_add_services() {
   echo Add both MicroOVN and MicroCeph to a MicroCloud that was set up without it
   lxc exec micro01 -- snap disable microovn
   lxc exec micro01 -- snap disable microceph
+  export MULTI_NODE="yes"
   export SETUP_ZFS="yes"
   unset SKIP_LOOKUP
   unset SETUP_OVN
@@ -1412,6 +1425,7 @@ test_add_services() {
   export SETUP_OVN="yes"
   export SETUP_CEPH="yes"
   export SKIP_LOOKUP=1
+  unset MULTI_NODE
   unset SETUP_ZFS
   microcloud_interactive | lxc exec micro01 -- sh -c "microcloud service add > out"
   services_validator
@@ -1422,6 +1436,7 @@ test_add_services() {
   echo Reuse a MicroCeph that was set up on one node of the MicroCloud
   lxc exec micro01 -- snap disable microceph
   lxc exec micro02 -- microceph cluster bootstrap
+  export MULTI_NODE="yes"
   export SETUP_ZFS="yes"
   unset SETUP_CEPH
   unset SKIP_LOOKUP
@@ -1431,6 +1446,7 @@ test_add_services() {
   export REUSE_EXISTING="add"
   export SETUP_CEPH="yes"
   export SKIP_LOOKUP=1
+  unset MULTI_NODE
   unset SETUP_ZFS
   unset SETUP_OVN
   unset CEPH_CLUSTER_NETWORK
@@ -1441,6 +1457,7 @@ test_add_services() {
   set_cluster_subnet 3  "${ceph_cluster_subnet_iface}" "${ceph_cluster_subnet_prefix}"
 
   echo Fail to add any services if they have been set up
+  export MULTI_NODE="yes"
   export SETUP_ZFS="yes"
   export SETUP_OVN="yes"
   unset REUSE_EXISTING
@@ -1450,6 +1467,7 @@ test_add_services() {
   export CEPH_CLUSTER_NETWORK="${ceph_cluster_subnet_prefix}.0/24"
   microcloud_interactive | lxc exec micro01 -- sh -c "microcloud init > out"
   export SKIP_LOOKUP=1
+  unset MULTI_NODE
   ! microcloud_interactive | lxc exec micro01 -- sh -c "microcloud service add > out" || true
 }
 
@@ -1457,6 +1475,7 @@ test_non_ha() {
   unset_interactive_vars
   microcloud_internal_net_addr="$(ip_config_to_netaddr lxdbr0)"
 
+  export MULTI_NODE="yes"
   export LOOKUP_IFACE="enp5s0"
   export LIMIT_SUBNET="yes"
   export EXPECT_PEERS=1

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -1344,6 +1344,7 @@ test_add_services() {
   export ZFS_WIPE="yes"
   export SETUP_CEPH="yes"
   export SETUP_CEPHFS="yes"
+  export CEPH_ENCRYPT="no"
   export CEPH_FILTER="lxd_disk2"
   export CEPH_WIPE="yes"
   export SETUP_OVN="yes"
@@ -1378,8 +1379,11 @@ test_add_services() {
   lxc exec micro01 -- snap disable microceph
   unset SETUP_CEPH
   unset REPLACE_PROFILE
+  unset SKIP_LOOKUP
   export MULTI_NODE="yes"
   export SKIP_SERVICE="yes"
+  export SETUP_ZFS="yes"
+  export SETUP_OVN="yes"
   microcloud_interactive | lxc exec micro01 -- sh -c "microcloud init > out"
   lxc exec micro01 -- snap enable microceph
   export SETUP_CEPH="yes"


### PR DESCRIPTION
Adds basic single-node support.

This adds an initial question to `microcloud init` asking if the user wants to set up just one node.
```
Do you want to set up more than one cluster member? (yes/no) [default=yes]: 
```

If the user enters `no`, the system will follow the ordinary setup with ZFS and OVN (or optionally a FAN network instead), but the user will not be prompted for a lookup subnet and will not be presented a list of systems.

MicroCeph will be skipped as we require 3 systems. 

The cluster can be grown after this point by using `microcloud add`.

TODO:

- [x] Add tests
- [x] Support preseed
- [x] Support adding missing services (maybe, if it makes sense)
- [x] Test MicroOVN functions properly with 1 node.
