### PR TITLE
`service add` and `service list`

### DIFF
--- a/cmd/microcloud/add.go
+++ b/cmd/microcloud/add.go
@@ -141,7 +141,7 @@ func (c *cmdAdd) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Ask to reuse existing clusters.
-	err = cfg.askClustered(s)
+	err = cfg.askClustered(s, services)
 	if err != nil {
 		return err
 	}

--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -1230,13 +1230,8 @@ func (c *initConfig) askCephNetwork(sh *service.Handler) error {
 // If a service is already initialized on some systems, we will offer to add the remaining systems, or skip that service.
 // In auto setup, we will expect no initialized services so that we can be opinionated about how we configure the cluster without user input.
 // This works by deleting the record for the service from the `service.Handler`, thus ignoring it for the remainder of the setup.
-func (c *initConfig) askClustered(s *service.Handler) error {
-	expectedServices := make(map[types.ServiceType]struct{}, len(s.Services))
-	for k := range s.Services {
-		expectedServices[k] = struct{}{}
-	}
-
-	for serviceType := range expectedServices {
+func (c *initConfig) askClustered(s *service.Handler, expectedServices []types.ServiceType) error {
+	for _, serviceType := range expectedServices {
 		for name, info := range c.state {
 			_, newSystem := c.systems[name]
 			if !newSystem {

--- a/cmd/microcloud/main.go
+++ b/cmd/microcloud/main.go
@@ -84,6 +84,9 @@ EOF`)
 	var cmdRemove = cmdRemove{common: &commonCmd}
 	app.AddCommand(cmdRemove.Command())
 
+	var cmdService = cmdServices{common: &commonCmd}
+	app.AddCommand(cmdService.Command())
+
 	var cmdPeers = cmdClusterMembers{common: &commonCmd}
 	app.AddCommand(cmdPeers.Command())
 

--- a/cmd/microcloud/main_init.go
+++ b/cmd/microcloud/main_init.go
@@ -244,7 +244,7 @@ func (c *initConfig) RunInteractive(cmd *cobra.Command, args []string) error {
 	}
 
 	// Ask to reuse existing clusters.
-	err = c.askClustered(s)
+	err = c.askClustered(s, services)
 	if err != nil {
 		return err
 	}

--- a/cmd/microcloud/services.go
+++ b/cmd/microcloud/services.go
@@ -1,0 +1,339 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/canonical/lxd/client"
+	lxdAPI "github.com/canonical/lxd/shared/api"
+	cli "github.com/canonical/lxd/shared/cmd"
+	"github.com/canonical/microcluster/client"
+	"github.com/canonical/microcluster/microcluster"
+	"github.com/spf13/cobra"
+
+	"github.com/canonical/microcloud/microcloud/api"
+	"github.com/canonical/microcloud/microcloud/api/types"
+	"github.com/canonical/microcloud/microcloud/mdns"
+	"github.com/canonical/microcloud/microcloud/service"
+)
+
+type cmdServices struct {
+	common *CmdControl
+}
+
+func (c *cmdServices) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "service",
+		Short: "Manage MicroCloud services",
+		RunE:  func(cmd *cobra.Command, args []string) error { return cmd.Help() },
+	}
+
+	var cmdServiceList = cmdServiceList{common: c.common}
+	cmd.AddCommand(cmdServiceList.Command())
+
+	var cmdServiceAdd = cmdServiceAdd{common: c.common}
+	cmd.AddCommand(cmdServiceAdd.Command())
+
+	return cmd
+}
+
+type cmdServiceList struct {
+	common *CmdControl
+}
+
+func (c *cmdServiceList) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List MicroCloud services and their cluster members",
+		RunE:  c.Run,
+	}
+
+	return cmd
+}
+
+func (c *cmdServiceList) Run(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		return cmd.Help()
+	}
+
+	// Get a microcluster client so we can get state information.
+	cloudApp, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagMicroCloudDir})
+	if err != nil {
+		return err
+	}
+
+	// Fetch the name and address, and ensure we're initialized.
+	status, err := cloudApp.Status(context.Background())
+	if err != nil {
+		return fmt.Errorf("Failed to get MicroCloud status: %w", err)
+	}
+
+	if !status.Ready {
+		return fmt.Errorf("MicroCloud is uninitialized, run 'microcloud init' first")
+	}
+
+	services := []types.ServiceType{types.MicroCloud, types.LXD}
+	optionalServices := map[types.ServiceType]string{
+		types.MicroCeph: api.MicroCephDir,
+		types.MicroOVN:  api.MicroOVNDir,
+	}
+
+	cfg := initConfig{
+		bootstrap: false,
+		common:    c.common,
+		asker:     &c.common.asker,
+		systems:   map[string]InitSystem{},
+		state:     map[string]service.SystemInformation{},
+	}
+
+	cfg.name = status.Name
+	cfg.address = status.Address.Addr().String()
+
+	services, err = cfg.askMissingServices(services, optionalServices)
+	if err != nil {
+		return err
+	}
+
+	// Instantiate a handler for the services.
+	s, err := service.NewHandler(status.Name, status.Address.Addr().String(), c.common.FlagMicroCloudDir, c.common.FlagLogDebug, c.common.FlagLogVerbose, services...)
+	if err != nil {
+		return err
+	}
+
+	mu := sync.Mutex{}
+	header := []string{"NAME", "ADDRESS", "ROLE", "STATUS"}
+	allClusters := map[types.ServiceType][][]string{}
+	err = s.RunConcurrent("", "", func(s service.Service) error {
+		var err error
+		var data [][]string
+		var microClient *client.Client
+		var lxd lxd.InstanceServer
+		switch s.Type() {
+		case types.LXD:
+			lxd, err = s.(*service.LXDService).Client(context.Background(), "")
+		case types.MicroCeph:
+			microClient, err = s.(*service.CephService).Client("", "")
+		case types.MicroOVN:
+			microClient, err = s.(*service.OVNService).Client()
+		case types.MicroCloud:
+			microClient, err = s.(*service.CloudService).Client()
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if microClient != nil {
+			clusterMembers, err := microClient.GetClusterMembers(context.Background())
+			if err != nil && !lxdAPI.StatusErrorCheck(err, http.StatusServiceUnavailable) {
+				return err
+			}
+
+			if len(clusterMembers) != 0 {
+				data = make([][]string, len(clusterMembers))
+				for i, clusterMember := range clusterMembers {
+					data[i] = []string{clusterMember.Name, clusterMember.Address.String(), clusterMember.Role, string(clusterMember.Status)}
+				}
+
+				sort.Sort(cli.SortColumnsNaturally(data))
+			}
+		} else if lxd != nil {
+			server, _, err := lxd.GetServer()
+			if err != nil {
+				return err
+			}
+
+			if server.Environment.ServerClustered {
+				clusterMembers, err := lxd.GetClusterMembers()
+				if err != nil {
+					return err
+				}
+
+				data = make([][]string, len(clusterMembers))
+				for i, clusterMember := range clusterMembers {
+					data[i] = []string{clusterMember.ServerName, clusterMember.URL, strings.Join(clusterMember.Roles, "\n"), string(clusterMember.Status)}
+				}
+
+				sort.Sort(cli.SortColumnsNaturally(data))
+			}
+		}
+
+		mu.Lock()
+		allClusters[s.Type()] = data
+		mu.Unlock()
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	for serviceType, data := range allClusters {
+		if len(data) == 0 {
+			fmt.Printf("%s: Not initialized\n", serviceType)
+		} else {
+			fmt.Printf("%s:\n", serviceType)
+			err = cli.RenderTable(cli.TableFormatTable, header, data, nil)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+type cmdServiceAdd struct {
+	common *CmdControl
+}
+
+func (c *cmdServiceAdd) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add new services to the existing MicroCloud",
+		RunE:  c.Run,
+	}
+
+	return cmd
+}
+
+func (c *cmdServiceAdd) Run(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		return cmd.Help()
+	}
+
+	cfg := initConfig{
+		// Set bootstrap to true because we are setting up a new cluster for new services.
+		bootstrap: true,
+		common:    c.common,
+		asker:     &c.common.asker,
+		systems:   map[string]InitSystem{},
+		state:     map[string]service.SystemInformation{},
+	}
+
+	// Get a microcluster client so we can get state information.
+	cloudApp, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagMicroCloudDir})
+	if err != nil {
+		return err
+	}
+
+	// Fetch the name and address, and ensure we're initialized.
+	status, err := cloudApp.Status(context.Background())
+	if err != nil {
+		return fmt.Errorf("Failed to get MicroCloud status: %w", err)
+	}
+
+	if !status.Ready {
+		return fmt.Errorf("MicroCloud is uninitialized, run 'microcloud init' first")
+	}
+
+	cfg.name = status.Name
+	cfg.address = status.Address.Addr().String()
+	// enable auto setup to skip lookup related questions.
+	cfg.autoSetup = true
+	err = cfg.askAddress()
+	if err != nil {
+		return err
+	}
+
+	cfg.autoSetup = false
+	services := []types.ServiceType{types.MicroCloud, types.LXD}
+	optionalServices := map[types.ServiceType]string{
+		types.MicroCeph: api.MicroCephDir,
+		types.MicroOVN:  api.MicroOVNDir,
+	}
+
+	// Set the auto flag to true so that we automatically omit any services that aren't installed.
+	services, err = cfg.askMissingServices(services, optionalServices)
+	if err != nil {
+		return err
+	}
+
+	// Instantiate a handler for the services.
+	s, err := service.NewHandler(cfg.name, cfg.address, c.common.FlagMicroCloudDir, c.common.FlagLogDebug, c.common.FlagLogVerbose, services...)
+	if err != nil {
+		return err
+	}
+
+	state, err := s.CollectSystemInformation(context.Background(), mdns.ServerInfo{Name: cfg.name, Address: cfg.address, Services: services})
+	if err != nil {
+		return err
+	}
+
+	cfg.state[cfg.name] = *state
+	// Create an InitSystem map to carry through the interactive setup.
+	clusters := cfg.state[cfg.name].ExistingServices
+	for name, address := range clusters[types.MicroCloud] {
+		cfg.systems[name] = InitSystem{
+			ServerInfo: mdns.ServerInfo{
+				Name:     name,
+				Address:  address,
+				Services: services,
+			},
+		}
+	}
+
+	for _, system := range cfg.systems {
+		if system.ServerInfo.Name == "" || system.ServerInfo.Name == cfg.name {
+			continue
+		}
+
+		state, err := s.CollectSystemInformation(context.Background(), system.ServerInfo)
+		if err != nil {
+			return err
+		}
+
+		cfg.state[system.ServerInfo.Name] = *state
+	}
+
+	askClusteredServices := []types.ServiceType{}
+	serviceMap := map[types.ServiceType]bool{}
+	for _, state := range cfg.state {
+		localState := cfg.state[s.Name]
+		if len(state.ExistingServices[types.LXD]) != len(localState.ExistingServices[types.LXD]) || len(state.ExistingServices[types.LXD]) <= 0 {
+			return fmt.Errorf("Unable to add services. Some systems are not part of the LXD cluster")
+		}
+
+		if len(state.ExistingServices[types.MicroCeph]) <= 0 && !serviceMap[types.MicroCeph] {
+			askClusteredServices = append(askClusteredServices, types.MicroCeph)
+			serviceMap[types.MicroCeph] = true
+		}
+
+		if len(state.ExistingServices[types.MicroOVN]) <= 0 && !serviceMap[types.MicroOVN] {
+			askClusteredServices = append(askClusteredServices, types.MicroOVN)
+			serviceMap[types.MicroOVN] = true
+		}
+	}
+
+	if len(askClusteredServices) == 0 {
+		return fmt.Errorf("All services have already been set up")
+	}
+
+	err = cfg.askClustered(s, askClusteredServices)
+	if err != nil {
+		return err
+	}
+
+	// Go through the normal setup for disks and networks if necessary.
+	for _, service := range askClusteredServices {
+		switch service {
+		case types.MicroCeph:
+			err := cfg.askDisks(s)
+			if err != nil {
+				return err
+			}
+
+		case types.MicroOVN:
+			err := cfg.askNetwork(s)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return cfg.setupCluster(s)
+}

--- a/doc/how-to/add_service.md
+++ b/doc/how-to/add_service.md
@@ -1,0 +1,46 @@
+(howto-add-service)=
+# How to add a service
+
+If you set up the MicroCloud without MicroOVN or MicroCeph initially, you can add those services with the {command}`microcloud service add` command:
+
+    sudo microcloud service add
+
+If MicroCloud detects a service is installed but not set up, it will ask to configure the service.
+
+To add MicroCeph:
+
+   ```{note}
+   To set up distributed storage, you need at least three additional disks on at least three different machines.
+   The disks must not contain any partitions.
+   ```
+
+1. Select `yes` to set up distributed storage.
+
+   1. Select the disks that you want to use for distributed storage.
+      You must select at least three disks.
+
+   1. Select whether you want to wipe any of the disks.
+      Wiping a disk will destroy all data on it.
+
+   1. You can choose to optionally encrypt the chosen disks.
+
+   1. You can choose to optionally set up a CephFS distributed file system.
+
+   1. Select either an IPv4 or IPv6 CIDR subnet for the Ceph internal traffic. You can leave it empty to use the default value, which is the MicroCloud internal network (see {ref}`howto-ceph-networking` for how to configure it).
+
+To add MicroOVN:
+
+1. Select `yes` to set up distributed networking.
+
+   1. Select the network interfaces that you want to use (see {ref}`microcloud-networking-uplink`).
+      You must select one network interface per machine.
+
+   1. If you want to use IPv4, specify the IPv4 gateway on the uplink network (in CIDR notation) and the first and last IPv4 address in the range that you want to use with LXD.
+
+   1. If you want to use IPv6, specify the IPv6 gateway on the uplink network (in CIDR notation).
+
+MicroCloud now starts to bootstrap the cluster for only the new services.
+
+Monitor the output to see whether all steps complete successfully.
+
+See {ref}`bootstrapping-process` for more information.

--- a/doc/how-to/commands.md
+++ b/doc/how-to/commands.md
@@ -260,7 +260,10 @@ See {ref}`lxd:cluster-manage-instance` and {ref}`lxd:cluster-evacuate`.
 ```{list-table}
  :widths: 2 3
 
- * - Inspect the cluster status
+ * - Inspect the cluster status for all services at once
+   - :command:`microcloud service list`
+
+ * - Inspect the cluster status for each service
    - {command}`microcloud cluster list`
 
      {command}`lxc cluster list`

--- a/doc/how-to/index.md
+++ b/doc/how-to/index.md
@@ -12,6 +12,7 @@ Initialise MicroCloud </how-to/initialise>
 Configure Ceph networking </how-to/ceph_networking>
 Add a machine </how-to/add_machine>
 Remove a machine </how-to/remove_machine>
+Add a service </how-to/add_service>
 Get support </how-to/support>
 Contribute to MicroCloud </how-to/contribute>
 Work with MicroCloud </how-to/commands>

--- a/service/lxd.go
+++ b/service/lxd.go
@@ -68,9 +68,16 @@ func (s LXDService) remoteClient(secret string, address string, port int64) (lxd
 		return nil, err
 	}
 
+	serverCert, err := s.m.FileSystem.ServerCert()
+	if err != nil {
+		return nil, err
+	}
+
 	remoteURL := c.URL()
 	client, err := lxd.ConnectLXD(remoteURL.String(), &lxd.ConnectionArgs{
 		HTTPClient:         c.Client.Client,
+		TLSClientCert:      string(serverCert.PublicKey()),
+		TLSClientKey:       string(serverCert.PrivateKey()),
 		InsecureSkipVerify: true,
 		SkipGetServer:      true,
 		Proxy:              cloudClient.AuthProxy(secret, types.LXD),

--- a/service/microcloud.go
+++ b/service/microcloud.go
@@ -76,6 +76,11 @@ func (s *CloudService) StartCloud(ctx context.Context, service *Handler, endpoin
 	})
 }
 
+// Client returns a client to the MicroCloud unix socket.
+func (s CloudService) Client() (*microClient.Client, error) {
+	return s.client.LocalClient()
+}
+
 // Bootstrap bootstraps the MicroCloud daemon on the default port.
 func (s CloudService) Bootstrap(ctx context.Context) error {
 	err := s.client.NewCluster(ctx, s.name, util.CanonicalNetworkAddress(s.address, s.port), nil)


### PR DESCRIPTION
Closed the old PR to start fresh.

Adds two new commands:
* `microcloud service list` will list the cluster members for every installed service, or report if it is not initialized. This will effectively be the same as calling all of the following in succession:
```
lxc cluster list
microcloud cluster list
microceph cluster list
microovn cluster list
```

The information shown will be the name, address, dqlite role, and current status of each member.

* `microcloud service add` will try to setup MicroOVN and MicroCeph on all existing MicroCloud cluster members, optionally setting up storage and networks for LXD. This is useful if MicroOVN or MicroCeph was at one point not installed on the systems and skipped during `microcloud init`. LXD and MicroCloud itself are required to already be set up. 
Thanks to #259 we can also try to re-use a service that partially covers existing MicroCloud cluster members. So if a MicroCloud is set up without MicroCeph, and then the user manually configures MicroCeph to partially cover the cluster, the user can then use `microcloud service add` to further configure MicroCeph to work with MicroCloud, and set up storage pools for LXD.