### PR TITLE
Fix VM start in github tests

### DIFF
--- a/service/lxd.go
+++ b/service/lxd.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/canonical/lxd/client"

--- a/test/includes/microcloud.sh
+++ b/test/includes/microcloud.sh
@@ -399,11 +399,6 @@ validate_system_lxd() {
       validate_system_lxd_fan "${name}"
     fi
 
-    if [ -n "${local_disk}" ] || [ "${remote_disks}" -gt 0 ] ; then
-      echo "Check LXD resources for disk ordering"
-      lxc exec "local:${name}" -- lxc query "/1.0/resources" | jq -r '.storage.disks[] | {id, device_id, device_path}'
-    fi
-
     if [ -n "${local_disk}" ]; then
       validate_system_lxd_zfs "${name}" "${local_disk}"
     fi

--- a/test/includes/microcloud.sh
+++ b/test/includes/microcloud.sh
@@ -966,7 +966,7 @@ setup_system() {
     fi
 
     # Disable unneeded services/timers/sockets/mounts (source of noise/slowdown)
-    lxc exec "${name}" -- systemctl mask --now apport.service cron.service e2scrub_reap.service grub-common.service grub-initrd-fallback.service lvm2-monitor.service networkd-dispatcher.service polkit.service secureboot-db.service serial-getty@ttyS0.service ssh.service unattended-upgrades.service
+    lxc exec "${name}" -- systemctl mask --now apport.service cron.service e2scrub_reap.service grub-common.service grub-initrd-fallback.service lvm2-monitor.service networkd-dispatcher.service polkit.service secureboot-db.service serial-getty@ttyS0.service ssh.service unattended-upgrades.service esm-cache.service
     lxc exec "${name}" -- systemctl mask --now apt-daily-upgrade.timer apt-daily.timer dpkg-db-backup.timer e2scrub_all.timer fstrim.timer motd-news.timer update-notifier-download.timer update-notifier-motd.timer
     lxc exec "${name}" -- systemctl mask --now cloud-init-hotplugd.socket lvm2-lvmpolld.socket lxd-installer.socket iscsid.socket
     lxc exec "${name}" -- systemctl mask --now dev-hugepages.mount sys-kernel-debug.mount sys-kernel-tracing.mount

--- a/test/includes/microcloud.sh
+++ b/test/includes/microcloud.sh
@@ -966,9 +966,9 @@ setup_system() {
     fi
 
     # Disable unneeded services/timers/sockets/mounts (source of noise/slowdown)
-    lxc exec "${name}" -- systemctl mask --now apport.service cron.service e2scrub_reap.service grub-common.service grub-initrd-fallback.service lvm2-monitor.service networkd-dispatcher.service polkit.service secureboot-db.service serial-getty@ttyS0.service ssh.service systemd-journald.service systemd-journal-flush.service unattended-upgrades.service
+    lxc exec "${name}" -- systemctl mask --now apport.service cron.service e2scrub_reap.service grub-common.service grub-initrd-fallback.service lvm2-monitor.service networkd-dispatcher.service polkit.service secureboot-db.service serial-getty@ttyS0.service ssh.service unattended-upgrades.service
     lxc exec "${name}" -- systemctl mask --now apt-daily-upgrade.timer apt-daily.timer dpkg-db-backup.timer e2scrub_all.timer fstrim.timer motd-news.timer update-notifier-download.timer update-notifier-motd.timer
-    lxc exec "${name}" -- systemctl mask --now cloud-init-hotplugd.socket lvm2-lvmpolld.socket lxd-installer.socket iscsid.socket systemd-journald-dev-log.socket
+    lxc exec "${name}" -- systemctl mask --now cloud-init-hotplugd.socket lvm2-lvmpolld.socket lxd-installer.socket iscsid.socket
     lxc exec "${name}" -- systemctl mask --now dev-hugepages.mount sys-kernel-debug.mount sys-kernel-tracing.mount
 
     # Turn off debugfs and mitigations

--- a/test/main.sh
+++ b/test/main.sh
@@ -61,6 +61,13 @@ cleanup() {
 	lxc list --all-projects || true
 	lxc exec micro01 -- lxc list || true
 
+  for i in $(seq 1 4); do
+    name=$(printf "micro%02d" "${i}")
+    echo "Check LXD resources on ${name} for disk ordering"
+    lxc exec "local:${name}" -- lxc query "/1.0/resources" | jq -r '.storage.disks[] | {id, device_id, device_path}'
+    lxc exec "local:${name}" -- lsblk
+  done
+
 	if [ -n "${GITHUB_ACTIONS:-}" ]; then
 		echo "==> Skipping cleanup (GitHub Action runner detected)"
 	else


### PR DESCRIPTION
Seems the `systemd-journald` masks were causing cloud-init to fail to complete its run.

Also masks `esm-cache` because @simondeziel said it would help startup time.


Lastly, moves the disk ordering checks to `cleanup` so we actually see the result when a test fails. Also puts `lsblk` here so we can check if a disk is occupied.