### PR TITLE
Add service-wide cluster member remove command

### DIFF
--- a/api/services.go
+++ b/api/services.go
@@ -5,59 +5,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/util"
-	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/microcluster/rest"
 	"github.com/canonical/microcluster/state"
-	"github.com/gorilla/mux"
 
 	"github.com/canonical/microcloud/microcloud/api/types"
 	"github.com/canonical/microcloud/microcloud/service"
 )
-
-// endpointHandler is just a convenience for writing clean return types.
-type endpointHandler func(*state.State, *http.Request) response.Response
-
-// authHandler ensures a request has been authenticated with the mDNS broadcast secret.
-func authHandler(sh *service.Handler, f endpointHandler) endpointHandler {
-	return func(s *state.State, r *http.Request) response.Response {
-		if r.RemoteAddr == "@" {
-			logger.Debug("Allowing unauthenticated request through unix socket")
-
-			return f(s, r)
-		}
-
-		// Use certificate based authentication between cluster members.
-		if r.TLS != nil && r.Host == s.Address().URL.Host {
-			trustedCerts := s.Remotes().CertificatesNative()
-			for _, cert := range r.TLS.PeerCertificates {
-				trusted, _ := util.CheckMutualTLS(*cert, trustedCerts)
-				if trusted {
-					return f(s, r)
-				}
-			}
-		}
-
-		secret := r.Header.Get("X-MicroCloud-Auth")
-		if secret == "" {
-			return response.BadRequest(fmt.Errorf("No auth secret in response"))
-		}
-
-		if sh.AuthSecret == "" {
-			return response.BadRequest(fmt.Errorf("No generated auth secret"))
-		}
-
-		if sh.AuthSecret != secret {
-			return response.SmartError(fmt.Errorf("Request secret does not match, ignoring request"))
-		}
-
-		return f(s, r)
-	}
-}
 
 // ServicesCmd represents the /1.0/services API on MicroCloud.
 var ServicesCmd = func(sh *service.Handler) rest.Endpoint {
@@ -68,47 +25,6 @@ var ServicesCmd = func(sh *service.Handler) rest.Endpoint {
 
 		Put: rest.EndpointAction{Handler: authHandler(sh, servicesPut), AllowUntrusted: true, ProxyTarget: true},
 	}
-}
-
-// ServiceTokensCmd represents the /1.0/services/serviceType/tokens API on MicroCloud.
-var ServiceTokensCmd = func(sh *service.Handler) rest.Endpoint {
-	return rest.Endpoint{
-		AllowedBeforeInit: true,
-		Name:              "services/{serviceType}/tokens",
-		Path:              "services/{serviceType}/tokens",
-
-		Post: rest.EndpointAction{Handler: authHandler(sh, serviceTokensPost), AllowUntrusted: true, ProxyTarget: true},
-	}
-}
-
-// serviceTokensPost issues a token for service using the MicroCloud proxy.
-// Normally a token request to a service would be restricted to trusted systems,
-// so this endpoint validates the mDNS auth token and then proxies the request to the local unix socket of the remote system.
-func serviceTokensPost(s *state.State, r *http.Request) response.Response {
-	serviceType, err := url.PathUnescape(mux.Vars(r)["serviceType"])
-	if err != nil {
-		return response.SmartError(err)
-	}
-
-	// Parse the request.
-	req := types.ServiceTokensPost{}
-
-	err = json.NewDecoder(r.Body).Decode(&req)
-	if err != nil {
-		return response.BadRequest(err)
-	}
-
-	sh, err := service.NewHandler(s.Name(), req.ClusterAddress, s.OS.StateDir, false, false, types.ServiceType(serviceType))
-	if err != nil {
-		return response.SmartError(err)
-	}
-
-	token, err := sh.Services[types.ServiceType(serviceType)].IssueToken(s.Context, req.JoinerName)
-	if err != nil {
-		return response.SmartError(fmt.Errorf("Failed to issue %s token for peer %q: %w", serviceType, req.JoinerName, err))
-	}
-
-	return response.SyncResponse(true, token)
 }
 
 // servicesPut updates the cluster status of the MicroCloud peer.

