### PR TITLE
Allow OSD selection with fewer than 3 systems

### DIFF
--- a/cmd/microcloud/main_init.go
+++ b/cmd/microcloud/main_init.go
@@ -34,6 +34,9 @@ const DefaultAutoLookupTimeout time.Duration = 5 * time.Second
 // DefaultLookupTimeout is the default time limit for finding systems interactively.
 const DefaultLookupTimeout time.Duration = time.Minute
 
+// RecommendedOSDHosts is the minimum number of OSD hosts recommended for a new cluster for fault-tolerance.
+const RecommendedOSDHosts = 3
+
 // InitSystem represents the configuration passed to individual systems that join via the Handler.
 type InitSystem struct {
 	// ServerInfo contains the data reported by mDNS about this system.

--- a/cmd/microcloud/main_init_preseed.go
+++ b/cmd/microcloud/main_init_preseed.go
@@ -274,7 +274,6 @@ func (p *Preseed) validate(name string, bootstrap bool) error {
 		return fmt.Errorf("Some systems are missing an uplink interface")
 	}
 
-	containsCephStorage = directCephCount > 0
 	containsLocalStorage = directLocalCount > 0
 	if containsLocalStorage && directLocalCount < len(p.Systems) && len(p.Storage.Local) == 0 {
 		return fmt.Errorf("Some systems are missing local storage disks")
@@ -289,6 +288,7 @@ func (p *Preseed) validate(name string, bootstrap bool) error {
 		return fmt.Errorf("Missing interface name for machine lookup")
 	}
 
+	containsCephStorage = directCephCount > 0 || len(p.Storage.Ceph) > 0
 	usingCephInternalNetwork := p.Ceph.InternalNetwork != ""
 	if !containsCephStorage && usingCephInternalNetwork {
 		return fmt.Errorf("Cannot specify a Ceph internal network without Ceph storage disks")

--- a/cmd/microcloud/main_init_preseed.go
+++ b/cmd/microcloud/main_init_preseed.go
@@ -723,6 +723,19 @@ func (p *Preseed) Parse(s *service.Handler, c *initConfig) (map[string]InitSyste
 			}
 		}
 
+		if c.bootstrap {
+			osdHosts := 0
+			for _, system := range c.systems {
+				if len(system.MicroCephDisks) > 0 {
+					osdHosts++
+				}
+			}
+
+			if osdHosts < RecommendedOSDHosts {
+				fmt.Printf("Warning: OSD host count is less than %d. Distributed storage is not fault-tolerant\n", RecommendedOSDHosts)
+			}
+		}
+
 		for _, filter := range p.Storage.Local {
 			// No need to check filters anymore if each machine has a disk.
 			if len(zfsMachines) == len(c.systems) {

--- a/cmd/microcloud/main_init_preseed.go
+++ b/cmd/microcloud/main_init_preseed.go
@@ -593,6 +593,13 @@ func (p *Preseed) Parse(s *service.Handler, c *initConfig) (map[string]InitSyste
 				directLocal = sys.Storage.Local
 				directCeph = sys.Storage.Ceph
 			}
+
+			for _, disk := range directCeph {
+				_, err := os.Stat(disk.Path)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to find specified disk path: %w", err)
+				}
+			}
 		}
 
 		// Setup directly specified disks for ZFS pool.

--- a/test/main.sh
+++ b/test/main.sh
@@ -220,6 +220,7 @@ run_basic_tests() {
   run_test test_reuse_cluster "reuse_cluster"
   run_test test_auto "auto"
   run_test test_remove_cluster_member "remove_cluster_member"
+  run_test test_non_ha "non_ha"
 }
 
 run_recover_tests() {

--- a/test/suites/add.sh
+++ b/test/suites/add.sh
@@ -155,7 +155,6 @@ test_add_interactive() {
   export ZFS_WIPE="yes"
   export SETUP_CEPH="yes"
   export CEPH_WIPE="yes"
-  export IGNORE_CEPH_NETWORKING="yes"
   export CEPH_ENCRYPT="no"
   export SETUP_OVN="yes"
   export OVN_FILTER="enp6s0"
@@ -191,7 +190,6 @@ test_add_interactive() {
   export SETUP_ZFS="yes"
   export ZFS_FILTER="lxd_disk1"
   export ZFS_WIPE="yes"
-  export IGNORE_CEPH_NETWORKING="yes"
   microcloud_interactive | lxc exec micro01 -- sh -c "microcloud add > out"
   lxc exec micro01 -- tail -1 out | grep "MicroCloud is ready" -q
 

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -658,20 +658,20 @@ _test_case() {
 
     microcloud_internal_net_addr="$(ip_config_to_netaddr lxdbr0)"
 
-    LOOKUP_IFACE="enp5s0" # filter string for the lookup interface table.
-    LIMIT_SUBNET="yes" # (yes/no) input for limiting lookup of systems to the above subnet.
-    CEPH_CLUSTER_NETWORK="${microcloud_internal_net_addr}"
+    export LOOKUP_IFACE="enp5s0" # filter string for the lookup interface table.
+    export LIMIT_SUBNET="yes" # (yes/no) input for limiting lookup of systems to the above subnet.
+    export CEPH_CLUSTER_NETWORK="${microcloud_internal_net_addr}"
 
-    EXPECT_PEERS="$((num_systems - 1))"
+    export EXPECT_PEERS="$((num_systems - 1))"
 
     if [ "${num_disks}" -gt 0 ] ; then
       if [ -z "${force_no_zfs}" ]; then
-        SETUP_ZFS="yes"
-        ZFS_FILTER="disk1"
-        ZFS_WIPE="yes"
+        export SETUP_ZFS="yes"
+        export ZFS_FILTER="disk1"
+        export ZFS_WIPE="yes"
         expected_zfs_disk="disk1"
       else
-        SETUP_ZFS="no"
+        export SETUP_ZFS="no"
       fi
     fi
 
@@ -680,10 +680,10 @@ _test_case() {
       if [ "${num_disks}" = 1 ] && [ -z "${force_no_zfs}" ] ; then
         echo "Insufficient disks"
       elif [ -z "${force_no_ceph}" ]; then
-        SETUP_CEPH="yes"
-        SETUP_CEPHFS="yes"
-        CEPH_WIPE="yes"
-        CEPH_ENCRYPT="no"
+        export SETUP_CEPH="yes"
+        export SETUP_CEPHFS="yes"
+        export CEPH_WIPE="yes"
+        export CEPH_ENCRYPT="no"
         expected_ceph_disks="${num_disks}"
         if [ -n "${expected_zfs_disk}" ]; then
           expected_ceph_disks="$((num_disks - 1))"
@@ -693,25 +693,25 @@ _test_case() {
           expected_cephfs=1
         fi
       else
-        SETUP_CEPH="no"
+        export SETUP_CEPH="no"
       fi
     fi
 
     if [ "${num_ifaces}" -gt 0 ] && [ "${num_systems}" -ge 3 ] ; then
       if [ -z "${force_no_ovn}" ] ; then
-        SETUP_OVN="yes"
+        export SETUP_OVN="yes"
 
         # Always pick the first available interface.
-        OVN_FILTER="enp6s0"
-        IPV4_SUBNET="10.1.123.1/24"
-        IPV4_START="10.1.123.100"
-        IPV4_END="10.1.123.254"
-        IPV6_SUBNET="fd42:1:1234:1234::1/64"
-        DNS_ADDRESSES="10.1.123.1,8.8.8.8"
+        export OVN_FILTER="enp6s0"
+        export IPV4_SUBNET="10.1.123.1/24"
+        export IPV4_START="10.1.123.100"
+        export IPV4_END="10.1.123.254"
+        export IPV6_SUBNET="fd42:1:1234:1234::1/64"
+        export DNS_ADDRESSES="10.1.123.1,8.8.8.8"
 
         expected_ovn_iface="enp6s0"
       else
-        SETUP_OVN="no"
+        export SETUP_OVN="no"
       fi
     fi
 

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -1170,6 +1170,7 @@ storage:
       wipe: true
   ceph:
     - find: device_id == *lxd_disk2
+      find_min: 3
       wipe: true
   cephfs: true
 EOF

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -900,7 +900,7 @@ test_disk_mismatch() {
   export ZFS_WIPE="yes"
   export SETUP_CEPH="yes"
   export SETUP_CEPHFS="yes"
-  export CEPH_WARNING="yes"
+  export CEPH_MISSING_DISKS="yes"
   export CEPH_WIPE="yes"
   export CEPH_ENCRYPT="no"
   export SETUP_OVN="no"


### PR DESCRIPTION
Depends on #367 

Allows setting up remote `ceph` storage with fewer than 3 systems supplying disks.

With interactive init, when selecting disks for Ceph, a warning will be displayed indicating the setup is not fault-tolerant:
```
Disk configuration does not meet recommendations for fault tolerance. At least 3 systems must supply disks.
Retry selecting disks? (yes/no) [default=yes]:
```

After all members have joined the cluster, we verify that the spread of OSDs is at least 3, and if it is not, then we update all pool sizes and set the default OSD replication factor. 

For preseed, both OVN and Ceph setup no longer require 3 systems. Some small changes were made to the disk filtering logic, namely that `find_min` will default to 1 for ZFS storage since we can verify that all systems supply a disk. For Ceph, `find_min` must be explicitly set because we can't know if the user actually wants a non-HA setup, or if they are okay with some systems being fully remote for ceph.

