### PR TITLE
Fix `microcloud add` storage & network questions

### DIFF
--- a/cmd/microcloud/main_init.go
+++ b/cmd/microcloud/main_init.go
@@ -509,10 +509,8 @@ func (c *initConfig) addPeers(sh *service.Handler) (revert.Hook, error) {
 	}
 
 	clusterSize := map[types.ServiceType]int{}
-	if c.bootstrap {
-		for serviceType, clusterMembers := range existingSystems {
-			clusterSize[serviceType] = len(clusterMembers)
-		}
+	for serviceType, clusterMembers := range existingSystems {
+		clusterSize[serviceType] = len(clusterMembers)
 	}
 
 	// Concurrently issue a token for each joiner.
@@ -548,23 +546,6 @@ func (c *initConfig) addPeers(sh *service.Handler) (revert.Hook, error) {
 						logger.Error("Failed to clean up join token", logger.Ctx{"service": s.Type(), "error": err})
 					}
 				})
-
-				mut.Unlock()
-
-				// Fetch the current cluster sizes if we are adding a new node.
-				var currentCluster map[string]string
-				if !c.bootstrap {
-					currentCluster, err = s.ClusterMembers(context.Background())
-					if err != nil {
-						return fmt.Errorf("Failed to check for existing %s cluster size: %w", s.Type(), err)
-					}
-				}
-
-				mut.Lock()
-
-				if !c.bootstrap {
-					clusterSize[s.Type()] = len(currentCluster)
-				}
 
 				cfg := joinConfig[peer]
 				cfg.Tokens = append(cfg.Tokens, types.ServiceToken{Service: s.Type(), JoinToken: token})
