### PR TITLE
Include 'lookup_interface' in preseed example and Use the correct ovn interface

### DIFF
--- a/doc/how-to/preseed.yaml
+++ b/doc/how-to/preseed.yaml
@@ -1,5 +1,7 @@
 # `lookup_subnet` limits the subnet when looking up systems with mDNS.
 lookup_subnet: 10.0.0.1/24
+# `lookup_interface` limits the interface when looking up systems with mDNS.
+lookup_interface: eth0
 
 # `systems` lists the systems we expect to find by their host name.
 #   `name` represents the host name


### PR DESCRIPTION
The preseed yaml file used as an example in the [docs](https://canonical-microcloud.readthedocs-hosted.com/en/latest/how-to/initialise/#howto-initialise-preseed) does not include the option 'lookup_subnet'. 

As this preseed example closely aligns with the [get started guide](https://canonical-microcloud.readthedocs-hosted.com/en/latest/tutorial/get_started/) `eth1` was changed  to `enp6s0` to avoid confusion with the device name added to the VM.

Not included in this PR, as I cannot find additional information on the behavior, is  `reuse_existing_clusters` which is also missing.