### PR TITLE
Cluster recovery

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,6 +91,7 @@ jobs:
           - "add"
           - "instances"
           - "basic"
+          - "recover"
           - "interactive"
           - "mismatch"
           - "preseed"

--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -8,6 +8,7 @@ balancer
 Charmhub
 CLI
 Diátaxis
+Dqlite
 dropdown
 EBS
 EKS

--- a/doc/how-to/index.md
+++ b/doc/how-to/index.md
@@ -14,4 +14,5 @@ Add a machine </how-to/add_machine>
 Get support </how-to/support>
 Contribute to MicroCloud </how-to/contribute>
 Work with MicroCloud </how-to/commands>
+Recover MicroCloud </how-to/recover>
 ```

--- a/doc/how-to/recover.md
+++ b/doc/how-to/recover.md
@@ -1,0 +1,68 @@
+# How to recover a MicroCloud cluster
+
+```{note}
+Each MicroCloud service uses the [Dqlite](https://dqlite.io/) distributed
+database for highly-available storage. While the cluster recovery process is
+similar for each service, this document only covers cluster recovery for the
+`microcloudd` daemon. For cluster recovery procedures for LXD, MicroCeph and
+MicroOVN, see:
+
+- [LXD Cluster Recovery](https://documentation.ubuntu.com/lxd/en/latest/howto/cluster_recover/)
+- [MicroOVN Launchpad Bug](https://bugs.launchpad.net/microovn/+bug/2072377)
+- [MicroCeph Issue](https://github.com/canonical/microceph/issues/380)
+```
+
+MicroCloud requires a majority of the database voters (a quorum) to be
+accessible in order to perform database operations. If a cluster has less than
+a quorum of voters up and accessible, then database operations will no longer
+be possible on the entire cluster.
+
+If the loss of quorum is temporary (e.g. some members temporarily lose power),
+database operations will be restored when the offline members come back online.
+
+This document describes how to recover database access if the offline members
+have been lost without the possibility of recovery (e.g. disk failure).
+
+## Recovery procedure
+
+1. Shut down all cluster members before performing cluster recovery:
+   ```
+   sudo snap stop microcloud
+   ```
+
+1. Once all cluster members are shut down, determine which Dqlite database is
+   most up to date. Look for files in `/var/snap/microcloud/common/state/database`
+   whose filenames are two numbers separated by a dash (i.e.
+   `0000000000056436-0000000000056501`). The largest second number in that directory
+   is the end index of the most recently closed segment (56501 in the example).
+   The cluster member with the highest end index is the most up to date.
+
+1. On the most up-to-date cluster member, use the following command to
+   reconfigure the Dqlite roles for each member:
+   ```
+   sudo microcloud cluster recover
+   ```
+
+1. As indicated by the output of the above command, copy
+   `/var/snap/microcloud/common/state/recovery_db.tar.gz` to the same path on
+   each cluster member.
+
+1. Restart MicroCloud. The recovered database tarball will be loaded on daemon
+   startup. Once a quorum of voters have been started, the MicroCloud database
+   will become available.
+   ```
+   sudo snap start microcloud
+   ```
+
+## Backups
+
+MicroCloud creates a backup of the database directory before performing the
+recovery operation to ensure that no data is lost. The backup tarball is created
+in `/var/snap/microcloud/common/state/`. If the cluster recovery operation
+fails, use the following commands to restore the existing database:
+
+```
+cd /var/snap/microcloud/common/state
+sudo mv database broken_db
+sudo tar -xf db_backup.TIMESTAMP.tar.gz
+```

--- a/test/includes/microcloud.sh
+++ b/test/includes/microcloud.sh
@@ -987,6 +987,7 @@ setup_system() {
     fi
 
     lxc exec "${name}" -- snap install snapd
+    lxc exec "${name}" -- snap install yq
 
     # Free disk blocks
     lxc exec "${name}" -- apt-get clean

--- a/test/main.sh
+++ b/test/main.sh
@@ -187,6 +187,10 @@ run_basic_tests() {
   run_test test_auto "auto"
 }
 
+run_recover_tests() {
+  run_test test_recover "recover"
+}
+
 run_interactive_tests() {
   run_test test_interactive "interactive"
   run_test test_interactive_combinations "interactive combinations"
@@ -206,6 +210,7 @@ if [ "${1:-"all"}" = "all" ]; then
   run_add_tests
   run_instances_tests
   run_basic_tests
+  run_recover_tests
   run_interactive_tests
   run_mismatch_tests
   run_preseed_tests
@@ -215,6 +220,8 @@ elif [ "${1}" = "instances" ]; then
   run_instances_tests
 elif [ "${1}" = "basic" ]; then
   run_basic_tests
+elif [ "${1}" = "recover" ]; then
+  run_recover_tests
 elif [ "${1}" = "interactive" ]; then
   run_interactive_tests
 elif [ "${1}" = "mismatch" ]; then

--- a/test/suites/recover.sh
+++ b/test/suites/recover.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+test_recover() {
+  reset_systems 4 0 0
+
+  systems=("micro01" "micro02" "micro03" "micro04")
+
+  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --auto > out"
+  for m in "${systems[@]}" ; do
+    validate_system_lxd "${m}" 4
+    validate_system_microceph "${m}"
+    validate_system_microovn "${m}"
+  done
+
+  # MicroCluster takes a while to update the core_cluster_members table
+  while lxc exec micro01 -- microcloud cluster list -f csv | grep -q PENDING; do
+    sleep 2
+  done
+
+  for m in "${systems[@]}"; do
+    lxc exec "${m}" -- sudo snap stop microcloud
+  done
+
+  lxc exec micro01 -- microcloud cluster list --local -f yaml
+
+  lxc exec micro01 -- sh -c "
+    TEST_CONSOLE=0 microcloud cluster list --local -f yaml |
+      yq '
+        sort_by(.name) |
+        .[0].role = \"voter\" |
+        .[1].role = \"voter\" |
+        .[2].role = \"spare\" |
+        .[3].role = \"spare\"' |
+      TEST_CONSOLE=0 microcloud cluster recover"
+
+  lxc file pull micro01/var/snap/microcloud/common/state/recovery_db.tar.gz ./
+  lxc file push recovery_db.tar.gz micro02/var/snap/microcloud/common/state/recovery_db.tar.gz
+
+  for m in micro01 micro02; do
+    lxc exec "${m}" -- sudo snap start microcloud
+  done
+
+  # microcluster takes a long time to update the member roles in the core_cluster_members table
+  sleep 90
+
+  for m in micro01 micro02; do
+    cluster_list=$(lxc exec "${m}" -- microcloud cluster list -f csv)
+
+    # assert_member_role(member_name, role)
+    assert_member_role() {
+      [[ $(echo "${cluster_list}" | grep "${1}" | awk -F, '{print $3}') == "${2}" ]]
+    }
+
+    assert_member_role micro01 voter
+    assert_member_role micro02 voter
+
+    for spare_member in micro03 micro04; do
+      assert_member_role "${spare_member}" spare
+    done
+  done
+}


### PR DESCRIPTION
Implements cluster recovery with the same set of changes described in https://github.com/canonical/microcluster/pull/149

- I added another suite in the github workflow while I was working on tests; I don't feel like it fits well with any of the [existing test groups](https://github.com/canonical/microcloud/blob/main/test/main.sh#L175-L202) except `basic`, and `basic` already takes ~1hr to run. Not sure what is preferred here.
- Dqlite spellcheck; https://github.com/canonical/sphinx-docs-starter-pack/pull/252

Fixes #291 

LXD-1118