--- a/api/services.go
+++ b/api/services.go
@@ -55,7 +55,7 @@ func servicesPut(state *state.State, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	err = sh.RunConcurrent(true, true, func(s service.Service) error {
+	err = sh.RunConcurrent(types.MicroCloud, types.LXD, func(s service.Service) error {
 		// set a 5 minute context for completing the join request in case the system is very slow.
 		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Minute)
 		defer cancel()

--- a/api/services_auth.go
+++ b/api/services_auth.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/lxd/lxd/util"
+	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/microcluster/state"
+
+	"github.com/canonical/microcloud/microcloud/service"
+)
+
+// endpointHandler is just a convenience for writing clean return types.
+type endpointHandler func(*state.State, *http.Request) response.Response
+
+// authHandler ensures a request has been authenticated with the mDNS broadcast secret.
+func authHandler(sh *service.Handler, f endpointHandler) endpointHandler {
+	return func(s *state.State, r *http.Request) response.Response {
+		if r.RemoteAddr == "@" {
+			logger.Debug("Allowing unauthenticated request through unix socket")
+
+			return f(s, r)
+		}
+
+		// Use certificate based authentication between cluster members.
+		if r.TLS != nil && r.Host == s.Address().URL.Host {
+			trustedCerts := s.Remotes().CertificatesNative()
+			for _, cert := range r.TLS.PeerCertificates {
+				trusted, _ := util.CheckMutualTLS(*cert, trustedCerts)
+				if trusted {
+					return f(s, r)
+				}
+			}
+		}
+
+		secret := r.Header.Get("X-MicroCloud-Auth")
+		if secret == "" {
+			return response.BadRequest(fmt.Errorf("No auth secret in response"))
+		}
+
+		if sh.AuthSecret == "" {
+			return response.BadRequest(fmt.Errorf("No generated auth secret"))
+		}
+
+		if sh.AuthSecret != secret {
+			return response.SmartError(fmt.Errorf("Request secret does not match, ignoring request"))
+		}
+
+		return f(s, r)
+	}
+}

--- a/api/services_cluster.go
+++ b/api/services_cluster.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/microcluster/rest"
+	"github.com/canonical/microcluster/state"
+	"github.com/gorilla/mux"
+
+	"github.com/canonical/microcloud/microcloud/api/types"
+	"github.com/canonical/microcloud/microcloud/service"
+)
+
+// ServicesClusterCmd represents the /1.0/services/cluster/{name} API on MicroCloud.
+var ServicesClusterCmd = func(sh *service.Handler) rest.Endpoint {
+	return rest.Endpoint{
+		AllowedBeforeInit: true,
+		Name:              "services/cluster/{name}",
+		Path:              "services/cluster/{name}",
+
+		Delete: rest.EndpointAction{Handler: authHandler(sh, removeClusterMember), AllowUntrusted: true},
+	}
+}
+
+// removeClusterMember removes the given cluster member from all services that it exists in.
+func removeClusterMember(state *state.State, r *http.Request) response.Response {
+	force := r.URL.Query().Get("force") == "1"
+	name, err := url.PathUnescape(mux.Vars(r)["name"])
+	if err != nil {
+		return response.BadRequest(err)
+	}
+
+	supportedServices := map[types.ServiceType]string{
+		types.MicroOVN:  MicroOVNDir,
+		types.MicroCeph: MicroCephDir,
+		types.LXD:       LXDDir,
+	}
+
+	existingServices := []types.ServiceType{types.MicroCloud}
+	for serviceType, stateDir := range supportedServices {
+		if service.Exists(serviceType, stateDir) {
+			existingServices = append(existingServices, serviceType)
+		}
+	}
+
+	addr, _, err := net.SplitHostPort(state.Address().URL.Host)
+	if err != nil {
+		return response.SmartError(fmt.Errorf("State address %q is invalid: %w", state.Address().String(), err))
+	}
+
+	sh, err := service.NewHandler(state.Name(), addr, state.OS.StateDir, false, false, existingServices...)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	// Remove the node from services in the following order:
+	// 1. Remove from LXD first as it may have storage & networks that depend on the others for cleanup.
+	// 2. Remove from MicroCeph and MicroOVN next, concurrently.
+	// 3. Remove from MicroCloud last so that if there were any errors causing the other services to fail, MicroCloud will still know about the node.
+	var memberExists bool
+	err = sh.RunConcurrent(types.LXD, types.MicroCloud, func(s service.Service) error {
+		existingMembers, err := s.ClusterMembers(r.Context())
+		if err != nil && !api.StatusErrorCheck(err, http.StatusServiceUnavailable) {
+			return err
+		}
+
+		// If we got a 503 error back, that means the service is installed, but hasn't been set up yet, so there are no cluster members to remove.
+		if err != nil {
+			return nil
+		}
+
+		// The cluster member may not exist for this service if it was removed manually, so skip removal for that service.
+		_, ok := existingMembers[name]
+		if !ok {
+			logger.Warn("Cluster member not found for service", logger.Ctx{"service": s.Type(), "member": name})
+			return nil
+		}
+
+		if !memberExists && ok {
+			memberExists = ok
+		}
+
+		return s.DeleteClusterMember(r.Context(), name, force)
+	})
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	if !memberExists {
+		return response.NotFound(fmt.Errorf("Cluster member %q not found on any service", name))
+	}
+
+	return response.EmptySyncResponse
+}

--- a/api/services_tokens.go
+++ b/api/services_tokens.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/microcluster/rest"
+	"github.com/canonical/microcluster/state"
+	"github.com/gorilla/mux"
+
+	"github.com/canonical/microcloud/microcloud/api/types"
+	"github.com/canonical/microcloud/microcloud/service"
+)
+
+// ServiceTokensCmd represents the /1.0/services/serviceType/tokens API on MicroCloud.
+var ServiceTokensCmd = func(sh *service.Handler) rest.Endpoint {
+	return rest.Endpoint{
+		AllowedBeforeInit: true,
+		Name:              "services/{serviceType}/tokens",
+		Path:              "services/{serviceType}/tokens",
+
+		Post: rest.EndpointAction{Handler: authHandler(sh, serviceTokensPost), AllowUntrusted: true, ProxyTarget: true},
+	}
+}
+
+// serviceTokensPost issues a token for service using the MicroCloud proxy.
+// Normally a token request to a service would be restricted to trusted systems,
+// so this endpoint validates the mDNS auth token and then proxies the request to the local unix socket of the remote system.
+func serviceTokensPost(s *state.State, r *http.Request) response.Response {
+	serviceType, err := url.PathUnescape(mux.Vars(r)["serviceType"])
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	// Parse the request.
+	req := types.ServiceTokensPost{}
+
+	err = json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		return response.BadRequest(err)
+	}
+
+	sh, err := service.NewHandler(s.Name(), req.ClusterAddress, s.OS.StateDir, false, false, types.ServiceType(serviceType))
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	token, err := sh.Services[types.ServiceType(serviceType)].IssueToken(s.Context, req.JoinerName)
+	if err != nil {
+		return response.SmartError(fmt.Errorf("Failed to issue %s token for peer %q: %w", serviceType, req.JoinerName, err))
+	}
+
+	return response.SyncResponse(true, token)
+}

