### PR TITLE
Collect system information prior to asking any questions

### DIFF
--- a/cmd/microcloud/add.go
+++ b/cmd/microcloud/add.go
@@ -112,7 +112,7 @@ func (c *cmdAdd) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	cfg.state[cfg.name] = *state
-
+	fmt.Println("Gathering system information...")
 	for _, system := range cfg.systems {
 		if system.ServerInfo.Name == "" || system.ServerInfo.Name == cfg.name {
 			continue

--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -450,7 +450,7 @@ func validateCephInterfacesForSubnet(lxdService *service.LXDService, systems map
 func getTargetCephNetworks(sh *service.Handler, s *InitSystem) (internalCephNetwork *net.IPNet, err error) {
 	microCephService := sh.Services[types.MicroCeph].(*service.CephService)
 	if microCephService == nil {
-		return nil, fmt.Errorf("failed to get MicroCeph service")
+		return nil, fmt.Errorf("Failed to get MicroCeph service")
 	}
 
 	var cephAddr string
@@ -471,7 +471,7 @@ func getTargetCephNetworks(sh *service.Handler, s *InitSystem) (internalCephNetw
 			// is not a network range but a regular IP address. We need to extract the network range.
 			_, valueNet, err := net.ParseCIDR(value)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse the Ceph cluster network configuration from the existing Ceph cluster: %v", err)
+				return nil, fmt.Errorf("Failed to parse the Ceph cluster network configuration from the existing Ceph cluster: %v", err)
 			}
 
 			internalCephNetwork = valueNet
@@ -1111,7 +1111,7 @@ func (c *initConfig) askNetwork(sh *service.Handler) error {
 			}
 
 			if !proceedWithNoOverlayNetworking {
-				return fmt.Errorf("cluster bootstrapping aborted due to lack of usable networking")
+				return fmt.Errorf("Cluster bootstrapping aborted due to lack of usable networking")
 			}
 		}
 
@@ -1183,7 +1183,7 @@ func (c *initConfig) askCephNetwork(sh *service.Handler) error {
 			// is not a network range but a regular IP address. We need to extract the network range.
 			_, valueNet, err := net.ParseCIDR(value)
 			if err != nil {
-				return fmt.Errorf("failed to parse the Ceph cluster network configuration from the existing Ceph cluster: %v", err)
+				return fmt.Errorf("Failed to parse the Ceph cluster network configuration from the existing Ceph cluster: %v", err)
 			}
 
 			defaultCephNetwork = valueNet

--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -421,7 +421,7 @@ func (c *initConfig) askLocalPool(sh *service.Handler) error {
 	return nil
 }
 
-func validateCephInterfacesForSubnet(lxdService *service.LXDService, systems map[string]InitSystem, availableCephNetworkInterfaces map[string][]service.CephDedicatedInterface, askedCephSubnet string) error {
+func validateCephInterfacesForSubnet(lxdService *service.LXDService, systems map[string]InitSystem, availableCephNetworkInterfaces map[string]map[string]service.CephDedicatedInterface, askedCephSubnet string) error {
 	validatedCephInterfacesData, err := lxdService.ValidateCephInterfaces(askedCephSubnet, availableCephNetworkInterfaces)
 	if err != nil {
 		return err
@@ -1155,7 +1155,7 @@ func (c *initConfig) askCephNetwork(sh *service.Handler) error {
 		return nil
 	}
 
-	availableCephNetworkInterfaces := map[string][]service.CephDedicatedInterface{}
+	availableCephNetworkInterfaces := map[string]map[string]service.CephDedicatedInterface{}
 	for name, state := range c.state {
 		if len(state.AvailableCephInterfaces) == 0 {
 			fmt.Printf("No network interfaces found with IPs on %q to set a dedicated Ceph network, skipping Ceph network setup\n", name)
@@ -1163,9 +1163,9 @@ func (c *initConfig) askCephNetwork(sh *service.Handler) error {
 			return nil
 		}
 
-		ifaces := make([]service.CephDedicatedInterface, 0, len(state.AvailableCephInterfaces))
-		for _, iface := range state.AvailableCephInterfaces {
-			ifaces = append(ifaces, iface)
+		ifaces := make(map[string]service.CephDedicatedInterface, len(state.AvailableCephInterfaces))
+		for name, iface := range state.AvailableCephInterfaces {
+			ifaces[name] = iface
 		}
 
 		availableCephNetworkInterfaces[name] = ifaces

--- a/cmd/microcloud/cluster_members.go
+++ b/cmd/microcloud/cluster_members.go
@@ -266,7 +266,7 @@ func (c *cmdClusterRecover) run(cmd *cobra.Command, args []string) error {
 
 	tarballPath, err := m.RecoverFromQuorumLoss(newMembers)
 	if err != nil {
-		return fmt.Errorf("cluster edit: %w", err)
+		return fmt.Errorf("Cluster edit: %w", err)
 	}
 
 	fmt.Printf("Cluster changes applied; new database state saved to %s\n\n", tarballPath)

--- a/cmd/microcloud/main_init.go
+++ b/cmd/microcloud/main_init.go
@@ -216,7 +216,7 @@ func (c *initConfig) RunInteractive(cmd *cobra.Command, args []string) error {
 	}
 
 	c.state[c.name] = *state
-
+	fmt.Println("Gathering system information...")
 	for _, system := range c.systems {
 		if system.ServerInfo.Name == "" || system.ServerInfo.Name == c.name {
 			continue

--- a/cmd/microcloud/main_init.go
+++ b/cmd/microcloud/main_init.go
@@ -630,9 +630,8 @@ func validateGatewayNet(config map[string]string, ipPrefix string, cidrValidator
 	return ovnIPRanges, nil
 }
 
-func validateSystems(s *service.Handler, systems map[string]InitSystem) (err error) {
-	curSystem, bootstrap := systems[s.Name]
-	if !bootstrap {
+func (c *initConfig) validateSystems(s *service.Handler) (err error) {
+	if !c.bootstrap {
 		return nil
 	}
 
@@ -641,7 +640,7 @@ func validateSystems(s *service.Handler, systems map[string]InitSystem) (err err
 	// systems' management addrs
 	var ip4OVNRanges, ip6OVNRanges []*shared.IPRange
 
-	for _, network := range curSystem.Networks {
+	for _, network := range c.systems[s.Name].Networks {
 		if network.Type == "physical" && network.Name == service.DefaultUplinkNetwork {
 			ip4OVNRanges, err = validateGatewayNet(network.Config, "ipv4", validate.IsNetworkAddressCIDRV4)
 			if err != nil {
@@ -676,7 +675,7 @@ func validateSystems(s *service.Handler, systems map[string]InitSystem) (err err
 
 	// Ensure that no system's management address falls within the OVN ranges
 	// to prevent OVN from allocating an IP that's already in use.
-	for systemName, system := range systems {
+	for systemName, system := range c.systems {
 		// If the system is ourselves, we don't have an mDNS payload so grab the address locally.
 		addr := system.ServerInfo.Address
 		if systemName == s.Name {

--- a/cmd/microcloud/main_init_preseed.go
+++ b/cmd/microcloud/main_init_preseed.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	lxdAPI "github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/filter"
@@ -102,7 +101,9 @@ func DiskOperatorSet() filter.OperatorSet {
 }
 
 // RunPreseed initializes MicroCloud from a preseed yaml filepath input.
-func (c *CmdControl) RunPreseed(cmd *cobra.Command, init bool, flagLookupTimeout int64) error {
+func (c *initConfig) RunPreseed(cmd *cobra.Command) error {
+	c.autoSetup = true
+
 	bytes, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		return fmt.Errorf("Failed to read from stdin: %w", err)
@@ -119,7 +120,7 @@ func (c *CmdControl) RunPreseed(cmd *cobra.Command, init bool, flagLookupTimeout
 		return err
 	}
 
-	err = config.validate(hostname, init)
+	err = config.validate(hostname, c.bootstrap)
 	if err != nil {
 		return err
 	}
@@ -136,27 +137,24 @@ func (c *CmdControl) RunPreseed(cmd *cobra.Command, init bool, flagLookupTimeout
 		types.MicroOVN:  api.MicroOVNDir,
 	}
 
-	services, err = c.askMissingServices(services, optionalServices, true)
+	services, err = c.askMissingServices(services, optionalServices)
 	if err != nil {
 		return err
 	}
 
-	s, err := service.NewHandler(hostname, ip.String(), c.FlagMicroCloudDir, c.FlagLogDebug, c.FlagLogVerbose, services...)
+	c.name = hostname
+	c.address = ip.String()
+	s, err := service.NewHandler(c.name, c.address, c.common.FlagMicroCloudDir, c.common.FlagLogDebug, c.common.FlagLogVerbose, services...)
 	if err != nil {
 		return err
 	}
 
-	lookupTimeout := DefaultAutoLookupTimeout
-	if flagLookupTimeout > 0 {
-		lookupTimeout = time.Duration(flagLookupTimeout) * time.Second
-	}
-
-	systems, err := config.Parse(s, init, lookupTimeout)
+	systems, err := config.Parse(s, c)
 	if err != nil {
 		return err
 	}
 
-	if !init {
+	if !c.bootstrap {
 		peers, err := s.Services[types.MicroCloud].ClusterMembers(context.Background())
 		if err != nil {
 			return err
@@ -175,12 +173,12 @@ func (c *CmdControl) RunPreseed(cmd *cobra.Command, init bool, flagLookupTimeout
 		}
 	}
 
-	err = validateSystems(s, systems)
+	err = c.validateSystems(s)
 	if err != nil {
 		return err
 	}
 
-	return setupCluster(s, systems)
+	return c.setupCluster(s)
 }
 
 // validate validates the unmarshaled preseed input.
@@ -385,10 +383,10 @@ func (d *DiskFilter) Match(disks []lxdAPI.ResourcesStorageDisk) ([]lxdAPI.Resour
 }
 
 // Parse converts the preseed data into the appropriate set of InitSystem to use when setting up MicroCloud.
-func (p *Preseed) Parse(s *service.Handler, bootstrap bool, lookupTimeout time.Duration) (map[string]InitSystem, error) {
-	systems := make(map[string]InitSystem, len(p.Systems))
-	if bootstrap {
-		systems[s.Name] = InitSystem{ServerInfo: mdns.ServerInfo{Name: s.Name}}
+func (p *Preseed) Parse(s *service.Handler, c *initConfig) (map[string]InitSystem, error) {
+	c.systems = make(map[string]InitSystem, len(p.Systems))
+	if c.bootstrap {
+		c.systems[s.Name] = InitSystem{ServerInfo: mdns.ServerInfo{Name: s.Name}}
 	}
 
 	expectedSystems := make([]string, 0, len(p.Systems))
@@ -401,7 +399,8 @@ func (p *Preseed) Parse(s *service.Handler, bootstrap bool, lookupTimeout time.D
 	}
 
 	// Lookup peers until expected systems are found.
-	_, lookupSubnet, err := net.ParseCIDR(p.LookupSubnet)
+	var err error
+	_, c.lookupSubnet, err = net.ParseCIDR(p.LookupSubnet)
 	if err != nil {
 		return nil, err
 	}
@@ -411,19 +410,18 @@ func (p *Preseed) Parse(s *service.Handler, bootstrap bool, lookupTimeout time.D
 		return nil, fmt.Errorf("Failed to get network interfaces: %w", err)
 	}
 
-	var lookupIface *net.Interface
 	for _, iface := range ifaces {
 		if iface.Name == p.LookupInterface {
-			lookupIface = &iface
+			c.lookupIface = &iface
 			break
 		}
 	}
 
-	if lookupIface == nil {
+	if c.lookupIface == nil {
 		return nil, fmt.Errorf("Failed to find lookup interface %q", p.LookupInterface)
 	}
 
-	err = lookupPeers(s, lookupTimeout, true, lookupIface, lookupSubnet, expectedSystems, systems)
+	err = c.lookupPeers(s, expectedSystems)
 	if err != nil {
 		return nil, err
 	}
@@ -433,26 +431,32 @@ func (p *Preseed) Parse(s *service.Handler, bootstrap bool, lookupTimeout time.D
 		expectedServices[k] = v
 	}
 
-	for serviceType := range expectedServices {
-		initializedSystem, _, err := checkClustered(s, false, serviceType, systems)
+	for peer, system := range c.systems {
+		existingClusters, err := s.GetExistingClusters(context.Background(), system.ServerInfo)
 		if err != nil {
 			return nil, err
 		}
 
-		if initializedSystem != "" && !p.ReuseExistingClusters {
-			fmt.Printf("Existing %s cluster on system %q is incompatible with MicroCloud, skipping %s setup\n", serviceType, initializedSystem, serviceType)
+		for serviceType, cluster := range existingClusters {
+			if len(cluster) > 0 {
+				fmt.Printf("Existing %s cluster is incompatible with MicroCloud, skipping %s setup\n", serviceType, serviceType)
 
-			delete(s.Services, serviceType)
+				delete(s.Services, serviceType)
+			}
 		}
+
+		state := c.state[peer]
+		state.ExistingServices = existingClusters
+		c.state[peer] = state
 	}
 
-	for name, system := range systems {
+	for name, system := range c.systems {
 		system.MicroCephDisks = []cephTypes.DisksPost{}
 		system.TargetStoragePools = []lxdAPI.StoragePoolsPost{}
 		system.StoragePools = []lxdAPI.StoragePoolsPost{}
 		system.JoinConfig = []lxdAPI.ClusterMemberConfigKey{}
 
-		systems[name] = system
+		c.systems[name] = system
 	}
 
 	lxd := s.Services[types.LXD].(*service.LXDService)
@@ -463,59 +467,86 @@ func (p *Preseed) Parse(s *service.Handler, bootstrap bool, lookupTimeout time.D
 		}
 	}
 
+	// If an uplink interface was explicitly chosen, we will try to set up an OVN network.
+	explicitOVN := len(ifaceByPeer) > 0
+
+	cephInterfaces := map[string][]service.CephDedicatedInterface{}
+	for _, system := range c.systems {
+		uplinkIfaces, cephIfaces, _, err := lxd.GetNetworkInterfaces(context.Background(), system.ServerInfo.Name, system.ServerInfo.Address, system.ServerInfo.AuthSecret)
+		if err != nil {
+			return nil, err
+		}
+
+		// Take the first alphabetical interface for each system's uplink network.
+		for k := range uplinkIfaces {
+			currentIface := ifaceByPeer[system.ServerInfo.Name]
+			if k < currentIface || currentIface == "" {
+				ifaceByPeer[system.ServerInfo.Name] = k
+			}
+		}
+
+		for _, iface := range cephIfaces {
+			if cephInterfaces[system.ServerInfo.Name] == nil {
+				cephInterfaces[system.ServerInfo.Name] = []service.CephDedicatedInterface{}
+			}
+
+			cephInterfaces[system.ServerInfo.Name] = append(cephInterfaces[system.ServerInfo.Name], iface)
+		}
+	}
+
 	// If we have specified any part of OVN config, implicitly assume we want to set it up.
-	usingOVN := p.OVN.IPv4Gateway != "" || p.OVN.IPv6Gateway != "" || len(ifaceByPeer) != 0
+	usingOVN := p.OVN.IPv4Gateway != "" || p.OVN.IPv6Gateway != "" || explicitOVN
 	if usingOVN {
 		// Only select systems not explicitly picked above.
-		infos := make([]mdns.ServerInfo, 0, len(systems))
-		for peer, system := range systems {
+		infos := make([]mdns.ServerInfo, 0, len(c.systems))
+		for peer, system := range c.systems {
 			if ifaceByPeer[peer] == "" {
 				infos = append(infos, system.ServerInfo)
 			}
 		}
 
-		// Pick the first interface for any system without an explicitly chosen one.
-		networks, err := lxd.GetUplinkInterfaces(context.Background(), bootstrap, infos)
+		for _, info := range infos {
+			ifaces, _, _, err := lxd.GetNetworkInterfaces(context.Background(), info.Name, info.Address, info.AuthSecret)
+			if err != nil {
+				return nil, err
+			}
+
+			for k := range ifaces {
+				ifaceByPeer[info.Name] = k
+				break
+			}
+		}
+	}
+
+	if usingOVN && c.bootstrap && len(ifaceByPeer) < 3 {
+		return nil, fmt.Errorf("Failed to find at least 3 interfaces on 3 machines for OVN configuration")
+	}
+
+	// Setup FAN network if OVN not available.
+	if usingOVN {
+		for peer, iface := range ifaceByPeer {
+			system := c.systems[peer]
+			if c.bootstrap {
+				system.TargetNetworks = append(system.TargetNetworks, lxd.DefaultPendingOVNNetwork(iface))
+				if s.Name == peer {
+					uplink, ovn := lxd.DefaultOVNNetwork(p.OVN.IPv4Gateway, p.OVN.IPv4Range, p.OVN.IPv6Gateway, p.OVN.DNSServers)
+					system.Networks = append(system.Networks, uplink, ovn)
+				}
+			} else {
+				system.JoinConfig = append(system.JoinConfig, lxd.DefaultOVNNetworkJoinConfig(iface))
+			}
+
+			c.systems[peer] = system
+		}
+	} else {
+		// Check if FAN networking is usable.
+		fanUsable, _, err := service.FanNetworkUsable()
 		if err != nil {
 			return nil, err
 		}
 
-		for peer, nets := range networks {
-			if len(nets) > 0 {
-				ifaceByPeer[peer] = nets[0].Name
-			}
-		}
-	}
-
-	if usingOVN && bootstrap && len(ifaceByPeer) < 3 {
-		return nil, fmt.Errorf("Failed to find at least 3 interfaces on 3 machines for OVN configuration")
-	}
-
-	for peer, iface := range ifaceByPeer {
-		system := systems[peer]
-		if bootstrap {
-			system.TargetNetworks = append(system.TargetNetworks, lxd.DefaultPendingOVNNetwork(iface))
-			if s.Name == peer {
-				uplink, ovn := lxd.DefaultOVNNetwork(p.OVN.IPv4Gateway, p.OVN.IPv4Range, p.OVN.IPv6Gateway, p.OVN.DNSServers)
-				system.Networks = append(system.Networks, uplink, ovn)
-			}
-		} else {
-			system.JoinConfig = append(system.JoinConfig, lxd.DefaultOVNNetworkJoinConfig(iface))
-		}
-
-		systems[peer] = system
-	}
-
-	// Check if FAN networking is usable.
-	fanUsable, _, err := lxd.FanNetworkUsable()
-	if err != nil {
-		return nil, err
-	}
-
-	// Setup FAN network if OVN not available.
-	if len(ifaceByPeer) == 0 && fanUsable {
-		for peer, system := range systems {
-			if bootstrap {
+		for peer, system := range c.systems {
+			if c.bootstrap && fanUsable {
 				system.TargetNetworks = append(system.TargetNetworks, lxd.DefaultPendingFanNetwork())
 				if s.Name == peer {
 					final, err := lxd.DefaultFanNetwork()
@@ -527,13 +558,13 @@ func (p *Preseed) Parse(s *service.Handler, bootstrap bool, lookupTimeout time.D
 				}
 			}
 
-			systems[peer] = system
+			c.systems[peer] = system
 		}
 	}
 
 	directCephMatches := map[string]int{}
 	directZFSMatches := map[string]int{}
-	for peer, system := range systems {
+	for peer, system := range c.systems {
 		directLocal := DirectStorage{}
 		directCeph := []DirectStorage{}
 		for _, sys := range p.Systems {
@@ -545,7 +576,7 @@ func (p *Preseed) Parse(s *service.Handler, bootstrap bool, lookupTimeout time.D
 
 		// Setup directly specified disks for ZFS pool.
 		if directLocal.Path != "" {
-			if bootstrap {
+			if c.bootstrap {
 				system.TargetStoragePools = append(system.TargetStoragePools, lxd.DefaultPendingZFSStoragePool(directLocal.Wipe, directLocal.Path))
 				if s.Name == peer {
 					system.StoragePools = append(system.StoragePools, lxd.DefaultZFSStoragePool())
@@ -570,7 +601,7 @@ func (p *Preseed) Parse(s *service.Handler, bootstrap bool, lookupTimeout time.D
 
 		// Setup ceph pool for disks specified to MicroCeph.
 		if len(system.MicroCephDisks) > 0 {
-			if bootstrap {
+			if c.bootstrap {
 				system.TargetStoragePools = append(system.TargetStoragePools, lxd.DefaultPendingCephStoragePool())
 
 				if s.Name == peer {
@@ -583,11 +614,11 @@ func (p *Preseed) Parse(s *service.Handler, bootstrap bool, lookupTimeout time.D
 			directCephMatches[peer] = directCephMatches[peer] + 1
 		}
 
-		systems[peer] = system
+		c.systems[peer] = system
 	}
 
 	allResources := map[string]*lxdAPI.Resources{}
-	for peer, system := range systems {
+	for peer, system := range c.systems {
 		// Skip any systems that had direct configuration.
 		if len(system.MicroCephDisks) > 0 || len(system.TargetStoragePools) > 0 || len(system.StoragePools) > 0 {
 			continue
@@ -617,7 +648,7 @@ func (p *Preseed) Parse(s *service.Handler, bootstrap bool, lookupTimeout time.D
 	cephMachines := map[string]bool{}
 	zfsMachines := map[string]bool{}
 	for peer, r := range allResources {
-		system := systems[peer]
+		system := c.systems[peer]
 
 		disks := make([]lxdAPI.ResourcesStorageDisk, 0, len(r.Storage.Disks))
 		for _, disk := range r.Storage.Disks {
@@ -644,7 +675,7 @@ func (p *Preseed) Parse(s *service.Handler, bootstrap bool, lookupTimeout time.D
 				)
 				// There should only be one ceph pool per system.
 				if !addedCephPool {
-					if bootstrap {
+					if c.bootstrap {
 						system.TargetStoragePools = append(system.TargetStoragePools, lxd.DefaultPendingCephStoragePool())
 
 						if s.Name == peer {
@@ -684,7 +715,7 @@ func (p *Preseed) Parse(s *service.Handler, bootstrap bool, lookupTimeout time.D
 
 		for _, filter := range p.Storage.Local {
 			// No need to check filters anymore if each machine has a disk.
-			if len(zfsMachines) == len(systems) {
+			if len(zfsMachines) == len(c.systems) {
 				break
 			}
 
@@ -695,7 +726,7 @@ func (p *Preseed) Parse(s *service.Handler, bootstrap bool, lookupTimeout time.D
 
 			if len(matched) > 0 {
 				zfsMachines[peer] = true
-				if bootstrap {
+				if c.bootstrap {
 					system.TargetStoragePools = append(system.TargetStoragePools, lxd.DefaultPendingZFSStoragePool(filter.Wipe, parseDiskPath(matched[0])))
 					if s.Name == peer {
 						system.StoragePools = append(system.StoragePools, lxd.DefaultZFSStoragePool())
@@ -708,28 +739,14 @@ func (p *Preseed) Parse(s *service.Handler, bootstrap bool, lookupTimeout time.D
 			}
 		}
 
-		systems[peer] = system
-	}
-
-	// Configure Ceph networks.
-	infos := make([]mdns.ServerInfo, 0, len(systems))
-	for _, system := range systems {
-		infos = append(infos, system.ServerInfo)
-	}
-
-	var cephInterfaces map[string][]service.CephDedicatedInterface
-	if p.Ceph.InternalNetwork != "" || !bootstrap {
-		cephInterfaces, err = lxd.GetCephInterfaces(context.Background(), bootstrap, infos)
-		if err != nil {
-			return nil, err
-		}
+		c.systems[peer] = system
 	}
 
 	// Initialize Ceph network if specified.
-	if bootstrap {
+	if c.bootstrap {
 		var initializedMicroCephSystem *InitSystem
-		for peer, system := range systems {
-			if system.InitializedServices[types.MicroCeph][peer] != "" {
+		for peer, system := range c.systems {
+			if c.state[peer].ExistingServices[types.MicroCeph][peer] != "" {
 				initializedMicroCephSystem = &system
 				break
 			}
@@ -744,7 +761,7 @@ func (p *Preseed) Parse(s *service.Handler, bootstrap bool, lookupTimeout time.D
 				return nil, err
 			}
 
-			if targetInternalCephNetwork.String() != lookupSubnet.String() {
+			if targetInternalCephNetwork.String() != c.lookupSubnet.String() {
 				customTargetCephInternalNetwork = targetInternalCephNetwork.String()
 			}
 		}
@@ -757,14 +774,14 @@ func (p *Preseed) Parse(s *service.Handler, bootstrap bool, lookupTimeout time.D
 		}
 
 		if internalCephNetwork != "" {
-			err = validateCephInterfacesForSubnet(lxd, systems, cephInterfaces, internalCephNetwork)
+			err = validateCephInterfacesForSubnet(lxd, c.systems, cephInterfaces, internalCephNetwork)
 			if err != nil {
 				return nil, err
 			}
 
-			bootstrapSystem := systems[s.Name]
+			bootstrapSystem := c.systems[s.Name]
 			bootstrapSystem.MicroCephInternalNetworkSubnet = internalCephNetwork
-			systems[s.Name] = bootstrapSystem
+			c.systems[s.Name] = bootstrapSystem
 		}
 	} else {
 		localInternalCephNetwork, err := getTargetCephNetworks(s, nil)
@@ -772,8 +789,8 @@ func (p *Preseed) Parse(s *service.Handler, bootstrap bool, lookupTimeout time.D
 			return nil, err
 		}
 
-		if localInternalCephNetwork.String() != "" && localInternalCephNetwork.String() != lookupSubnet.String() {
-			err = validateCephInterfacesForSubnet(lxd, systems, cephInterfaces, localInternalCephNetwork.String())
+		if localInternalCephNetwork.String() != "" && localInternalCephNetwork.String() != c.lookupSubnet.String() {
+			err = validateCephInterfacesForSubnet(lxd, c.systems, cephInterfaces, localInternalCephNetwork.String())
 			if err != nil {
 				return nil, err
 			}
@@ -801,17 +818,17 @@ func (p *Preseed) Parse(s *service.Handler, bootstrap bool, lookupTimeout time.D
 		}
 	}
 
-	if bootstrap && len(cephMachines)+len(directCephMatches) > 0 && len(cephMachines)+len(directCephMatches) < 3 {
+	if c.bootstrap && len(cephMachines)+len(directCephMatches) > 0 && len(cephMachines)+len(directCephMatches) < 3 {
 		return nil, fmt.Errorf("Failed to find at least 3 disks on 3 machines for MicroCeph configuration")
 	}
 
-	if bootstrap && len(zfsMachines)+len(directZFSMatches) > 0 && len(zfsMachines)+len(directZFSMatches) < len(systems) {
+	if c.bootstrap && len(zfsMachines)+len(directZFSMatches) > 0 && len(zfsMachines)+len(directZFSMatches) < len(c.systems) {
 		return nil, fmt.Errorf("Failed to find at least 1 disk on each machine for local storage pool configuration")
 	}
 
 	if len(cephMatches)+len(directCephMatches) > 0 && p.Storage.CephFS {
-		for name, system := range systems {
-			if bootstrap {
+		for name, system := range c.systems {
+			if c.bootstrap {
 				system.TargetStoragePools = append(system.TargetStoragePools, lxd.DefaultPendingCephFSStoragePool())
 				if s.Name == name {
 					system.StoragePools = append(system.StoragePools, lxd.DefaultCephFSStoragePool())
@@ -820,9 +837,9 @@ func (p *Preseed) Parse(s *service.Handler, bootstrap bool, lookupTimeout time.D
 				system.JoinConfig = append(system.JoinConfig, lxd.DefaultCephFSStoragePoolJoinConfig())
 			}
 
-			systems[name] = system
+			c.systems[name] = system
 		}
 	}
 
-	return systems, nil
+	return c.systems, nil
 }

--- a/cmd/microcloud/main_init_preseed.go
+++ b/cmd/microcloud/main_init_preseed.go
@@ -470,7 +470,7 @@ func (p *Preseed) Parse(s *service.Handler, c *initConfig) (map[string]InitSyste
 	// If an uplink interface was explicitly chosen, we will try to set up an OVN network.
 	explicitOVN := len(ifaceByPeer) > 0
 
-	cephInterfaces := map[string][]service.CephDedicatedInterface{}
+	cephInterfaces := map[string]map[string]service.CephDedicatedInterface{}
 	for _, system := range c.systems {
 		uplinkIfaces, cephIfaces, _, err := lxd.GetNetworkInterfaces(context.Background(), system.ServerInfo.Name, system.ServerInfo.Address, system.ServerInfo.AuthSecret)
 		if err != nil {
@@ -485,12 +485,12 @@ func (p *Preseed) Parse(s *service.Handler, c *initConfig) (map[string]InitSyste
 			}
 		}
 
-		for _, iface := range cephIfaces {
+		for ifaceName, iface := range cephIfaces {
 			if cephInterfaces[system.ServerInfo.Name] == nil {
-				cephInterfaces[system.ServerInfo.Name] = []service.CephDedicatedInterface{}
+				cephInterfaces[system.ServerInfo.Name] = map[string]service.CephDedicatedInterface{}
 			}
 
-			cephInterfaces[system.ServerInfo.Name] = append(cephInterfaces[system.ServerInfo.Name], iface)
+			cephInterfaces[system.ServerInfo.Name][ifaceName] = iface
 		}
 	}
 

--- a/cmd/microcloud/main_init_test.go
+++ b/cmd/microcloud/main_init_test.go
@@ -51,8 +51,9 @@ func newTestSystemsMap(systems ...InitSystem) map[string]InitSystem {
 func ensureValidateSystemsPasses(handler *service.Handler, testSystems map[string]InitSystem, t *testing.T) {
 	for testName, system := range testSystems {
 		systems := newTestSystemsMap(system)
+		cfg := initConfig{systems: systems, bootstrap: true}
 
-		err := validateSystems(handler, systems)
+		err := cfg.validateSystems(handler)
 		if err != nil {
 			t.Fatalf("Valid system %q failed validate: %s", testName, err)
 		}
@@ -62,8 +63,9 @@ func ensureValidateSystemsPasses(handler *service.Handler, testSystems map[strin
 func ensureValidateSystemsFails(handler *service.Handler, testSystems map[string]InitSystem, t *testing.T) {
 	for testName, system := range testSystems {
 		systems := newTestSystemsMap(system)
+		cfg := initConfig{systems: systems, bootstrap: true}
 
-		err := validateSystems(handler, systems)
+		err := cfg.validateSystems(handler)
 		if err == nil {
 			t.Fatalf("Invalid system %q passed validation", testName)
 		}
@@ -196,8 +198,9 @@ func TestValidateSystemsMultiSystem(t *testing.T) {
 	sys2.ServerInfo.Name = "sys2"
 
 	systems := newTestSystemsMap(sys1, sys2)
+	cfg := initConfig{systems: systems, bootstrap: true}
 
-	err := validateSystems(handler, systems)
+	err := cfg.validateSystems(handler)
 	if err == nil {
 		t.Fatalf("sys2 with conflicting management IP and ipv4.ovn.ranges passed validation")
 	}
@@ -216,8 +219,9 @@ func TestValidateSystemsMultiSystem(t *testing.T) {
 	sys4.ServerInfo.Name = "sys4"
 
 	systems = newTestSystemsMap(sys3, sys4)
+	cfg = initConfig{systems: systems, bootstrap: true}
 
-	err = validateSystems(handler, systems)
+	err = cfg.validateSystems(handler)
 	if err == nil {
 		t.Fatalf("sys4 with conflicting management IP and ipv6.ovn.ranges passed validation")
 	}

--- a/service/lxd.go
+++ b/service/lxd.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/canonical/microcloud/microcloud/api/types"
 	cloudClient "github.com/canonical/microcloud/microcloud/client"
-	"github.com/canonical/microcloud/microcloud/mdns"
 )
 
 // LXDService is a LXD service.
@@ -340,49 +339,8 @@ func (s *LXDService) GetResources(ctx context.Context, target string, address st
 	return client.GetServerResources()
 }
 
-// getClientsAndNetworks returns a map of clients and networks for the given LXDService and peers.
-func getClientsAndNetworks(s LXDService, ctx context.Context, bootstrap bool, peers []mdns.ServerInfo) (clients map[string]lxd.InstanceServer, networks map[string][]api.Network, err error) {
-	clients = make(map[string]lxd.InstanceServer)
-	networks = make(map[string][]api.Network)
-
-	if bootstrap {
-		client, err := s.Client(ctx, "")
-		if err != nil {
-			return nil, nil, err
-		}
-
-		networks[s.Name()], err = client.GetNetworks()
-		if err != nil {
-			return nil, nil, err
-		}
-
-		clients[s.Name()] = client
-	}
-
-	for _, info := range peers {
-		// Don't include a local interface unless we are bootstrapping, in which case we shouldn't use the remote client.
-		if info.Name == s.Name() {
-			continue
-		}
-
-		client, err := s.remoteClient(info.AuthSecret, info.Address, CloudPort)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		networks[info.Name], err = client.GetNetworks()
-		if err != nil {
-			return nil, nil, err
-		}
-
-		clients[info.Name] = client
-	}
-
-	return clients, networks, nil
-}
-
 // defaultNetworkInterfacesFilter filters a network based on default rules and return whether it should be skipped and the addresses on the interface.
-func defaultNetworkInterfacesFilter(clients map[string]lxd.InstanceServer, peer string, network api.Network) (bool, []string) {
+func defaultNetworkInterfacesFilter(client lxd.InstanceServer, network api.Network) (bool, []string) {
 	// Skip managed networks.
 	if network.Managed {
 		return true, []string{}
@@ -393,7 +351,7 @@ func defaultNetworkInterfacesFilter(clients map[string]lxd.InstanceServer, peer 
 		return true, []string{}
 	}
 
-	state, err := clients[peer].GetNetworkState(network.Name)
+	state, err := client.GetNetworkState(network.Name)
 	if err != nil {
 		return true, []string{}
 	}
@@ -424,32 +382,6 @@ func defaultNetworkInterfacesFilter(clients map[string]lxd.InstanceServer, peer 
 	return false, addresses
 }
 
-// GetUplinkInterfaces returns a map of peer name to slice of api.Network that may be used with OVN.
-func (s LXDService) GetUplinkInterfaces(ctx context.Context, bootstrap bool, peers []mdns.ServerInfo) (map[string][]api.Network, error) {
-	clients, networks, err := getClientsAndNetworks(s, ctx, bootstrap, peers)
-	if err != nil {
-		return nil, err
-	}
-
-	candidates := make(map[string][]api.Network)
-	for peer, nets := range networks {
-		for _, network := range nets {
-			filtered, addresses := defaultNetworkInterfacesFilter(clients, peer, network)
-			if filtered {
-				continue
-			}
-
-			if len(addresses) > 0 {
-				continue
-			}
-
-			candidates[peer] = append(candidates[peer], network)
-		}
-	}
-
-	return candidates, nil
-}
-
 // CephDedicatedInterface represents a dedicated interface for Ceph.
 type CephDedicatedInterface struct {
 	Name      string
@@ -457,35 +389,48 @@ type CephDedicatedInterface struct {
 	Addresses []string
 }
 
-// GetCephInterfaces returns a map of peer name to slice of CephDedicatedInterface that may be used to setup
-// a dedicated Ceph network.
-func (s LXDService) GetCephInterfaces(ctx context.Context, bootstrap bool, peers []mdns.ServerInfo) (map[string][]CephDedicatedInterface, error) {
-	clients, networks, err := getClientsAndNetworks(s, ctx, bootstrap, peers)
-	if err != nil {
-		return nil, err
+// GetNetworkInterfaces fetches the list of networks from LXD and returns the following:
+// - A map of uplink compatible networks keyed by interface name.
+// - A map of ceph compatible networks keyed by interface name.
+// - The list of all networks.
+func (s LXDService) GetNetworkInterfaces(ctx context.Context, name string, address string, secret string) (map[string]api.Network, map[string]CephDedicatedInterface, []api.Network, error) {
+	var err error
+	var client lxd.InstanceServer
+	if name == s.Name() {
+		client, err = s.Client(ctx, "")
+	} else {
+		client, err = s.remoteClient(secret, address, CloudPort)
 	}
 
-	candidates := make(map[string][]CephDedicatedInterface)
-	for peer, nets := range networks {
-		for _, network := range nets {
-			filtered, addresses := defaultNetworkInterfacesFilter(clients, peer, network)
-			if filtered {
-				continue
-			}
+	if err != nil {
+		return nil, nil, nil, err
+	}
 
-			if len(addresses) == 0 {
-				continue
-			}
+	networks, err := client.GetNetworks()
+	if err != nil {
+		return nil, nil, nil, err
+	}
 
-			candidates[peer] = append(candidates[peer], CephDedicatedInterface{
+	uplinkInterfaces := map[string]api.Network{}
+	cephInterfaces := map[string]CephDedicatedInterface{}
+	for _, network := range networks {
+		filtered, addresses := defaultNetworkInterfacesFilter(client, network)
+		if filtered {
+			continue
+		}
+
+		if len(addresses) == 0 {
+			uplinkInterfaces[network.Name] = network
+		} else {
+			cephInterfaces[network.Name] = CephDedicatedInterface{
 				Name:      network.Name,
 				Type:      network.Type,
 				Addresses: addresses,
-			})
+			}
 		}
 	}
 
-	return candidates, nil
+	return uplinkInterfaces, cephInterfaces, networks, nil
 }
 
 // ValidateCephInterfaces validates the given interfaces map against the given Ceph network subnet

--- a/service/lxd.go
+++ b/service/lxd.go
@@ -499,7 +499,7 @@ func (s LXDService) GetNetworkInterfaces(ctx context.Context, name string, addre
 func (s *LXDService) ValidateCephInterfaces(cephNetworkSubnetStr string, peerInterfaces map[string]map[string]CephDedicatedInterface) (map[string][][]string, error) {
 	_, subnet, err := net.ParseCIDR(cephNetworkSubnetStr)
 	if err != nil {
-		return nil, fmt.Errorf("invalid CIDR subnet: %v", err)
+		return nil, fmt.Errorf("Invalid CIDR subnet: %v", err)
 	}
 
 	ones, bits := subnet.Mask.Size()

--- a/service/lxd.go
+++ b/service/lxd.go
@@ -654,7 +654,7 @@ func (s *LXDService) waitReady(ctx context.Context, c lxd.InstanceServer, timeou
 
 // defaultGatewaySubnetV4 returns subnet of default gateway interface.
 func (s LXDService) defaultGatewaySubnetV4() (*net.IPNet, string, error) {
-	available, ifaceName, err := s.FanNetworkUsable()
+	available, ifaceName, err := FanNetworkUsable()
 	if err != nil {
 		return nil, "", err
 	}

--- a/service/lxd_config.go
+++ b/service/lxd_config.go
@@ -14,6 +14,9 @@ import (
 // lxdMinVersion is the minimum version of LXD that fully supports all MicroCloud features.
 const lxdMinVersion = "5.21"
 
+// DefaultFANNetwork is the name of the default FAN network.
+const DefaultFANNetwork = "lxdfan0"
+
 // DefaultUplinkNetwork is the name of the default OVN uplink network.
 const DefaultUplinkNetwork = "UPLINK"
 
@@ -32,7 +35,7 @@ const DefaultCephFSPool = "remote-fs"
 // DefaultPendingFanNetwork returns the default Ubuntu Fan network configuration when
 // creating a pending network on a specific cluster member target.
 func (s LXDService) DefaultPendingFanNetwork() api.NetworksPost {
-	return api.NetworksPost{Name: "lxdfan0", Type: "bridge"}
+	return api.NetworksPost{Name: DefaultFANNetwork, Type: "bridge"}
 }
 
 // FanNetworkUsable checks if the current host is capable of using a Fan network.
@@ -90,7 +93,7 @@ func (s LXDService) DefaultFanNetwork() (api.NetworksPost, error) {
 			},
 			Description: "Default Ubuntu fan powered bridge",
 		},
-		Name: "lxdfan0",
+		Name: DefaultFANNetwork,
 		Type: "bridge",
 	}, nil
 }

--- a/service/lxd_config.go
+++ b/service/lxd_config.go
@@ -40,7 +40,7 @@ func (s LXDService) DefaultPendingFanNetwork() api.NetworksPost {
 
 // FanNetworkUsable checks if the current host is capable of using a Fan network.
 // It actually checks if there is a default IPv4 gateway available.
-func (s LXDService) FanNetworkUsable() (available bool, ifaceName string, err error) {
+func FanNetworkUsable() (available bool, ifaceName string, err error) {
 	file, err := os.Open("/proc/net/route")
 	if err != nil {
 		return false, "", err

--- a/service/system_information.go
+++ b/service/system_information.go
@@ -276,16 +276,26 @@ func (s *SystemInformation) SupportsOVNNetwork() (hasNet bool, supportsNet bool)
 
 // SupportsFANNetwork checks if the SystemInformation supports a MicroCloud configured lxdfan0 network.
 // Additionally returns whether such a network already exists.
-func (s *SystemInformation) SupportsFANNetwork() (hasNet bool, supportsNet bool) {
+// If checkUsable is set, it will also check /proc/net/route to see if an interface that can support the FAN network is present.
+func (s *SystemInformation) SupportsFANNetwork(checkUsable bool) (hasNet bool, supportsNet bool, err error) {
 	if s.existingFanNetwork == nil {
-		return false, true
+		if checkUsable {
+			available, _, err := FanNetworkUsable()
+			if err != nil {
+				return false, false, err
+			}
+
+			return false, available, nil
+		}
+
+		return false, true, nil
 	}
 
 	if s.existingFanNetwork.Type == "bridge" && s.existingFanNetwork.Status == "Created" {
-		return true, true
+		return true, true, nil
 	}
 
-	return true, false
+	return true, false, nil
 }
 
 // ServiceClustered returns whether or not a particular service is already clustered

--- a/service/system_information.go
+++ b/service/system_information.go
@@ -1,0 +1,330 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/canonical/lxd/shared/api"
+
+	"github.com/canonical/microcloud/microcloud/api/types"
+	"github.com/canonical/microcloud/microcloud/mdns"
+)
+
+// SystemInformation represents all information MicroCloud needs from a system in order to set it up as part of the MicroCloud.
+type SystemInformation struct {
+	// ExistingServices is a map of cluster members for each service currently installed on the system.
+	ExistingServices map[types.ServiceType]map[string]string
+
+	// ClusterName is the name of the system in MicroCloud.
+	ClusterName string
+
+	// ClusterAddress is the default cluster address used for MicroCloud.
+	ClusterAddress string
+
+	// AuthSecret authenticates remote connections from the MicroCloud initiator.
+	AuthSecret string
+
+	// AvailableDisks is the list of disks available for use on the system.
+	AvailableDisks map[string]api.ResourcesStorageDisk
+
+	// AvailableUplinkInterfaces is the list of networks that can be used for the OVN uplink network.
+	AvailableUplinkInterfaces map[string]api.Network
+
+	// AvailableCephInterfaces is the list of networks that can be used for the Ceph cluster network.
+	AvailableCephInterfaces map[string]CephDedicatedInterface
+
+	// LXDLocalConfig is the local configuration of LXD on this system.
+	LXDLocalConfig map[string]any
+
+	// LXDConfig is the cluster configuration of LXD on this system.
+	LXDConfig map[string]any
+
+	// CephConfig is the MicroCeph configuration on this system.
+	CephConfig map[string]string
+
+	// existingLocalPool is the current storage pool named "local" on this system.
+	existingLocalPool *api.StoragePool
+
+	// existingRemotePool is the current storage pool named "remote" on this system.
+	existingRemotePool *api.StoragePool
+
+	// existingRemoteFSPool is the current storage pool named "remote-fs" on this system.
+	existingRemoteFSPool *api.StoragePool
+
+	// existingFanNetwork is the current network named "lxdfan0" on this system.
+	existingFanNetwork *api.Network
+
+	// existingOVNNetwork is the current network named "default" on this system.
+	existingOVNNetwork *api.Network
+
+	// existingUplinkNetwork is the current network named "UPLINK" on this system.
+	existingUplinkNetwork *api.Network
+}
+
+// CollectSystemInformation fetches the current cluster information of the system specified by the connection info.
+func (sh *Handler) CollectSystemInformation(ctx context.Context, connectInfo mdns.ServerInfo) (*SystemInformation, error) {
+	if connectInfo.Name == "" || connectInfo.Address == "" {
+		return nil, fmt.Errorf("Connection information is incomplete")
+	}
+
+	localSystem := sh.Name == connectInfo.Name
+
+	s := &SystemInformation{
+		ExistingServices:          map[types.ServiceType]map[string]string{},
+		ClusterName:               connectInfo.Name,
+		ClusterAddress:            connectInfo.Address,
+		AuthSecret:                connectInfo.AuthSecret,
+		AvailableDisks:            map[string]api.ResourcesStorageDisk{},
+		AvailableUplinkInterfaces: map[string]api.Network{},
+		AvailableCephInterfaces:   map[string]CephDedicatedInterface{},
+	}
+
+	var err error
+	s.ExistingServices, err = sh.GetExistingClusters(ctx, connectInfo)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to check for existing clusters on %q: %w", s.ClusterName, err)
+	}
+
+	var allResources *api.Resources
+	lxd := sh.Services[types.LXD].(*LXDService)
+	if localSystem {
+		allResources, err = lxd.GetResources(ctx, s.ClusterName, "", "")
+	} else {
+		allResources, err = lxd.GetResources(ctx, s.ClusterName, s.ClusterAddress, s.AuthSecret)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get system resources of peer %q: %w", s.ClusterName, err)
+	}
+
+	if allResources != nil {
+		for _, disk := range allResources.Storage.Disks {
+			if len(disk.Partitions) == 0 {
+				s.AvailableDisks[disk.ID] = disk
+			}
+		}
+	}
+
+	var allNets []api.Network
+	s.AvailableUplinkInterfaces, s.AvailableCephInterfaces, allNets, err = lxd.GetNetworkInterfaces(ctx, s.ClusterName, s.ClusterAddress, s.AuthSecret)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get network interfaces on %q: %w", s.ClusterName, err)
+	}
+
+	for _, network := range allNets {
+		if network.Name == DefaultFANNetwork {
+			s.existingFanNetwork = &network
+			continue
+		}
+
+		if network.Name == DefaultOVNNetwork {
+			s.existingOVNNetwork = &network
+			continue
+		}
+
+		if network.Name == DefaultUplinkNetwork {
+			s.existingUplinkNetwork = &network
+			continue
+		}
+	}
+
+	pools, err := lxd.GetStoragePools(ctx, s.ClusterName, s.ClusterAddress, s.AuthSecret)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get storage pools on %q: %w", s.ClusterName, err)
+	}
+
+	pool, ok := pools[DefaultZFSPool]
+	if ok {
+		poolCopy := pool
+		s.existingLocalPool = &poolCopy
+	}
+
+	pool, ok = pools[DefaultCephPool]
+	if ok {
+		poolCopy := pool
+		s.existingRemotePool = &poolCopy
+	}
+
+	pool, ok = pools[DefaultCephFSPool]
+	if ok {
+		poolCopy := pool
+		s.existingRemoteFSPool = &poolCopy
+	}
+
+	if len(s.ExistingServices[types.MicroCeph]) > 0 {
+		microceph := sh.Services[types.MicroCeph].(*CephService)
+
+		if localSystem {
+			s.CephConfig, err = microceph.ClusterConfig(ctx, "", "")
+		} else {
+			s.CephConfig, err = microceph.ClusterConfig(ctx, s.ClusterAddress, s.AuthSecret)
+		}
+
+		if err != nil && !api.StatusErrorCheck(err, http.StatusServiceUnavailable) {
+			return nil, fmt.Errorf("Failed to get Ceph configuration on %q: %w", s.ClusterName, err)
+		}
+	}
+
+	if localSystem {
+		s.LXDLocalConfig, s.LXDConfig, err = lxd.GetConfig(ctx, s.ServiceClustered(types.LXD), s.ClusterName, "", "")
+	} else {
+		s.LXDLocalConfig, s.LXDConfig, err = lxd.GetConfig(ctx, s.ServiceClustered(types.LXD), s.ClusterName, s.ClusterAddress, s.AuthSecret)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get LXD configuration on %q: %w", s.ClusterName, err)
+	}
+
+	return s, nil
+}
+
+// GetExistingClusters checks against the services reachable by the specified ServerInfo,
+// and returns a map of cluster members for each service supported by the Handler.
+// If a service is not clustered, its map will be nil.
+func (sh *Handler) GetExistingClusters(ctx context.Context, connectInfo mdns.ServerInfo) (map[types.ServiceType]map[string]string, error) {
+	localSystem := sh.Name == connectInfo.Name
+	var err error
+	existingServices := map[types.ServiceType]map[string]string{}
+	for service := range sh.Services {
+		var existingCluster map[string]string
+		if localSystem {
+			existingCluster, err = sh.Services[service].ClusterMembers(ctx)
+		} else {
+			existingCluster, err = sh.Services[service].RemoteClusterMembers(ctx, connectInfo.AuthSecret, connectInfo.Address)
+		}
+
+		if err != nil && !api.StatusErrorCheck(err, http.StatusServiceUnavailable) {
+			return nil, fmt.Errorf("Failed to reach %s on system %q: %w", service, connectInfo.Name, err)
+		}
+
+		// If a service isn't clustered, this loop will be skipped.
+
+		for k, v := range existingCluster {
+			if existingServices[service] == nil {
+				existingServices[service] = map[string]string{}
+			}
+
+			host, _, err := net.SplitHostPort(v)
+			if err != nil {
+				return nil, err
+			}
+
+			existingServices[service][k] = host
+		}
+	}
+
+	return existingServices, nil
+}
+
+// SupportsLocalPool checks if the SystemInformation supports a MicroCloud configured local storage pool.
+// Additionally returns whether such a pool already exists.
+func (s *SystemInformation) SupportsLocalPool() (hasPool bool, supportsPool bool) {
+	if s.existingLocalPool == nil {
+		return false, true
+	}
+
+	if s.existingLocalPool.Driver == "zfs" && s.existingLocalPool.Status == "Created" {
+		return true, true
+	}
+
+	return true, false
+}
+
+// SupportsRemotePool checks if the SystemInformation supports a MicroCloud configured remote storage pool.
+// Additionally returns whether such a pool already exists.
+func (s *SystemInformation) SupportsRemotePool() (hasPool bool, supportsPool bool) {
+	if s.existingRemotePool == nil {
+		return false, true
+	}
+
+	if s.existingRemotePool.Driver == "ceph" && s.existingRemotePool.Status == "Created" {
+		return true, true
+	}
+
+	return true, false
+}
+
+// SupportsRemoteFSPool checks if the SystemInformation supports a MicroCloud configured remote-fs storage pool.
+// Additionally returns whether such a pool already exists.
+func (s *SystemInformation) SupportsRemoteFSPool() (hasPool bool, supportsPool bool) {
+	if s.existingRemoteFSPool == nil {
+		return false, true
+	}
+
+	if s.existingRemoteFSPool.Driver == "cephfs" && s.existingRemoteFSPool.Status == "Created" {
+		return true, true
+	}
+
+	return true, false
+}
+
+// SupportsOVNNetwork checks if the SystemInformation supports MicroCloud configured default and UPLINK networks.
+// Additionally returns whether such networks already exist.
+func (s *SystemInformation) SupportsOVNNetwork() (hasNet bool, supportsNet bool) {
+	if s.existingOVNNetwork == nil && s.existingUplinkNetwork == nil {
+		return false, true
+	}
+
+	if s.existingOVNNetwork.Type == "ovn" && s.existingOVNNetwork.Status == "Created" && s.existingUplinkNetwork.Type == "physical" && s.existingUplinkNetwork.Status == "Created" {
+		return true, true
+	}
+
+	return true, false
+}
+
+// SupportsFANNetwork checks if the SystemInformation supports a MicroCloud configured lxdfan0 network.
+// Additionally returns whether such a network already exists.
+func (s *SystemInformation) SupportsFANNetwork() (hasNet bool, supportsNet bool) {
+	if s.existingFanNetwork == nil {
+		return false, true
+	}
+
+	if s.existingFanNetwork.Type == "bridge" && s.existingFanNetwork.Status == "Created" {
+		return true, true
+	}
+
+	return true, false
+}
+
+// ServiceClustered returns whether or not a particular service is already clustered
+// by checking if there are any cluster members in-memory.
+func (s *SystemInformation) ServiceClustered(service types.ServiceType) bool {
+	return len(s.ExistingServices[service]) > 0
+}
+
+// ClustersConflict compares the cluster members reported by each system in the list of systems, for each given service.
+// If two distinct clusters exist for any service, this function returns true, with the name of the service.
+func ClustersConflict(systems map[string]SystemInformation, services []types.ServiceType) (bool, types.ServiceType) {
+	firstEncounteredClusters := map[types.ServiceType]map[string]string{}
+	for _, info := range systems {
+		for _, service := range services {
+			// If a service is not clustered, it cannot conflict.
+			if !info.ServiceClustered(service) {
+				continue
+			}
+
+			// Record the first encountered cluster for each service.
+			cluster, encountered := firstEncounteredClusters[service]
+			if !encountered {
+				firstEncounteredClusters[service] = info.ExistingServices[service]
+
+				continue
+			}
+
+			// Check if the first encountered cluster for this service is identical to each system's record.
+			for name, addr := range info.ExistingServices[service] {
+				if cluster[name] != addr {
+					return true, service
+				}
+			}
+
+			if len(cluster) != len(info.ExistingServices[service]) {
+				return true, service
+			}
+		}
+	}
+
+	return false, ""
+}

--- a/test/includes/microcloud.sh
+++ b/test/includes/microcloud.sh
@@ -98,7 +98,7 @@ $(true)                                                 # workaround for set -e
 "
 fi
 
-if [ -z "${IGNORE_CEPH_NETWORKING}" ]; then
+if [ -z "${IGNORE_CEPH_NETWORKING}" ] && [ "${SETUP_CEPH}" = "yes" ] ; then
   if [ -n "${CEPH_CLUSTER_NETWORK}" ]; then
     setup="${setup}
 ${CEPH_CLUSTER_NETWORK}
@@ -632,6 +632,7 @@ reset_system() {
     # Re-enable as many interfaces as we want for this run.
     for i in $(seq 1 "${num_ifaces}") ; do
       iface="enp$((i + 5))s0"
+      lxc exec "${name}" -- ip addr flush dev "${iface}"
       lxc exec "${name}" -- ip link set "${iface}" up
       lxc exec "${name}" -- sh -c "echo 1 > /proc/sys/net/ipv6/conf/${iface}/disable_ipv6" > /dev/null
     done


### PR DESCRIPTION
It was getting very hard and inefficient to modify or extend the MicroCloud setup logic without devolving into lots of temporary maps and slices, and redundantly calling back over the network to the other systems to fetch their configuration.

This PR attempts to address that by immediately collecting all relevant system information for the cluster setup in a `SystemInformation` for each system. Each question helper can then reference the fields and methods of the `SystemInformation` to check what is and isn't supported, rather than fetching them over the network each time.

In order to pass around `SystemInformation` as well as other common state information that were previously passed directly as arguments to each function, this PR also adds an `initConfig` type, of which all question functions are a method of. 

Sadly, this does result in quite a large refactor, but given how deeply everything here is coupled together, I don't see a way around it. I've tried to at least split the commits by the functions that are being changed.

Due to this refactor, several edge cases around detecting already configured storage pools and networks have been addressed (tests for these will come later, I didn't want to make this PR any bigger). As well, the ceph cluster network questions are now part of the distributed storage set of questions, rather than the OVN network questions.