@@ -728,62 +709,60 @@ func (c *initConfig) setupCluster(s *service.Handler) error {
 
 	initializedServices := map[types.ServiceType]string{}
 	bootstrapSystem := c.systems[s.Name]
-	if c.bootstrap {
-		for serviceType := range s.Services {
-			for peer := range c.systems {
-				if c.state[peer].ExistingServices[serviceType] != nil {
-					initializedServices[serviceType] = peer
-					break
-				}
+	for serviceType := range s.Services {
+		for peer := range c.systems {
+			if c.state[peer].ExistingServices[serviceType] != nil {
+				initializedServices[serviceType] = peer
+				break
 			}
 		}
+	}
 
-		fmt.Println("Initializing a new cluster")
-		mu := sync.Mutex{}
-		err := s.RunConcurrent(types.MicroCloud, "", func(s service.Service) error {
-			// If there's already an initialized system for this service, we don't need to bootstrap it.
-			if initializedServices[s.Type()] != "" {
-				return nil
-			}
-
-			if s.Type() == types.MicroCeph {
-				microCephBootstrapConf := make(map[string]string)
-				if bootstrapSystem.MicroCephInternalNetworkSubnet != "" {
-					microCephBootstrapConf["ClusterNet"] = bootstrapSystem.MicroCephInternalNetworkSubnet
-				}
-
-				if len(microCephBootstrapConf) > 0 {
-					s.SetConfig(microCephBootstrapConf)
-				}
-			}
-
-			// set a 2 minute timeout to bootstrap a service in case the node is slow.
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-			defer cancel()
-
-			err := s.Bootstrap(ctx)
-			if err != nil {
-				return fmt.Errorf("Failed to bootstrap local %s: %w", s.Type(), err)
-			}
-
-			// Since the system is now clustered, update its existing services map.
-			mu.Lock()
-			clustered := c.state[s.Name()]
-			if clustered.ExistingServices == nil {
-				clustered.ExistingServices = map[types.ServiceType]map[string]string{}
-			}
-
-			clustered.ExistingServices[s.Type()] = map[string]string{s.Name(): s.Address()}
-			c.state[s.Name()] = clustered
-			mu.Unlock()
-
-			fmt.Printf(" Local %s is ready\n", s.Type())
-
+	fmt.Println("Initializing a new cluster")
+	mu := sync.Mutex{}
+	err := s.RunConcurrent(types.MicroCloud, "", func(s service.Service) error {
+		// If there's already an initialized system for this service, we don't need to bootstrap it.
+		if initializedServices[s.Type()] != "" {
 			return nil
-		})
-		if err != nil {
-			return err
 		}
+
+		if s.Type() == types.MicroCeph {
+			microCephBootstrapConf := make(map[string]string)
+			if bootstrapSystem.MicroCephInternalNetworkSubnet != "" {
+				microCephBootstrapConf["ClusterNet"] = bootstrapSystem.MicroCephInternalNetworkSubnet
+			}
+
+			if len(microCephBootstrapConf) > 0 {
+				s.SetConfig(microCephBootstrapConf)
+			}
+		}
+
+		// set a 2 minute timeout to bootstrap a service in case the node is slow.
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+
+		err := s.Bootstrap(ctx)
+		if err != nil {
+			return fmt.Errorf("Failed to bootstrap local %s: %w", s.Type(), err)
+		}
+
+		// Since the system is now clustered, update its existing services map.
+		mu.Lock()
+		clustered := c.state[s.Name()]
+		if clustered.ExistingServices == nil {
+			clustered.ExistingServices = map[types.ServiceType]map[string]string{}
+		}
+
+		clustered.ExistingServices[s.Type()] = map[string]string{s.Name(): s.Address()}
+		c.state[s.Name()] = clustered
+		mu.Unlock()
+
+		fmt.Printf(" Local %s is ready\n", s.Type())
+
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	cleanup, err := c.addPeers(s)
@@ -793,34 +772,31 @@ func (c *initConfig) setupCluster(s *service.Handler) error {
 
 	reverter.Add(cleanup)
 
-	if c.bootstrap {
-		// Joiners will add their disks as part of the join process, so only add disks here for the system we bootstrapped, or already existed.
-		peer := s.Name
-		microCeph := initializedServices[types.MicroCeph]
-		if microCeph != "" {
-			peer = microCeph
+	peer := s.Name
+	microCeph := initializedServices[types.MicroCeph]
+	if microCeph != "" {
+		peer = microCeph
+	}
+
+	for name := range c.state[peer].ExistingServices[types.MicroCeph] {
+		// There may be existing cluster members that are not a part of MicroCloud, so ignore those.
+		if c.systems[name].ServerInfo.Name == "" {
+			continue
 		}
 
-		for name := range c.state[peer].ExistingServices[types.MicroCeph] {
-			// There may be existing cluster members that are not a part of MicroCloud, so ignore those.
-			if c.systems[name].ServerInfo.Name == "" {
-				continue
-			}
-
-			var client *client.Client
-			for _, disk := range c.systems[name].MicroCephDisks {
-				if client == nil {
-					client, err = s.Services[types.MicroCeph].(*service.CephService).Client(name, c.systems[name].ServerInfo.AuthSecret)
-					if err != nil {
-						return err
-					}
-				}
-
-				logger.Debug("Adding disk to MicroCeph", logger.Ctx{"name": name, "disk": disk.Path})
-				_, err = cephClient.AddDisk(context.Background(), client, &disk)
+		var client *client.Client
+		for _, disk := range c.systems[name].MicroCephDisks {
+			if client == nil {
+				client, err = s.Services[types.MicroCeph].(*service.CephService).Client(name, c.systems[name].ServerInfo.AuthSecret)
 				if err != nil {
 					return err
 				}
+			}
+
+			logger.Debug("Adding disk to MicroCeph", logger.Ctx{"name": name, "disk": disk.Path})
+			_, err = cephClient.AddDisk(context.Background(), client, &disk)
+			if err != nil {
+				return err
 			}
 		}
 	}
@@ -841,16 +817,8 @@ func (c *initConfig) setupCluster(s *service.Handler) error {
 		}
 
 		clusterMap := map[string]string{}
-		if c.bootstrap {
-			for peer, system := range c.systems {
-				clusterMap[peer] = system.ServerInfo.Address
-			}
-		} else {
-			cloud := s.Services[types.MicroCloud].(*service.CloudService)
-			clusterMap, err = cloud.ClusterMembers(context.Background())
-			if err != nil {
-				return err
-			}
+		for peer, system := range c.systems {
+			clusterMap[peer] = system.ServerInfo.Address
 		}
 
 		conns := []string{}
@@ -946,109 +914,101 @@ func (c *initConfig) setupCluster(s *service.Handler) error {
 
 	// If bootstrapping, finalize setup of storage pools & networks, and update the default profile accordingly.
 	system := c.systems[s.Name]
-	if c.bootstrap {
-		lxd := s.Services[types.LXD].(*service.LXDService)
-		lxdClient, err := lxd.Client(context.Background(), system.ServerInfo.AuthSecret)
+	profile := lxdAPI.ProfilesPost{ProfilePut: lxdAPI.ProfilePut{Devices: map[string]map[string]string{}}, Name: "default"}
+
+	for _, network := range system.Networks {
+		if network.Name == service.DefaultOVNNetwork || profile.Devices["eth0"] == nil {
+			profile.Devices["eth0"] = map[string]string{"name": "eth0", "network": network.Name, "type": "nic"}
+		}
+
+		err = lxdClient.CreateNetwork(network)
+		if err != nil {
+			return err
+		}
+	}
+
+	cephFSPool := lxdAPI.StoragePoolsPost{}
+	for _, pool := range system.StoragePools {
+		if pool.Driver == "ceph" || profile.Devices["root"] == nil {
+			profile.Devices["root"] = map[string]string{"path": "/", "pool": pool.Name, "type": "disk"}
+		}
+
+		// Ensure the cephfs pool is created after the ceph pool so we set up crush rules.
+		if pool.Driver == "cephfs" {
+			cephFSPool = pool
+			continue
+		}
+
+		err = lxdClient.CreateStoragePool(pool)
+		if err != nil {
+			return err
+		}
+	}
+
+	if cephFSPool.Driver != "" {
+		err = lxdClient.CreateStoragePool(cephFSPool)
+		if err != nil {
+			return err
+		}
+	}
+
+	profiles, err := lxdClient.GetProfileNames()
+	if err != nil {
+		return err
+	}
+
+	if !shared.ValueInSlice(profile.Name, profiles) {
+		err = lxdClient.CreateProfile(profile)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Ensure any pre-existing devices and config are carried over to the new profile, unless we are managing them.
+		existingProfile, _, err := lxdClient.GetProfile("default")
 		if err != nil {
 			return err
 		}
 
-		profile := lxdAPI.ProfilesPost{ProfilePut: lxdAPI.ProfilePut{Devices: map[string]map[string]string{}}, Name: "default"}
-
-		for _, network := range system.Networks {
-			if network.Name == service.DefaultOVNNetwork || profile.Devices["eth0"] == nil {
-				profile.Devices["eth0"] = map[string]string{"name": "eth0", "network": network.Name, "type": "nic"}
-			}
-
-			err = lxdClient.CreateNetwork(network)
-			if err != nil {
-				return err
+		askConflictingConfig := []string{}
+		askConflictingDevices := []string{}
+		for k, v := range profile.Config {
+			_, ok := existingProfile.Config[k]
+			if !ok {
+				existingProfile.Config[k] = v
+			} else {
+				askConflictingConfig = append(askConflictingConfig, k)
 			}
 		}
 
-		cephFSPool := lxdAPI.StoragePoolsPost{}
-		for _, pool := range system.StoragePools {
-			if pool.Driver == "ceph" || profile.Devices["root"] == nil {
-				profile.Devices["root"] = map[string]string{"path": "/", "pool": pool.Name, "type": "disk"}
-			}
-
-			// Ensure the cephfs pool is created after the ceph pool so we set up crush rules.
-			if pool.Driver == "cephfs" {
-				cephFSPool = pool
-				continue
-			}
-
-			err = lxdClient.CreateStoragePool(pool)
-			if err != nil {
-				return err
+		for k, v := range profile.Devices {
+			_, ok := existingProfile.Devices[k]
+			if !ok {
+				existingProfile.Devices[k] = v
+			} else {
+				askConflictingDevices = append(askConflictingDevices, k)
 			}
 		}
 
-		if cephFSPool.Driver != "" {
-			err = lxdClient.CreateStoragePool(cephFSPool)
+		if !c.autoSetup && len(askConflictingConfig) > 0 || len(askConflictingDevices) > 0 {
+			replace, err := c.asker.AskBool("Replace existing default profile configuration? (yes/no) [default=no]: ", "no")
 			if err != nil {
 				return err
 			}
+
+			if replace {
+				for _, key := range askConflictingConfig {
+					existingProfile.Config[key] = profile.Config[key]
+				}
+
+				for _, key := range askConflictingDevices {
+					existingProfile.Devices[key] = profile.Devices[key]
+				}
+			}
 		}
 
-		profiles, err := lxdClient.GetProfileNames()
+		err = lxdClient.UpdateProfile(profile.Name, existingProfile.Writable(), "")
 		if err != nil {
 			return err
-		}
-
-		if !shared.ValueInSlice(profile.Name, profiles) {
-			err = lxdClient.CreateProfile(profile)
-			if err != nil {
-				return err
-			}
-		} else {
-			// Ensure any pre-existing devices and config are carried over to the new profile, unless we are managing them.
-			existingProfile, _, err := lxdClient.GetProfile("default")
-			if err != nil {
-				return err
-			}
-
-			askConflictingConfig := []string{}
-			askConflictingDevices := []string{}
-			for k, v := range profile.Config {
-				_, ok := existingProfile.Config[k]
-				if !ok {
-					existingProfile.Config[k] = v
-				} else {
-					askConflictingConfig = append(askConflictingConfig, k)
-				}
-			}
-
-			for k, v := range profile.Devices {
-				_, ok := existingProfile.Devices[k]
-				if !ok {
-					existingProfile.Devices[k] = v
-				} else {
-					askConflictingDevices = append(askConflictingDevices, k)
-				}
-			}
-
-			if !c.autoSetup && len(askConflictingConfig) > 0 || len(askConflictingDevices) > 0 {
-				replace, err := c.asker.AskBool("Replace existing default profile configuration? (yes/no) [default=no]: ", "no")
-				if err != nil {
-					return err
-				}
-
-				if replace {
-					for _, key := range askConflictingConfig {
-						existingProfile.Config[key] = profile.Config[key]
-					}
-
-					for _, key := range askConflictingDevices {
-						existingProfile.Devices[key] = profile.Devices[key]
-					}
-				}
-			}
-
-			err = lxdClient.UpdateProfile(profile.Name, existingProfile.Writable(), "")
-			if err != nil {
-				return err
-			}
 		}
 	}
 
@@ -1060,7 +1020,7 @@ func (c *initConfig) setupCluster(s *service.Handler) error {
 		}
 
 		poolNames := []string{}
-		if c.bootstrap {
+		if len(system.TargetStoragePools) > 0 {
 			for _, pool := range system.TargetStoragePools {
 				poolNames = append(poolNames, pool.Name)
 			}

--- a/cmd/microcloud/main_init.go
+++ b/cmd/microcloud/main_init.go
@@ -162,7 +162,7 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 
 func (c *initConfig) RunInteractive(cmd *cobra.Command, args []string) error {
 	// Initially restart LXD so that the correct MicroCloud service related state is set by the LXD snap.
-	fmt.Println("Waiting for LXD to start...")
+	fmt.Println("Waiting for LXD to start ...")
 	lxdService, err := service.NewLXDService("", "", c.common.FlagMicroCloudDir)
 	if err != nil {
 		return err
@@ -217,7 +217,7 @@ func (c *initConfig) RunInteractive(cmd *cobra.Command, args []string) error {
 	}
 
 	c.state[c.name] = *state
-	fmt.Println("Gathering system information...")
+	fmt.Println("Gathering system information ...")
 	for _, system := range c.systems {
 		if system.ServerInfo.Name == "" || system.ServerInfo.Name == c.name {
 			continue

--- a/cmd/microcloud/main_init.go
+++ b/cmd/microcloud/main_init.go
@@ -745,7 +745,7 @@ func (c *initConfig) setupCluster(s *service.Handler) error {
 		}
 	}
 
-	fmt.Println("Initializing a new cluster")
+	fmt.Println("Initializing new services")
 	mu := sync.Mutex{}
 	err = s.RunConcurrent(types.MicroCloud, "", func(s service.Service) error {
 		// If there's already an initialized system for this service, we don't need to bootstrap it.

--- a/cmd/microcloud/main_init_preseed.go
+++ b/cmd/microcloud/main_init_preseed.go
@@ -188,6 +188,32 @@ func (c *initConfig) RunPreseed(cmd *cobra.Command) error {
 		return err
 	}
 
+	if !c.bootstrap {
+		existingClusters, err := s.GetExistingClusters(context.Background(), mdns.ServerInfo{Name: c.name, Address: c.address})
+		if err != nil {
+			return err
+		}
+
+		for name, address := range existingClusters[types.MicroCloud] {
+			_, ok := c.systems[name]
+			if !ok {
+				c.systems[name] = InitSystem{
+					ServerInfo: mdns.ServerInfo{
+						Name:     name,
+						Address:  address,
+						Services: services,
+					},
+				}
+			}
+
+			state, ok := c.state[name]
+			if !ok {
+				state.ExistingServices = existingClusters
+				c.state[name] = state
+			}
+		}
+	}
+
 	return c.setupCluster(s)
 }
 

--- a/test/includes/microcloud.sh
+++ b/test/includes/microcloud.sh
@@ -130,7 +130,7 @@ $(true)                                                 # workaround for set -e
 "
 fi
 
-if [ -n "${REPLACE_PROFILE}" ] && [ "${SKIP_LOOKUP}" = 1 ]; then
+if [ -n "${REPLACE_PROFILE}" ] ; then
   setup="${setup}
 ${REPLACE_PROFILE}
 $(true)                                                 # workaround for set -e

--- a/test/suites/add.sh
+++ b/test/suites/add.sh
@@ -198,4 +198,56 @@ test_add_interactive() {
   for m in micro01 micro02 micro03 micro04 ; do
     validate_system_lxd "${m}" 4 disk1
   done
+
+  reset_systems 4 2 1
+  echo "Test growing a MicroCloud when storage & networks were not already set up"
+  unset_interactive_vars
+  export LOOKUP_IFACE="enp5s0"
+  export LIMIT_SUBNET="yes"
+  export EXPECT_PEERS=2
+  export SETUP_ZFS="no"
+  export SETUP_CEPH="no"
+  export SETUP_OVN="no"
+
+  lxc exec micro04 -- snap disable microcloud
+  microcloud_interactive | lxc exec micro01 -- sh -c "microcloud init > out"
+  lxc exec micro01 -- tail -1 out | grep "MicroCloud is ready" -q
+
+  for m in micro01 micro02 micro03; do
+    validate_system_lxd "${m}" 3
+    validate_system_microceph "${m}"
+    validate_system_microovn "${m}"
+  done
+
+  unset_interactive_vars
+  export LIMIT_SUBNET="yes"
+  export EXPECT_PEERS=1
+  export SETUP_ZFS="yes"
+  export ZFS_FILTER="lxd_disk1"
+  export ZFS_WIPE="yes"
+  export SETUP_CEPH="yes"
+  export SETUP_CEPHFS="yes"
+  export CEPH_WIPE="yes"
+  export CEPH_ENCRYPT="no"
+  export SETUP_OVN="yes"
+  export OVN_FILTER="enp6s0"
+  export IPV4_SUBNET="10.1.123.1/24"
+  export IPV4_START="10.1.123.100"
+  export IPV4_END="10.1.123.254"
+  export IPV6_SUBNET="fd42:1:1234:1234::1/64"
+  export DNS_ADDRESSES="10.1.123.1,fd42:1:1234:1234::1"
+  export REPLACE_PROFILE="yes"
+
+  lxc exec micro04 -- snap enable microcloud
+  lxc exec micro04 -- snap start microcloud
+  microcloud_interactive | lxc exec micro01 -- sh -c "microcloud add > out"
+
+  lxc exec micro01 -- tail -1 out | grep "MicroCloud is ready" -q
+
+  default_cluster_subnet="$(lxc exec micro01 -- ip -4 -br a show enp5s0 | awk '{print $3}')"
+  for m in micro01 micro02 micro03 micro04 ; do
+    validate_system_lxd "${m}" 4 disk1 1 1 enp6s0 10.1.123.1/24 10.1.123.100-10.1.123.254 fd42:1:1234:1234::1/64  10.1.123.1,fd42:1:1234:1234::1
+    validate_system_microceph "${m}" 1 "${default_cluster_subnet}" disk2
+    validate_system_microovn "${m}"
+  done
 }

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -1348,7 +1348,6 @@ test_add_services() {
   export DNS_ADDRESSES="10.1.123.1,8.8.8.8"
   export IPV6_SUBNET="fd42:1:1234:1234::1/64"
   export CEPH_CLUSTER_NETWORK="${ceph_cluster_subnet_prefix}.0/24"
-  export REPLACE_PROFILE="no"
 
   reset_systems 3 3 3
   set_cluster_subnet 3  "${ceph_cluster_subnet_iface}" "${ceph_cluster_subnet_prefix}"
@@ -1362,6 +1361,7 @@ test_add_services() {
   export SKIP_LOOKUP=1
   unset SETUP_ZFS
   unset SETUP_OVN
+  export REPLACE_PROFILE="no"
   microcloud_interactive | lxc exec micro01 -- sh -c "microcloud service add > out"
   services_validator
 
@@ -1370,14 +1370,15 @@ test_add_services() {
   echo Add MicroCeph to MicroCloud that was set up without it, and setup remote storage.
   lxc exec micro01 -- snap disable microceph
   unset SETUP_CEPH
+  unset REPLACE_PROFILE
   export SKIP_SERVICE="yes"
-  export REPLACE_PROFILE="yes"
   microcloud_interactive | lxc exec micro01 -- sh -c "microcloud init > out"
   lxc exec micro01 -- snap enable microceph
   export SETUP_CEPH="yes"
   export SKIP_LOOKUP=1
   unset SETUP_ZFS
   unset SETUP_OVN
+  export REPLACE_PROFILE="yes"
   microcloud_interactive | lxc exec micro01 -- sh -c "microcloud service add > out"
   services_validator
 


### PR DESCRIPTION
If storage & networks have not been set up on existing cluster members, `microcloud add` should try to set them up for both new cluster members and old ones. 

This can be accomplished by simply populating the `InitSystem`s for all existing cluster members.

This also simplifies `setupCluster` because it no longer has different behaviour based on the `bootstrap` flag being set on `initConfig`. 

---
Some other cleanup:
* The profile update question has been moved to before cluster formation because the flow is awkward when the user has to wait a few minutes and then gets asked another question before the setup continues. 
* Standardizes ellipses in messages to be of the form `text ...`