--- a/client/client.go
+++ b/client/client.go
@@ -37,3 +37,16 @@ func RemoteIssueToken(ctx context.Context, c *client.Client, serviceType types.S
 
 	return token, nil
 }
+
+// DeleteClusterMember removes the cluster member from any service that it is part of.
+func DeleteClusterMember(ctx context.Context, c *client.Client, memberName string, force bool) error {
+	queryCtx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	path := api.NewURL().Path("services", "cluster", memberName)
+	if force {
+		path = path.WithQuery("force", "1")
+	}
+
+	return c.Query(queryCtx, "DELETE", types.APIVersion, path, nil, nil)
+}

--- a/cmd/microcloud/main.go
+++ b/cmd/microcloud/main.go
@@ -81,6 +81,9 @@ EOF`)
 	var cmdAdd = cmdAdd{common: &commonCmd}
 	app.AddCommand(cmdAdd.Command())
 
+	var cmdRemove = cmdRemove{common: &commonCmd}
+	app.AddCommand(cmdRemove.Command())
+
 	var cmdPeers = cmdClusterMembers{common: &commonCmd}
 	app.AddCommand(cmdPeers.Command())
 

--- a/cmd/microcloud/main_init.go
+++ b/cmd/microcloud/main_init.go
@@ -514,7 +514,7 @@ func (c *initConfig) addPeers(sh *service.Handler) error {
 	// Concurrently issue a token for each joiner.
 	for peer := range c.systems {
 		mut := sync.Mutex{}
-		err := sh.RunConcurrent(false, false, func(s service.Service) error {
+		err := sh.RunConcurrent("", "", func(s service.Service) error {
 			// Only issue a token if the system isn't already part of that cluster.
 			if existingSystems[s.Type()][peer] == "" {
 				clusteredSystem := c.systems[initializedServices[s.Type()]]
@@ -719,7 +719,7 @@ func (c *initConfig) setupCluster(s *service.Handler) error {
 
 		fmt.Println("Initializing a new cluster")
 		mu := sync.Mutex{}
-		err := s.RunConcurrent(true, false, func(s service.Service) error {
+		err := s.RunConcurrent(types.MicroCloud, "", func(s service.Service) error {
 			// If there's already an initialized system for this service, we don't need to bootstrap it.
 			if initializedServices[s.Type()] != "" {
 				return nil

--- a/cmd/microcloud/remove.go
+++ b/cmd/microcloud/remove.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+
+	"github.com/canonical/microcluster/microcluster"
+	"github.com/spf13/cobra"
+
+	cloudClient "github.com/canonical/microcloud/microcloud/client"
+)
+
+type cmdRemove struct {
+	common *CmdControl
+
+	flagForce bool
+}
+
+func (c *cmdRemove) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "remove <name>",
+		Aliases: []string{"rm"},
+		Short:   "Remove the specified member from all MicroCloud services",
+		RunE:    c.Run,
+	}
+
+	cmd.Flags().BoolVarP(&c.flagForce, "force", "f", false, "Forcibly remove the cluster member")
+
+	return cmd
+}
+
+func (c *cmdRemove) Run(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return cmd.Help()
+	}
+
+	options := microcluster.Args{StateDir: c.common.FlagMicroCloudDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug}
+	m, err := microcluster.App(options)
+	if err != nil {
+		return err
+	}
+
+	client, err := m.LocalClient()
+	if err != nil {
+		return err
+	}
+
+	return cloudClient.DeleteClusterMember(context.Background(), client, args[0], c.flagForce)
+}

--- a/cmd/microcloudd/main.go
+++ b/cmd/microcloudd/main.go
@@ -133,6 +133,7 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 	endpoints := []rest.Endpoint{
 		api.ServicesCmd(s),
 		api.ServiceTokensCmd(s),
+		api.ServicesClusterCmd(s),
 		api.LXDProxy(s),
 		api.CephProxy(s),
 		api.OVNProxy(s),

--- a/doc/.custom_wordlist.txt
+++ b/doc/.custom_wordlist.txt
@@ -40,3 +40,4 @@ disaggregated
 subnets
 GbE
 QSFP
+OSDs

--- a/doc/how-to/index.md
+++ b/doc/how-to/index.md
@@ -11,6 +11,7 @@ Manage the snaps </how-to/snaps>
 Initialise MicroCloud </how-to/initialise>
 Configure Ceph networking </how-to/ceph_networking>
 Add a machine </how-to/add_machine>
+Remove a machine </how-to/remove_machine>
 Get support </how-to/support>
 Contribute to MicroCloud </how-to/contribute>
 Work with MicroCloud </how-to/commands>

--- a/doc/how-to/remove_machine.md
+++ b/doc/how-to/remove_machine.md
@@ -1,0 +1,17 @@
+(howto-remove)=
+# How to remove a machine
+
+If you want to remove a machine from the MicroCloud cluster after the initialisation, use the {command}`microcloud remove` command:
+
+    sudo microcloud remove <name>
+
+Before removing the machine, ensure that there are no LXD instances or storage volumes located on the machine, and that there are no MicroCeph OSDs located on the machine.
+
+See [how to remove instances](https://documentation.ubuntu.com/lxd/en/latest/howto/instances_manage/#delete-an-instance) in the LXD documentation.
+See [how to remove OSDs](https://canonical-microceph.readthedocs-hosted.com/en/latest/how-to/remove-disk/) in the MicroCeph documentation.
+
+If the machine is no longer reachable over the network, you can also add the `--force` flag to bypass removal restrictions and skip attempting to clean up the machine. Note that MicroCeph requires `--force` to be used if the remaining cluster size will be less than 3.
+
+```{caution}
+Removing a cluster member with `--force` will not attempt to perform any clean-up of the removed machine. All services will need to be fully re-installed before they can be re-initialised. Resources allocated to the MicroCloud like disks and network interfaces may need to be re-initialised as well.
+```

--- a/service/interface.go
+++ b/service/interface.go
@@ -15,6 +15,8 @@ type Service interface {
 	ClusterMembers(ctx context.Context) (map[string]string, error)
 	RemoteClusterMembers(ctx context.Context, secret string, address string) (map[string]string, error)
 
+	DeleteClusterMember(ctx context.Context, name string, force bool) error
+
 	Type() types.ServiceType
 	Name() string
 	Address() string

--- a/service/lxd.go
+++ b/service/lxd.go
@@ -260,6 +260,16 @@ func (s LXDService) clusterMembers(client lxd.InstanceServer) (map[string]string
 	return genericMembers, nil
 }
 
+// DeleteClusterMember removes the given cluster member from the service.
+func (s LXDService) DeleteClusterMember(ctx context.Context, name string, force bool) error {
+	c, err := s.Client(ctx, "")
+	if err != nil {
+		return err
+	}
+
+	return c.DeleteClusterMember(name, force)
+}
+
 // Type returns the type of Service.
 func (s LXDService) Type() types.ServiceType {
 	return types.LXD

--- a/service/microceph.go
+++ b/service/microceph.go
@@ -153,6 +153,16 @@ func (s CephService) ClusterMembers(ctx context.Context) (map[string]string, err
 	return clusterMembers(ctx, client)
 }
 
+// DeleteClusterMember removes the given cluster member from the service.
+func (s CephService) DeleteClusterMember(ctx context.Context, name string, force bool) error {
+	c, err := s.m.LocalClient()
+	if err != nil {
+		return err
+	}
+
+	return c.DeleteClusterMember(ctx, name, force)
+}
+
 // ClusterConfig returns the Ceph cluster configuration.
 func (s CephService) ClusterConfig(ctx context.Context, targetAddress string, targetSecret string) (map[string]string, error) {
 	var c *client.Client

--- a/service/microcloud.go
+++ b/service/microcloud.go
@@ -196,6 +196,16 @@ func clusterMembers(ctx context.Context, client *microClient.Client) (map[string
 	return genericMembers, nil
 }
 
+// DeleteClusterMember removes the given cluster member from the service.
+func (s CloudService) DeleteClusterMember(ctx context.Context, name string, force bool) error {
+	c, err := s.client.LocalClient()
+	if err != nil {
+		return err
+	}
+
+	return c.DeleteClusterMember(ctx, name, force)
+}
+
 // Type returns the type of Service.
 func (s CloudService) Type() types.ServiceType {
 	return types.MicroCloud

--- a/service/microovn.go
+++ b/service/microovn.go
@@ -119,6 +119,16 @@ func (s OVNService) ClusterMembers(ctx context.Context) (map[string]string, erro
 	return clusterMembers(ctx, client)
 }
 
+// DeleteClusterMember removes the given cluster member from the service.
+func (s OVNService) DeleteClusterMember(ctx context.Context, name string, force bool) error {
+	c, err := s.m.LocalClient()
+	if err != nil {
+		return err
+	}
+
+	return c.DeleteClusterMember(ctx, name, force)
+}
+
 // Type returns the type of Service.
 func (s OVNService) Type() types.ServiceType {
 	return types.MicroOVN

--- a/test/main.sh
+++ b/test/main.sh
@@ -216,6 +216,7 @@ run_instances_tests() {
 run_basic_tests() {
   run_test test_reuse_cluster "reuse_cluster"
   run_test test_auto "auto"
+  run_test test_remove_cluster_member "remove_cluster_member"
 }
 
 run_recover_tests() {


### PR DESCRIPTION
`microcloud remove <name>` will now remove the given cluster member from all services. If `--force` is specified, it is also propagated to all services.

Since the clusters may not have all the same members, we do not error out if some services don't have the corresponding cluster member, instead we will log this as a warning and continue attempting to remove the cluster member from other services.

If no service has the cluster member, then we will error out, reporting that we couldn't find the cluster member across any services.

LXD will be attempted first, as it depends on the other ones. Then we concurrently try to remove the system from MicroCloud, MicroOVN, and MicroCeph.