### PR TITLE
cmd/microcloud: Force disk ordering by path name

### DIFF
--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -268,7 +268,13 @@ func askLocalPool(systems map[string]InitSystem, autoSetup bool, wipeAllDisks bo
 			return nil
 		}
 
-		for _, disk := range system.AvailableDisks {
+		sortedDisks := make([]api.ResourcesStorageDisk, 0, len(system.AvailableDisks))
+		sortedDisks = append(sortedDisks, system.AvailableDisks...)
+		sort.Slice(sortedDisks, func(i, j int) bool {
+			return parseDiskPath(sortedDisks[i]) < parseDiskPath(sortedDisks[j])
+		})
+
+		for _, disk := range sortedDisks {
 			devicePath := parseDiskPath(disk)
 			data = append(data, []string{peer, disk.Model, units.GetByteSizeStringIEC(int64(disk.Size), 2), disk.Type, devicePath})
 
@@ -450,7 +456,13 @@ func (c *CmdControl) askRemotePool(systems map[string]InitSystem, autoSetup bool
 	header := []string{"LOCATION", "MODEL", "CAPACITY", "TYPE", "PATH"}
 	data := [][]string{}
 	for peer, system := range systems {
-		for _, disk := range system.AvailableDisks {
+		sortedDisks := make([]api.ResourcesStorageDisk, 0, len(system.AvailableDisks))
+		sortedDisks = append(sortedDisks, system.AvailableDisks...)
+		sort.Slice(sortedDisks, func(i, j int) bool {
+			return parseDiskPath(sortedDisks[i]) < parseDiskPath(sortedDisks[j])
+		})
+
+		for _, disk := range sortedDisks {
 			// Skip any disks that have been reserved for the local storage pool.
 			devicePath := parseDiskPath(disk)
 			data = append(data, []string{peer, disk.Model, units.GetByteSizeStringIEC(int64(disk.Size), 2), disk.Type, devicePath})

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -242,17 +242,17 @@ systems:
 - name: micro01
   storage:
     local:
-      path: /dev/sdb
+      path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk1
       wipe: true
 - name: micro02
   storage:
     local:
-      path: /dev/sdb
+      path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk1
       wipe: true
 - name: micro03
   storage:
     local:
-      path: /dev/sdb
+      path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk1
       wipe: true
 EOF
 
@@ -277,23 +277,23 @@ systems:
 - name: micro01
   storage:
     ceph:
-      - path: /dev/sdc
+      - path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk2
         wipe: true
-      - path: /dev/sdd
+      - path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk3
         wipe: true
 - name: micro02
   storage:
     ceph:
-      - path: /dev/sdc
+      - path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk2
         wipe: true
-      - path: /dev/sdd
+      - path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk3
         wipe: true
 - name: micro03
   storage:
     ceph:
-      - path: /dev/sdc
+      - path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk2
         wipe: true
-      - path: /dev/sdd
+      - path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk3
         wipe: true
 ovn:
   ipv4_gateway: 10.1.123.1/24
@@ -333,17 +333,17 @@ systems:
 - name: micro01
   storage:
     local:
-      path: /dev/sdb
+      path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk1
       wipe: true
 - name: micro02
   storage:
     local:
-      path: /dev/sdb
+      path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk1
       wipe: true
 - name: micro03
   storage:
     local:
-      path: /dev/sdb
+      path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk1
       wipe: true
 EOF
 
@@ -409,23 +409,23 @@ systems:
 - name: micro01
   storage:
     ceph:
-      - path: /dev/sdc
+      - path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk2
         wipe: true
-      - path: /dev/sdd
+      - path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk3
         wipe: true
 - name: micro02
   storage:
     ceph:
-      - path: /dev/sdc
+      - path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk2
         wipe: true
-      - path: /dev/sdd
+      - path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk3
         wipe: true
 - name: micro03
   storage:
     ceph:
-      - path: /dev/sdc
+      - path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk2
         wipe: true
-      - path: /dev/sdd
+      - path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk3
         wipe: true
 ovn:
   ipv4_gateway: 10.1.123.1/24
@@ -543,23 +543,23 @@ systems:
 - name: micro01
   storage:
     ceph:
-      - path: /dev/sdc
+      - path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk2
         wipe: true
-      - path: /dev/sdd
+      - path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk3
         wipe: true
 - name: micro02
   storage:
     ceph:
-      - path: /dev/sdc
+      - path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk2
         wipe: true
-      - path: /dev/sdd
+      - path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk3
         wipe: true
 - name: micro03
   storage:
     ceph:
-      - path: /dev/sdc
+      - path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk2
         wipe: true
-      - path: /dev/sdd
+      - path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk3
         wipe: true
 ovn:
   ipv4_gateway: 10.1.123.1/24
@@ -1177,10 +1177,10 @@ ovn:
   dns_servers: 10.1.123.1,8.8.8.8
 storage:
   local:
-    - find: id == sdb
+    - find: device_id == *lxd_disk1
       wipe: true
   ceph:
-    - find: id == sdc
+    - find: device_id == *lxd_disk2
       wipe: true
   cephfs: true
 EOF

--- a/test/suites/preseed.sh
+++ b/test/suites/preseed.sh
@@ -15,12 +15,12 @@ systems:
   ovn_uplink_interface: enp6s0
   storage:
     local:
-      path: /dev/sdc
+      path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk2
       wipe: true
     ceph:
-      - path: /dev/sdb
+      - path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk1
         wipe: true
-      - path: /dev/sdd
+      - path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk3
         wipe: true
 - name: micro03
   ovn_uplink_interface: enp6s0
@@ -34,16 +34,16 @@ ovn:
 storage:
   cephfs: true
   local:
-    - find: id == sdb
+    - find: device_id == *lxd_disk1
       find_min: 2
       find_max: 2
       wipe: true
   ceph:
-    - find: id == sdc
+    - find: device_id == *lxd_disk2
       find_min: 2
       find_max: 2
       wipe: true
-    - find: id == sdd
+    - find: device_id == *lxd_disk3
       find_min: 2
       find_max: 2
       wipe: true
@@ -56,7 +56,7 @@ EOF
   done
 
   # Disks on micro02 should have been manually selected.
-  validate_system_lxd micro02 3 sdc 2 1 enp6s0 10.1.123.1/24 10.1.123.100-10.1.123.254 fd42:1:1234:1234::1/64
+  validate_system_lxd micro02 3 disk2 2 1 enp6s0 10.1.123.1/24 10.1.123.100-10.1.123.254 fd42:1:1234:1234::1/64
   validate_system_microceph micro02 1 disk1 disk3
   validate_system_microovn micro02
 
@@ -70,12 +70,12 @@ systems:
 storage:
   cephfs: true
   local:
-    - find: id == sdb
+    - find: device_id == *lxd_disk1
       find_min: 1
       find_max: 1
       wipe: true
   ceph:
-    - find: id == sdc
+    - find: device_id == *lxd_disk2
       find_min: 1
       find_max: 1
       wipe: true


### PR DESCRIPTION
This is part of #332 too but since #334 is having issues with 24.04 VMs, I think it's worth merging now.

This makes it so that when disks are loaded for selection either internally during preseed/auto, or visually in a table with interactive setup, that they are sorted by their path, rather than the order that they appear in the list of resources fetched from LXD.

