### PR TITLE
test/lint: Add a check for error messages starting with lower case

### DIFF
--- a/test/lint/capitalize-errors.sh
+++ b/test/lint/capitalize-errors.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -eu
+
+echo "Checking for error messages beginning with lower-case letters..."
+
+! git grep --untracked -P -n 'fmt\.Errorf\("[a-z]' -- '*.go'


### PR DESCRIPTION
Quick and dirty but hopefully will save some time.