### PR TITLE
test/includes: Add back specific disk validation

### DIFF
--- a/test/suites/add.sh
+++ b/test/suites/add.sh
@@ -14,7 +14,7 @@ test_add_auto() {
     lxc exec "${m}" -- snap disable microcloud
   done
 
-  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --auto > out"
+  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --auto --lookup-timeout 10 > out"
   lxc exec micro01 -- tail -1 out | grep "MicroCloud is ready" -q
 
   # Re-enable the nodes.
@@ -24,7 +24,7 @@ test_add_auto() {
   done
 
   # Add the nodes.
-  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud add --auto > out"
+  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud add --auto --lookup-timeout 10 > out"
   lxc exec micro01 -- tail -1 out | grep "MicroCloud is ready" -q
 
   for m in micro01 micro02 micro03 micro04 ; do
@@ -45,7 +45,7 @@ test_add_auto() {
     lxc exec "${m}" -- snap disable microcloud
   done
 
-  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --auto > out"
+  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --auto --lookup-timeout 10 > out"
   lxc exec micro01 -- tail -1 out | grep "MicroCloud is ready" -q
 
   # Re-enable the nodes.
@@ -55,7 +55,7 @@ test_add_auto() {
   done
 
   # Add the nodes.
-  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud add --auto > out"
+  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud add --auto --lookup-timeout 10 > out"
   lxc exec micro01 -- tail -1 out | grep "MicroCloud is ready" -q
 
   for m in micro01 micro02 micro03 micro04 ; do
@@ -79,7 +79,7 @@ test_add_auto() {
     lxc exec "${m}" -- snap disable microcloud
   done
 
-  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --auto > out"
+  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --auto --lookup-timeout 10 > out"
   lxc exec micro01 -- tail -1 out | grep "MicroCloud is ready" -q
 
   # Re-enable the nodes.
@@ -90,7 +90,7 @@ test_add_auto() {
   done
 
   # Add the nodes.
-  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud add --auto > out"
+  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud add --auto --lookup-timeout 10 > out"
   lxc exec micro01 -- tail -1 out | grep "MicroCloud is ready" -q
 
   for m in micro01 micro02 micro03 micro04 ; do
@@ -179,7 +179,7 @@ test_add_interactive() {
   done
 
   lxc exec micro04 -- snap disable microcloud
-  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --auto > out"
+  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --auto --lookup-timeout 10 > out"
   lxc exec micro01 -- tail -1 out | grep "MicroCloud is ready" -q
   lxc exec micro04 -- snap enable microcloud
   lxc exec micro04 -- snap start microcloud

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -218,7 +218,7 @@ test_instances_config() {
 
   # Setup a MicroCloud with 3 systems, ZFS storage, and a FAN network.
   addr=$(lxc ls micro01 -f csv -c4 | grep enp5s0 | cut -d' ' -f1)
-  lxc exec micro01 --env TEST_CONSOLE=0 -- microcloud init --preseed << EOF
+  lxc exec micro01 --env TEST_CONSOLE=0 -- microcloud init --preseed --lookup-timeout 10 << EOF
 lookup_subnet: ${addr}/24
 lookup_interface: enp5s0
 systems:
@@ -253,7 +253,7 @@ EOF
 
   # Create a MicroCloud with ceph and ovn setup.
   addr=$(lxc ls micro01 -f csv -c4 | grep enp5s0 | cut -d' ' -f1)
-  lxc exec micro01 --env TEST_CONSOLE=0 -- microcloud init --preseed << EOF
+  lxc exec micro01 --env TEST_CONSOLE=0 -- microcloud init --preseed --lookup-timeout 10 << EOF
 lookup_subnet: ${addr}/24
 lookup_interface: enp5s0
 systems:
@@ -309,7 +309,7 @@ test_instances_launch() {
 
   # Setup a MicroCloud with 3 systems, ZFS storage, and a FAN network.
   addr=$(lxc ls micro01 -f csv -c4 | grep enp5s0 | cut -d' ' -f1)
-  lxc exec micro01 --env TEST_CONSOLE=0 -- microcloud init --preseed << EOF
+  lxc exec micro01 --env TEST_CONSOLE=0 -- microcloud init --preseed --lookup-timeout 10 << EOF
 lookup_subnet: ${addr}/24
 lookup_interface: enp5s0
 systems:
@@ -385,7 +385,7 @@ EOF
 
   # Create a MicroCloud with ceph and ovn setup.
   addr=$(lxc ls micro01 -f csv -c4 | grep enp5s0 | cut -d' ' -f1)
-  lxc exec micro01 --env TEST_CONSOLE=0 -- microcloud init --preseed << EOF
+  lxc exec micro01 --env TEST_CONSOLE=0 -- microcloud init --preseed --lookup-timeout 10 << EOF
 lookup_subnet: ${addr}/24
 lookup_interface: enp5s0
 systems:
@@ -519,7 +519,7 @@ EOF
     lxc exec "micro0$((n-1))" -- ip addr add "${dedicated_ip}" dev "${ceph_dedicated_subnet_iface}"
   done
 
-  lxc exec micro01 --env TEST_CONSOLE=0 -- microcloud init --preseed <<EOF
+  lxc exec micro01 --env TEST_CONSOLE=0 -- microcloud init --preseed --lookup-timeout 10 <<EOF
 lookup_subnet: ${addr}/24
 lookup_interface: enp5s0
 systems:
@@ -929,7 +929,7 @@ test_auto() {
   lxc exec micro02 -- snap start microcloud
 
   echo Auto-create a MicroCloud with 2 systems with no disks/interfaces.
-  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --auto > out"
+  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --auto --lookup-timeout 10 > out"
   for m in micro01 micro02 ; do
     validate_system_lxd "${m}" 2
     validate_system_microceph "${m}"
@@ -945,7 +945,7 @@ test_auto() {
   reset_systems 2 0 1
 
   echo Auto-create a MicroCloud with 2 systems with 1 interface each.
-  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --auto > out"
+  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --auto --lookup-timeout 10 > out"
   for m in micro01 micro02 ; do
     validate_system_lxd "${m}" 2
     validate_system_microceph "${m}"
@@ -963,7 +963,7 @@ test_auto() {
   reset_systems 2 3 1
 
   echo Auto-create a MicroCloud with 2 systems with 3 disks and 1 interface each.
-  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --auto > out"
+  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --auto --lookup-timeout 10 > out"
   for m in micro01 micro02 ; do
     validate_system_lxd "${m}" 2 disk1
     validate_system_microceph "${m}"
@@ -980,7 +980,7 @@ test_auto() {
   reset_systems 3 0 0
 
   echo Auto-create a MicroCloud with 3 systems with no disks/interfaces.
-  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --auto > out"
+  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --auto --lookup-timeout 10 > out"
   for m in micro01 micro02 micro03 ; do
     validate_system_lxd "${m}" 3
     validate_system_microceph "${m}"
@@ -996,7 +996,7 @@ test_auto() {
   reset_systems 3 0 1
 
   echo Auto-create a MicroCloud with 3 systems with 1 interface each.
-  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --auto > out"
+  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --auto --lookup-timeout 10 > out"
   for m in micro01 micro02 micro03; do
     validate_system_lxd "${m}" 3
     validate_system_microceph "${m}"
@@ -1013,7 +1013,7 @@ test_auto() {
   reset_systems 3 1 1
 
   echo Auto-create a MicroCloud with 3 systems with 1 disk and 1 interface each.
-  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --auto > out"
+  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --auto --lookup-timeout 10 > out"
   for m in micro01 micro02 micro03; do
     validate_system_lxd "${m}" 3 "" 1 0
     validate_system_microceph "${m}" 0 disk1
@@ -1030,7 +1030,7 @@ test_auto() {
   reset_systems 3 3 1
 
   echo Auto-create a MicroCloud with 3 systems with 3 disks and 1 interface each.
-  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --auto > out"
+  lxc exec micro01 -- sh -c "TEST_CONSOLE=0 microcloud init --auto --lookup-timeout 10 > out"
   for m in micro01 micro02 micro03 ; do
     validate_system_lxd "${m}" 3 disk1 2 0
     validate_system_microceph "${m}" 0 disk2 disk3
@@ -1148,7 +1148,7 @@ test_reuse_cluster() {
   reset_systems 3 3 3
   echo "Create a MicroCloud that re-uses an existing service with preseed"
   addr=$(lxc ls micro01 -f csv -c4 | grep enp5s0 | cut -d' ' -f1)
-  lxc exec micro01 --env TEST_CONSOLE=0 --  microcloud init --preseed << EOF
+  lxc exec micro01 --env TEST_CONSOLE=0 --  microcloud init --preseed --lookup-timeout 10 << EOF
 lookup_subnet: ${addr}/24
 lookup_interface: enp5s0
 reuse_existing_clusters: true

--- a/test/suites/preseed.sh
+++ b/test/suites/preseed.sh
@@ -5,7 +5,7 @@ test_preseed() {
   lookup_addr=$(lxc ls micro01 -f json -c4 | jq -r '.[0].state.network.enp5s0.addresses[] | select(.family == "inet") | .address')
 
   # Create a MicroCloud with storage directly given by-path on one node, and by filter on other nodes.
-  lxc exec micro01 --env TEST_CONSOLE=0 -- microcloud init --preseed << EOF
+  lxc exec micro01 --env TEST_CONSOLE=0 -- microcloud init --preseed --lookup-timeout 10 << EOF
 lookup_subnet: ${lookup_addr}/24
 lookup_interface: enp5s0
 systems:
@@ -65,7 +65,7 @@ EOF
   validate_system_microovn micro02
 
   # Grow the MicroCloud with a new node, with filter-based storage selection.
-  lxc exec micro01 --env TEST_CONSOLE=0 -- microcloud add --preseed <<EOF
+  lxc exec micro01 --env TEST_CONSOLE=0 -- microcloud add --preseed --lookup-timeout 10 <<EOF
 lookup_subnet: ${lookup_addr}/24
 lookup_interface: enp5s0
 systems:
@@ -94,7 +94,7 @@ EOF
   lookup_addr=$(lxc ls micro01 -f json -c4 | jq -r '.[0].state.network.enp5s0.addresses[] | select(.family == "inet") | .address')
 
   # Create a MicroCloud but don't set up storage or network (Should get a FAN setup).
-  lxc exec micro01 --env TEST_CONSOLE=0 -- microcloud init --preseed << EOF
+  lxc exec micro01 --env TEST_CONSOLE=0 -- microcloud init --preseed --lookup-timeout 10 << EOF
 lookup_subnet: ${lookup_addr}/24
 lookup_interface: enp5s0
 systems:
@@ -117,7 +117,7 @@ EOF
   lxc exec micro01 -- snap disable microovn
   sleep 1
 
-  lxc exec micro01 --env TEST_CONSOLE=0 -- microcloud init --preseed << EOF
+  lxc exec micro01 --env TEST_CONSOLE=0 -- microcloud init --preseed --lookup-timeout 10 << EOF
 lookup_subnet: ${lookup_addr}/24
 lookup_interface: enp5s0
 systems:


### PR DESCRIPTION
Now that we are properly sorting disks, we can reliably validate that the disk ID we expected is the one that was selected automatically.