### PR TITLE
Explicitly set bootstrap flag

### DIFF
--- a/cmd/microcloud/add.go
+++ b/cmd/microcloud/add.go
@@ -84,15 +84,15 @@ func (c *cmdAdd) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = c.common.askDisks(s, systems, c.flagAutoSetup, c.flagWipe)
+	err = c.common.askDisks(s, systems, c.flagAutoSetup, c.flagWipe, false)
 	if err != nil {
 		return err
 	}
 
-	err = c.common.askNetwork(s, systems, subnet, c.flagAutoSetup)
+	err = c.common.askNetwork(s, systems, subnet, c.flagAutoSetup, false)
 	if err != nil {
 		return err
 	}
 
-	return setupCluster(s, systems)
+	return setupCluster(s, false, systems)
 }

--- a/cmd/microcloud/main_init.go
+++ b/cmd/microcloud/main_init.go
@@ -12,6 +12,7 @@ import (
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
 	lxdAPI "github.com/canonical/lxd/shared/api"
+	cli "github.com/canonical/lxd/shared/cmd"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/validate"
 	cephTypes "github.com/canonical/microceph/microceph/api/types"
@@ -50,6 +51,22 @@ type InitSystem struct {
 	StorageVolumes map[string][]lxdAPI.StorageVolumesPost
 	// JoinConfig is the LXD configuration for joining members.
 	JoinConfig []lxdAPI.ClusterMemberConfigKey
+}
+
+// initConfig holds the configuration for cluster formation based on the initial flags and answers provided to MicroCloud.
+type initConfig struct {
+	common *CmdControl
+	asker  *cli.Asker
+
+	address      string
+	bootstrap    bool
+	autoSetup    bool
+	wipeAllDisks bool
+
+	name         string
+	lookupIface  *net.Interface
+	lookupSubnet *net.IPNet
+	systems      map[string]InitSystem
 }
 
 type cmdInit struct {

--- a/cmd/microcloud/main_init_preseed.go
+++ b/cmd/microcloud/main_init_preseed.go
@@ -167,12 +167,13 @@ func (c *CmdControl) RunPreseed(cmd *cobra.Command, init bool) error {
 		}
 	}
 
-	err = validateSystems(s, systems)
+	_, bootstrap := systems[s.Name]
+	err = validateSystems(s, systems, bootstrap)
 	if err != nil {
 		return err
 	}
 
-	return setupCluster(s, systems)
+	return setupCluster(s, bootstrap, systems)
 }
 
 // validate validates the unmarshaled preseed input.

--- a/cmd/microcloud/main_init_test.go
+++ b/cmd/microcloud/main_init_test.go
@@ -51,8 +51,9 @@ func newTestSystemsMap(systems ...InitSystem) map[string]InitSystem {
 func ensureValidateSystemsPasses(handler *service.Handler, testSystems map[string]InitSystem, t *testing.T) {
 	for testName, system := range testSystems {
 		systems := newTestSystemsMap(system)
+		cfg := initConfig{systems: systems, bootstrap: true}
 
-		err := validateSystems(handler, systems)
+		err := cfg.validateSystems(handler)
 		if err != nil {
 			t.Fatalf("Valid system %q failed validate: %s", testName, err)
 		}
@@ -62,8 +63,9 @@ func ensureValidateSystemsPasses(handler *service.Handler, testSystems map[strin
 func ensureValidateSystemsFails(handler *service.Handler, testSystems map[string]InitSystem, t *testing.T) {
 	for testName, system := range testSystems {
 		systems := newTestSystemsMap(system)
+		cfg := initConfig{systems: systems, bootstrap: true}
 
-		err := validateSystems(handler, systems)
+		err := cfg.validateSystems(handler)
 		if err == nil {
 			t.Fatalf("Invalid system %q passed validation", testName)
 		}
@@ -196,8 +198,9 @@ func TestValidateSystemsMultiSystem(t *testing.T) {
 	sys2.ServerInfo.Name = "sys2"
 
 	systems := newTestSystemsMap(sys1, sys2)
+	cfg := initConfig{systems: systems, bootstrap: true}
 
-	err := validateSystems(handler, systems)
+	err := cfg.validateSystems(handler)
 	if err == nil {
 		t.Fatalf("sys2 with conflicting management IP and ipv4.ovn.ranges passed validation")
 	}
@@ -216,8 +219,9 @@ func TestValidateSystemsMultiSystem(t *testing.T) {
 	sys4.ServerInfo.Name = "sys4"
 
 	systems = newTestSystemsMap(sys3, sys4)
+	cfg = initConfig{systems: systems, bootstrap: true}
 
-	err = validateSystems(handler, systems)
+	err = cfg.validateSystems(handler)
 	if err == nil {
 		t.Fatalf("sys4 with conflicting management IP and ipv6.ovn.ranges passed validation")
 	}

--- a/service/lxd.go
+++ b/service/lxd.go
@@ -363,6 +363,17 @@ func getClientsAndNetworks(s LXDService, ctx context.Context, bootstrap bool, pe
 	for _, info := range peers {
 		// Don't include a local interface unless we are bootstrapping, in which case we shouldn't use the remote client.
 		if info.Name == s.Name() {
+			if clients[info.Name] == nil {
+				clients[info.Name], err = s.Client(ctx, "")
+				if err != nil {
+					return nil, nil, err
+				}
+
+				networks[info.Name], err = clients[info.Name].GetNetworks()
+				if err != nil {
+					return nil, nil, err
+				}
+			}
 			continue
 		}
 


### PR DESCRIPTION
We often infer whether or not we are bootstrapping by checking the `systems` map for the local system. However now that we can re-use clusters from existing systems, we can't always rely on the local member being the bootstrapper. 

Instead, this PR explicitly sets whether or not we are bootstrapping based on the command we are running.


Additionally, there is a commit that cleans up the network questions. Before, we used to apply the FAN network first and then overwrite it with the OVN network. This is a bit inefficient and will break with adding services (#260) so this PR splits the network questions into two functions. First we try to create the OVN network (or return nil). Then if weren't able to do that, we try to create the FAN network.