### PR TITLE
Add missing net/url import

### DIFF
--- a/service/lxd.go
+++ b/service/lxd.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"strings"
 	"time"


### PR DESCRIPTION
It looks in between merging the long list of PRs during the last hours we missed a dependency due to not rebasing the PRs.

https://github.com/canonical/microcloud/pull/287 removed the `net/url` import from the `service/lxd.go` file. This now causes build failures on `main`: https://github.com/canonical/microcloud/actions/runs/9647792769/job/26607464289


