### PR TITLE
Status

### DIFF
--- a/api/status.go
+++ b/api/status.go
@@ -1,0 +1,288 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/lxd/lxd/util"
+	lxdAPI "github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/logger"
+	cephTypes "github.com/canonical/microceph/microceph/api/types"
+	cephClient "github.com/canonical/microceph/microceph/client"
+	microClient "github.com/canonical/microcluster/v2/client"
+	"github.com/canonical/microcluster/v2/rest"
+	microTypes "github.com/canonical/microcluster/v2/rest/types"
+	"github.com/canonical/microcluster/v2/state"
+	ovnTypes "github.com/canonical/microovn/microovn/api/types"
+	ovnClient "github.com/canonical/microovn/microovn/client"
+
+	"github.com/canonical/microcloud/microcloud/api/types"
+	"github.com/canonical/microcloud/microcloud/client"
+	"github.com/canonical/microcloud/microcloud/service"
+)
+
+// StatusCmd represents the /1.0/status API on MicroCloud.
+var StatusCmd = func(sh *service.Handler) rest.Endpoint {
+	return rest.Endpoint{
+		Name: "status",
+		Path: "status",
+
+		Get: rest.EndpointAction{Handler: statusGet(sh), ProxyTarget: true},
+	}
+}
+
+func statusGet(sh *service.Handler) endpointHandler {
+	// statusMu is used to synchronize map writes to the returned status information, as we populate cluster members for each service concurrently.
+	var statusMu sync.Mutex
+
+	return func(s state.State, r *http.Request) response.Response {
+		statuses := []types.Status{}
+
+		if !microClient.IsNotification(r) {
+			cluster, err := s.Cluster(true)
+			if err != nil {
+				return response.SmartError(err)
+			}
+
+			err = cluster.Query(r.Context(), true, func(ctx context.Context, c *microClient.Client) error {
+				memberStatuses, err := client.GetStatus(ctx, c)
+				if err != nil {
+					logger.Error("Failed to get status for cluster member", logger.Ctx{"error": err, "address": c.URL()})
+
+					return nil
+				}
+
+				statuses = append(statuses, memberStatuses...)
+
+				return nil
+			})
+			if err != nil {
+				return response.SmartError(err)
+			}
+		}
+
+		status := &types.Status{
+			Name:         sh.Name,
+			Address:      sh.Address,
+			Clusters:     make(map[types.ServiceType][]microTypes.ClusterMember, len(sh.Services)),
+			OSDs:         []cephTypes.Disk{},
+			CephServices: []cephTypes.Service{},
+			OVNServices:  []ovnTypes.Service{},
+		}
+
+		err := sh.RunConcurrent("", "", func(s service.Service) error {
+			switch s.Type() {
+			case types.LXD:
+				clusterMembers, err := lxdStatus(r.Context(), s)
+				if err != nil {
+					logger.Error("Failed to get service status", logger.Ctx{"type": s.Type(), "name": sh.Name})
+				}
+
+				statusMu.Lock()
+				status.Clusters[s.Type()] = clusterMembers
+				statusMu.Unlock()
+			case types.MicroCeph:
+				clusterMembers, osds, cephServices, err := cephStatus(r.Context(), s)
+				if err != nil {
+					logger.Error("Failed to get service status", logger.Ctx{"type": s.Type(), "name": sh.Name})
+				}
+
+				status.OSDs = osds
+				status.CephServices = cephServices
+
+				statusMu.Lock()
+				status.Clusters[s.Type()] = clusterMembers
+				statusMu.Unlock()
+			case types.MicroOVN:
+				clusterMembers, ovnServices, err := ovnStatus(r.Context(), s)
+				if err != nil {
+					logger.Error("Failed to get service status", logger.Ctx{"type": s.Type(), "name": sh.Name})
+				}
+
+				status.OVNServices = ovnServices
+
+				statusMu.Lock()
+				status.Clusters[s.Type()] = clusterMembers
+				statusMu.Unlock()
+			case types.MicroCloud:
+				microClient, err := s.(*service.CloudService).Client()
+				if err != nil {
+					return err
+				}
+
+				clusterMembers, err := microStatus(r.Context(), microClient, s)
+				if err != nil {
+					logger.Error("Failed to get service status", logger.Ctx{"type": s.Type(), "name": sh.Name})
+				}
+
+				statusMu.Lock()
+				status.Clusters[s.Type()] = clusterMembers
+				statusMu.Unlock()
+			}
+
+			return nil
+		})
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		statuses = append(statuses, *status)
+
+		return response.SyncResponse(true, statuses)
+	}
+}
+
+func cephStatus(ctx context.Context, s service.Service) (clusterMembers []microTypes.ClusterMember, osds []cephTypes.Disk, cephServices []cephTypes.Service, err error) {
+	microClient, err := s.(*service.CephService).Client("")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	clusterMembers, err = microStatus(ctx, microClient, s)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	disks, err := cephClient.GetDisks(ctx, microClient)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	for _, disk := range disks {
+		if disk.Location == s.Name() {
+			if osds == nil {
+				osds = []cephTypes.Disk{}
+			}
+
+			osds = append(osds, disk)
+		}
+	}
+
+	services, err := cephClient.GetServices(ctx, microClient)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	for _, service := range services {
+		if service.Location == s.Name() {
+			if cephServices == nil {
+				cephServices = []cephTypes.Service{}
+			}
+
+			cephServices = append(cephServices, service)
+		}
+	}
+
+	return clusterMembers, osds, cephServices, nil
+}
+
+func ovnStatus(ctx context.Context, s service.Service) (clusterMembers []microTypes.ClusterMember, ovnServices []ovnTypes.Service, err error) {
+	microClient, err := s.(*service.OVNService).Client()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	clusterMembers, err = microStatus(ctx, microClient, s)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	services, err := ovnClient.GetServices(ctx, microClient)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, service := range services {
+		if service.Location == s.Name() {
+			if ovnServices == nil {
+				ovnServices = []ovnTypes.Service{}
+			}
+
+			ovnServices = append(ovnServices, service)
+		}
+	}
+
+	return clusterMembers, ovnServices, nil
+}
+
+func microStatus(ctx context.Context, microClient *microClient.Client, s service.Service) ([]microTypes.ClusterMember, error) {
+	clusterMembers, err := microClient.GetClusterMembers(context.Background())
+	if err != nil && !lxdAPI.StatusErrorCheck(err, http.StatusServiceUnavailable) {
+		return nil, err
+	}
+
+	return clusterMembers, nil
+}
+
+func lxdStatus(ctx context.Context, s service.Service) ([]microTypes.ClusterMember, error) {
+	lxdClient, err := s.(*service.LXDService).Client(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	server, _, err := lxdClient.GetServer()
+	if err != nil {
+		return nil, err
+	}
+
+	var microMembers []microTypes.ClusterMember
+	if server.Environment.ServerClustered {
+		clusterMembers, err := lxdClient.GetClusterMembers()
+		if err != nil {
+			return nil, err
+		}
+
+		certs, err := lxdClient.GetCertificates()
+		if err != nil {
+			return nil, err
+		}
+
+		microMembers = make([]microTypes.ClusterMember, 0, len(clusterMembers))
+		for _, member := range clusterMembers {
+			url, err := url.Parse(member.URL)
+			if err != nil {
+				return nil, err
+			}
+
+			addrPort, err := microTypes.ParseAddrPort(util.CanonicalNetworkAddress(url.Host, service.LXDPort))
+			if err != nil {
+				return nil, err
+			}
+
+			// Microcluster requires a certificate to be specified in types.ClusterMemberLocal.
+			var serverCert *microTypes.X509Certificate
+			for _, cert := range certs {
+				if cert.Type == "server" && cert.Name == member.ServerName {
+					serverCert, err = microTypes.ParseX509Certificate(cert.Certificate)
+					if err != nil {
+						return nil, err
+					}
+				}
+			}
+
+			microMember := microTypes.ClusterMember{
+				ClusterMemberLocal: microTypes.ClusterMemberLocal{
+					Name:        member.ServerName,
+					Address:     addrPort,
+					Certificate: *serverCert,
+				},
+				Role:       strings.Join(member.Roles, ","),
+				Status:     microTypes.MemberStatus(member.Status),
+				Extensions: []string{},
+			}
+
+			// If the status is Online, use the microcluster representation, all other cluster states will be considered invalid and be treated like an offline state.
+			if member.Status == "Online" {
+				microMember.Status = microTypes.MemberOnline
+			}
+
+			microMembers = append(microMembers, microMember)
+		}
+	}
+
+	return microMembers, nil
+}

--- a/api/types/status.go
+++ b/api/types/status.go
@@ -1,0 +1,28 @@
+package types
+
+import (
+	cephTypes "github.com/canonical/microceph/microceph/api/types"
+	microTypes "github.com/canonical/microcluster/v2/rest/types"
+	ovnTypes "github.com/canonical/microovn/microovn/api/types"
+)
+
+// Status is a set of status information from a cluster member.
+type Status struct {
+	// Name represents the cluster name for the member.
+	Name string `json:"name" yaml:"name"`
+
+	// Address represnts the cluster address for the member.
+	Address string `json:"address" yaml:"address"`
+
+	// Clusters is a list of cluster members for each service installed on the member.
+	Clusters map[ServiceType][]microTypes.ClusterMember `json:"clusters" yaml:"clusters"`
+
+	// OSDs is a list of all OSDs local to the member.
+	OSDs cephTypes.Disks `json:"osds" yaml:"osds"`
+
+	// CephServices is a list of all ceph services running on this member.
+	CephServices cephTypes.Services `json:"ceph_services" yaml:"ceph_services"`
+
+	// OVNServices is a list of all ovn services running on this member.
+	OVNServices ovnTypes.Services `json:"ovn_services" yaml:"ovn_services"`
+}

--- a/client/client.go
+++ b/client/client.go
@@ -16,6 +16,20 @@ import (
 	"github.com/canonical/microcloud/microcloud/api/types"
 )
 
+// GetStatus fetches a set of status information for the whole cluster.
+func GetStatus(ctx context.Context, c *client.Client) ([]types.Status, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	var statuses []types.Status
+	err := c.Query(queryCtx, "GET", types.APIVersion, api.NewURL().Path("status"), nil, &statuses)
+	if err != nil {
+		return nil, err
+	}
+
+	return statuses, nil
+}
+
 // StartSession starts a new session and returns the underlying websocket connection.
 func StartSession(ctx context.Context, c *client.Client, role string, sessionTimeout time.Duration) (*websocket.Conn, error) {
 	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)

--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -698,7 +698,7 @@ func (c *initConfig) askRemotePool(sh *service.Handler) error {
 
 			if insufficientDisks {
 				// This error will be printed to STDOUT as a normal message, so it includes a new-line for readability.
-				return fmt.Errorf("Disk configuration does not meet recommendations for fault tolerance. At least %d systems must supply disks.\nContinuing with this configuration will leave MicroCloud susceptible to data loss", RecommendedOSDHosts)
+				return fmt.Errorf("Disk configuration does not meet recommendations for fault tolerance. At least %d systems must supply disks.\nContinuing with this configuration will inhibit MicroCloud's ability to retain data on system failure", RecommendedOSDHosts)
 			}
 
 			return nil

--- a/cmd/microcloud/main.go
+++ b/cmd/microcloud/main.go
@@ -90,6 +90,9 @@ EOF`)
 	var cmdService = cmdServices{common: &commonCmd}
 	app.AddCommand(cmdService.Command())
 
+	var cmdStatus = cmdStatus{common: &commonCmd}
+	app.AddCommand(cmdStatus.Command())
+
 	var cmdPeers = cmdClusterMembers{common: &commonCmd}
 	app.AddCommand(cmdPeers.Command())
 

--- a/cmd/microcloud/main.go
+++ b/cmd/microcloud/main.go
@@ -123,6 +123,8 @@ EOF`)
 
 	app.InitDefaultHelpCmd()
 
+	app.SetErr(&tui.ColorErr{})
+
 	err := app.Execute()
 	if err != nil {
 		os.Exit(1)

--- a/cmd/microcloud/main.go
+++ b/cmd/microcloud/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/spf13/cobra"
 
+	"github.com/canonical/microcloud/microcloud/cmd/tui"
 	"github.com/canonical/microcloud/microcloud/version"
 )
 
@@ -21,6 +22,7 @@ type CmdControl struct {
 	FlagHelp          bool
 	FlagVersion       bool
 	FlagMicroCloudDir string
+	FlagNoColor       bool
 
 	asker cli.Asker
 }
@@ -34,6 +36,11 @@ func main() {
 
 	// common flags.
 	commonCmd := CmdControl{asker: cli.NewAsker(bufio.NewReader(os.Stdin), logger.Log)}
+
+	noColor := os.Getenv("NO_COLOR")
+	if noColor != "" {
+		tui.DisableColors()
+	}
 
 	useTestConsole := os.Getenv("TEST_CONSOLE")
 	if useTestConsole == "1" {
@@ -64,11 +71,17 @@ EOF`)
 		Version:           version.Version,
 		SilenceUsage:      true,
 		CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if commonCmd.FlagNoColor {
+				tui.DisableColors()
+			}
+		},
 	}
 
 	app.PersistentFlags().StringVar(&commonCmd.FlagMicroCloudDir, "state-dir", "", "Path to store MicroCloud state information"+"``")
 	app.PersistentFlags().BoolVarP(&commonCmd.FlagHelp, "help", "h", false, "Print help")
 	app.PersistentFlags().BoolVar(&commonCmd.FlagVersion, "version", false, "Print version number")
+	app.PersistentFlags().BoolVar(&commonCmd.FlagNoColor, "no-color", false, "Disable colorization of the CLI")
 
 	app.SetVersionTemplate("{{.Version}}\n")
 

--- a/cmd/microcloud/services.go
+++ b/cmd/microcloud/services.go
@@ -83,6 +83,7 @@ func (c *cmdServiceList) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	cfg := initConfig{
+		autoSetup: true,
 		bootstrap: false,
 		common:    c.common,
 		asker:     &c.common.asker,

--- a/cmd/microcloud/status.go
+++ b/cmd/microcloud/status.go
@@ -1,0 +1,458 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/canonical/microcluster/v2/microcluster"
+	microTypes "github.com/canonical/microcluster/v2/rest/types"
+	"github.com/spf13/cobra"
+
+	"github.com/canonical/microcloud/microcloud/api"
+	"github.com/canonical/microcloud/microcloud/api/types"
+	"github.com/canonical/microcloud/microcloud/client"
+	"github.com/canonical/microcloud/microcloud/cmd/tui"
+	"github.com/canonical/microcloud/microcloud/service"
+)
+
+// Warning represents a warning message with a severity level.
+type Warning struct {
+	Level   StatusLevel
+	Message string
+}
+
+// Warnings is a list of warnings.
+type Warnings []Warning
+
+// Status returns the overall status of the warning list.
+// If there are any Error level warnings, the status will be error.
+// Otherwise, if there are any Warn level warnings, the status will be warn.
+// Finally, the status will be Success, implying no warnings.
+func (w Warnings) Status() StatusLevel {
+	if len(w) == 0 {
+		return Success
+	}
+
+	for _, warning := range w {
+		if warning.Level == Error {
+			return Error
+		}
+	}
+
+	return Warn
+}
+
+// StatusLevel represents the severity level of warnings.
+type StatusLevel int
+
+const (
+	// Success represents a lack of warnings.
+	Success StatusLevel = iota
+
+	// Warn represents a medium severity warning.
+	Warn
+
+	// Error represents a critical warning.
+	Error
+)
+
+// Symbol returns the single-character symbol representing the StatusLevel, color coded.
+func (s StatusLevel) Symbol() string {
+	switch s {
+	case Success:
+		return tui.SuccessSymbol()
+	case Warn:
+		return tui.WarningSymbol()
+	case Error:
+		return tui.ErrorSymbol()
+	}
+
+	return ""
+}
+
+// Symbol returns a word representing the StatusLevel, color coded.
+func (s StatusLevel) String() string {
+	switch s {
+	case Success:
+		return tui.SuccessColor("HEALTHY", true)
+	case Warn:
+		return tui.WarningColor("WARNING", true)
+	case Error:
+		return tui.ErrorColor("ERROR", true)
+	}
+
+	return ""
+}
+
+type cmdStatus struct {
+	common *CmdControl
+}
+
+func (c *cmdStatus) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Deployment status with configuration warnings",
+		RunE:  c.Run,
+	}
+
+	return cmd
+}
+
+func (c *cmdStatus) Run(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		return cmd.Help()
+	}
+
+	cloudApp, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagMicroCloudDir})
+	if err != nil {
+		return err
+	}
+
+	status, err := cloudApp.Status(context.Background())
+	if err != nil {
+		return fmt.Errorf("Failed to get MicroCloud status: %w", err)
+	}
+
+	if !status.Ready {
+		return fmt.Errorf("MicroCloud is uninitialized, run 'microcloud init' first")
+	}
+
+	cfg := initConfig{
+		autoSetup: true,
+		bootstrap: false,
+		common:    c.common,
+		asker:     &c.common.asker,
+		systems:   map[string]InitSystem{},
+		state:     map[string]service.SystemInformation{},
+	}
+
+	cfg.name = status.Name
+	cfg.address = status.Address.Addr().String()
+
+	services := []types.ServiceType{types.MicroCloud, types.LXD}
+	optionalServices := map[types.ServiceType]string{
+		types.MicroCeph: api.MicroCephDir,
+		types.MicroOVN:  api.MicroOVNDir,
+	}
+
+	services, err = cfg.askMissingServices(services, optionalServices)
+	if err != nil {
+		return err
+	}
+
+	// Instantiate a handler for the services.
+	sh, err := service.NewHandler(status.Name, status.Address.Addr().String(), c.common.FlagMicroCloudDir, services...)
+	if err != nil {
+		return err
+	}
+
+	cloudClient, err := sh.Services[types.MicroCloud].(*service.CloudService).Client()
+	if err != nil {
+		return err
+	}
+
+	// Query the status API for the cluster.
+	statuses, err := client.GetStatus(context.Background(), cloudClient)
+	if err != nil {
+		return err
+	}
+
+	// compile all warning messages.
+	warnings := compileWarnings(cfg.name, statuses)
+
+	// Print the warning summary, and all warnings.
+	fmt.Println("")
+	fmt.Printf(" %s: %s\n", tui.SetColor(tui.Bright, "Status", true), warnings.Status().String())
+	fmt.Println("")
+	for _, w := range warnings {
+		fmt.Printf(" %s %s %s\n", tui.SetColor(tui.Bright, "┃", true), w.Level.Symbol(), w.Message)
+	}
+
+	if len(warnings) > 0 {
+		fmt.Println("")
+	}
+
+	headers := []string{"Name", "Address", "OSDs", "MicroCeph Units", "MicroOVN Units", "Status"}
+
+	statusByName := make(map[string]types.Status, len(statuses))
+	var localStatus types.Status
+	for _, s := range statuses {
+		if s.Name == cfg.name {
+			localStatus = s
+		}
+
+		statusByName[s.Name] = s
+	}
+
+	// Format and colorize cells of the table.
+	rows := make([][]string, 0, len(statuses))
+	for _, s := range statuses {
+		rows = append(rows, formatStatusRow(localStatus, s))
+	}
+
+	for _, member := range localStatus.Clusters[types.MicroCloud] {
+		_, ok := statusByName[member.Name]
+		if ok {
+			continue
+		}
+
+		status := types.Status{
+			Name:     member.Name,
+			Address:  member.Address.Addr().String(),
+			Clusters: localStatus.Clusters,
+		}
+
+		rows = append(rows, formatStatusRow(localStatus, status))
+	}
+
+	// Sort the rows by the Name column.
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i][0] < rows[j][0]
+	})
+
+	// Print the table.
+	fmt.Println(tui.NewTable(headers, rows))
+
+	return nil
+}
+
+// compileWarnings returns a set of warnings based on the given set of statuses. The name supplied should be the local cluster name.
+func compileWarnings(name string, statuses []types.Status) Warnings {
+	// Systems that exist in other clusters but not in MicroCloud.
+	unmanagedSystems := map[types.ServiceType]map[string]bool{}
+
+	// Systems that exist in MicroCloud, but not other clusters.
+	orphanedSystems := map[types.ServiceType]map[string]bool{}
+
+	// Services that are uninitialized on a system.
+	uninstalledServices := map[types.ServiceType][]string{}
+
+	// Services undergoing schema/API upgrades.
+	upgradingServices := map[types.ServiceType]bool{}
+
+	// Systems that are offline on at least one service.
+	offlineSystems := map[string][]string{}
+
+	osdsConfigured := false
+	clusterSize := 0
+	osdCount := 0
+
+	for _, s := range statuses {
+		if s.Name == name {
+			clusterSize = len(s.Clusters[types.MicroCloud])
+			for service, clusterMembers := range s.Clusters {
+				for _, member := range clusterMembers {
+					if member.Status == microTypes.MemberNeedsUpgrade || member.Status == microTypes.MemberUpgrading {
+						upgradingServices[service] = true
+					} else if member.Status != microTypes.MemberOnline {
+						if offlineSystems[member.Name] == nil {
+							offlineSystems[member.Name] = []string{}
+						}
+
+						offlineSystems[member.Name] = append(offlineSystems[member.Name], string(service))
+					}
+				}
+			}
+		}
+
+		osdCount = osdCount + len(s.OSDs)
+		allServices := []types.ServiceType{types.LXD, types.MicroCeph, types.MicroOVN, types.MicroCloud}
+		cloudMembers := make(map[string]bool, len(s.Clusters[types.MicroCloud]))
+		for _, member := range s.Clusters[types.MicroCloud] {
+			cloudMembers[member.Name] = true
+		}
+
+		for _, service := range allServices {
+			_, ok := s.Clusters[service]
+			if !ok {
+				if uninstalledServices[service] == nil {
+					uninstalledServices[service] = []string{}
+				}
+
+				uninstalledServices[service] = append(uninstalledServices[service], s.Name)
+			}
+
+			if service == types.MicroCloud || s.Name != name {
+				continue
+			}
+
+			for _, member := range s.Clusters[service] {
+				if !cloudMembers[member.Name] {
+					if unmanagedSystems[service] == nil {
+						unmanagedSystems[service] = map[string]bool{}
+					}
+
+					unmanagedSystems[service][member.Name] = true
+				}
+			}
+
+			if len(s.Clusters[service]) > 0 {
+				clusterMap := make(map[string]bool, len(s.Clusters[service]))
+				for _, member := range s.Clusters[service] {
+					clusterMap[member.Name] = true
+				}
+
+				for name := range cloudMembers {
+					if !clusterMap[name] {
+						if orphanedSystems[service] == nil {
+							orphanedSystems[service] = map[string]bool{}
+						}
+
+						orphanedSystems[service][name] = true
+					}
+				}
+			}
+		}
+
+		if osdCount > 0 && len(s.Clusters[types.MicroCeph]) > 0 {
+			osdsConfigured = true
+		}
+	}
+
+	// Format the actual warnings based on the collected data.
+	warnings := Warnings{}
+	if clusterSize < 3 {
+		tmpl := tui.Fmt{Arg: "%s: %d systems are required for effective fault tolerance"}
+		msg := tui.Printf(tmpl,
+			tui.Fmt{Color: tui.Red, Arg: "Reliability risk", Bold: true},
+			tui.Fmt{Color: tui.Bright, Arg: 3, Bold: true},
+		)
+
+		warnings = append(warnings, Warning{Level: Warn, Message: msg})
+	}
+
+	if osdCount < 3 && osdsConfigured {
+		tmpl := tui.Fmt{Arg: "%s: MicroCeph OSD replication recommends at least %d disks across %d systems"}
+		msg := tui.Printf(tmpl,
+			tui.Fmt{Color: tui.Red, Arg: "Data loss risk", Bold: true},
+			tui.Fmt{Color: tui.Bright, Arg: 3, Bold: true},
+			tui.Fmt{Color: tui.Bright, Arg: 3, Bold: true},
+		)
+
+		warnings = append(warnings, Warning{Level: Warn, Message: msg})
+	}
+
+	if len(uninstalledServices[types.LXD]) > 0 {
+		tmpl := tui.Fmt{Arg: "LXD is not found on %s"}
+		msg := tui.Printf(tmpl, tui.Fmt{Color: tui.Bright, Arg: strings.Join(uninstalledServices[types.LXD], ", "), Bold: true})
+		warnings = append(warnings, Warning{Level: Error, Message: msg})
+	}
+
+	for service, systems := range orphanedSystems {
+		list := make([]string, 0, len(systems))
+		for name := range systems {
+			list = append(list, name)
+		}
+
+		tmpl := tui.Fmt{Arg: "MicroCloud members not found in %s: %s"}
+		msg := tui.Printf(tmpl,
+			tui.Fmt{Color: tui.Bright, Arg: service, Bold: true},
+			tui.Fmt{Color: tui.Bright, Bold: true, Arg: strings.Join(list, ", ")})
+		warnings = append(warnings, Warning{Level: Error, Message: msg})
+	}
+
+	if !osdsConfigured && len(uninstalledServices[types.MicroCeph]) < clusterSize {
+		warnings = append(warnings, Warning{Level: Warn, Message: "No MicroCeph OSDs configured"})
+	}
+
+	for name, services := range offlineSystems {
+		tmpl := tui.Fmt{Arg: "%s is not available on %s"}
+		msg := tui.Printf(tmpl, tui.Fmt{Color: tui.Bright, Bold: true, Arg: strings.Join(services, ", ")}, tui.Fmt{Color: tui.Bright, Bold: true, Arg: name})
+		warnings = append(warnings, Warning{Level: Error, Message: msg})
+	}
+
+	for service := range upgradingServices {
+		tmpl := tui.Fmt{Arg: "%s upgrade in progress"}
+		msg := tui.Printf(tmpl, tui.Fmt{Color: tui.Bright, Bold: true, Arg: service})
+		warnings = append(warnings, Warning{Level: Warn, Message: msg})
+	}
+
+	for service, names := range uninstalledServices {
+		if service == types.LXD || service == types.MicroCloud {
+			continue
+		}
+
+		tmpl := tui.Fmt{Arg: "%s is not found on %s"}
+		msg := tui.Printf(tmpl,
+			tui.Fmt{Color: tui.Bright, Bold: true, Arg: service},
+			tui.Fmt{Color: tui.Bright, Bold: true, Arg: strings.Join(names, ", ")})
+		warnings = append(warnings, Warning{Level: Warn, Message: msg})
+	}
+
+	for service, systems := range unmanagedSystems {
+		list := make([]string, 0, len(systems))
+		for name := range systems {
+			list = append(list, name)
+		}
+
+		tmpl := tui.Fmt{Arg: "Found %s systems not managed by MicroCloud: %s"}
+		msg := tui.Printf(tmpl,
+			tui.Fmt{Color: tui.Bright, Bold: true, Arg: service},
+			tui.Fmt{Color: tui.Bright, Bold: true, Arg: strings.Join(list, ",")})
+		warnings = append(warnings, Warning{Level: Warn, Message: msg})
+	}
+
+	return warnings
+}
+
+// formatStatusRow formats the given status data for a cluster member into a row of the table.
+// Also takes the local system's status which will be used as the source of truth for cluster member responsiveness.
+func formatStatusRow(localStatus types.Status, s types.Status) []string {
+	osds := tui.WarningColor("0", false)
+	if len(s.OSDs) > 0 {
+		osds = strconv.Itoa(len(s.OSDs))
+	}
+
+	cephServices := tui.WarningColor("-", false)
+
+	if len(s.CephServices) > 0 {
+		services := make([]string, 0, len(s.CephServices))
+		for _, service := range s.CephServices {
+			services = append(services, service.Service)
+		}
+
+		cephServices = strings.Join(services, ",")
+	}
+
+	ovnServices := tui.WarningColor("-", false)
+	if len(s.OVNServices) > 0 {
+		services := make([]string, 0, len(s.OVNServices))
+		for _, service := range s.OVNServices {
+			services = append(services, service.Service)
+		}
+
+		ovnServices = strings.Join(services, ",")
+	}
+
+	if len(s.Clusters[types.MicroOVN]) == 0 {
+		ovnServices = tui.ErrorColor("-", false)
+	}
+
+	if len(s.Clusters[types.MicroCeph]) == 0 {
+		cephServices = tui.ErrorColor("-", false)
+		osds = tui.ErrorColor("-", false)
+	}
+
+	status := tui.SuccessColor(string(microTypes.MemberOnline), false)
+	for _, members := range localStatus.Clusters {
+		for _, member := range members {
+			if member.Name != s.Name {
+				continue
+			}
+
+			// Only set the service status to upgrading if no other member has a more urgent status.
+			if member.Status == microTypes.MemberUpgrading || member.Status == microTypes.MemberNeedsUpgrade {
+				if status == tui.SuccessColor(string(microTypes.MemberOnline), false) {
+					status = tui.WarningColor(string(member.Status), false)
+				}
+			} else if member.Status != microTypes.MemberOnline {
+				status = tui.ErrorColor(string(member.Status), false)
+			}
+		}
+	}
+
+	return []string{s.Name, s.Address, osds, cephServices, ovnServices, status}
+}

--- a/cmd/microcloud/status_test.go
+++ b/cmd/microcloud/status_test.go
@@ -1,0 +1,492 @@
+package main
+
+import (
+	"testing"
+
+	cephTypes "github.com/canonical/microceph/microceph/api/types"
+	microTypes "github.com/canonical/microcluster/v2/rest/types"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/canonical/microcloud/microcloud/api/types"
+)
+
+type statusSuite struct {
+	suite.Suite
+}
+
+func TestStatusSuite(t *testing.T) {
+	suite.Run(t, new(statusSuite))
+}
+
+func (s *statusSuite) Test_statusWarnings() {
+	genMember := func(name string, status microTypes.MemberStatus) microTypes.ClusterMember {
+		return microTypes.ClusterMember{
+			ClusterMemberLocal: microTypes.ClusterMemberLocal{Name: name},
+			Status:             status,
+		}
+	}
+
+	cases := []struct {
+		desc             string
+		statuses         []types.Status
+		expectedWarnings Warnings
+		expectedStatus   map[string]microTypes.MemberStatus
+	}{
+		{
+			desc: "Single node MicroCloud with LXD",
+			statuses: []types.Status{
+				{
+					Name:    "micro01",
+					Address: "10.0.0.101",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline)},
+					},
+				},
+			},
+			expectedWarnings: []Warning{
+				{Level: Warn, Message: "Reliability risk: 3 systems are required for effective fault tolerance"},
+				{Level: Warn, Message: "MicroOVN is not found on micro01"},
+				{Level: Warn, Message: "MicroCeph is not found on micro01"},
+			},
+			expectedStatus: map[string]microTypes.MemberStatus{"micro01": microTypes.MemberOnline, "micro02": microTypes.MemberOnline},
+		},
+		{
+			desc: "2 node MicroCloud with LXD",
+			statuses: []types.Status{
+				{
+					Name:    "micro01",
+					Address: "10.0.0.101",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+					},
+				},
+				{
+					Name:    "micro02",
+					Address: "10.0.0.102",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+					},
+				},
+			},
+			expectedWarnings: []Warning{
+				{Level: Warn, Message: "Reliability risk: 3 systems are required for effective fault tolerance"},
+				{Level: Warn, Message: "MicroOVN is not found on micro01, micro02"},
+				{Level: Warn, Message: "MicroCeph is not found on micro01, micro02"},
+			},
+			expectedStatus: map[string]microTypes.MemberStatus{"micro01": microTypes.MemberOnline, "micro02": microTypes.MemberOnline},
+		},
+		{
+			desc: "2 node MicroCloud with LXD, member is not online",
+			statuses: []types.Status{
+				{
+					Name:    "micro01",
+					Address: "10.0.0.101",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline), genMember("micro02", "some unknown status")},
+					},
+				},
+				{
+					Name:    "micro02",
+					Address: "10.0.0.102",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+					},
+				},
+			},
+			expectedWarnings: []Warning{
+				{Level: Warn, Message: "Reliability risk: 3 systems are required for effective fault tolerance"},
+				{Level: Warn, Message: "MicroOVN is not found on micro01, micro02"},
+				{Level: Warn, Message: "MicroCeph is not found on micro01, micro02"},
+				{Level: Error, Message: "LXD is not available on micro02"},
+			},
+			expectedStatus: map[string]microTypes.MemberStatus{"micro01": microTypes.MemberOnline, "micro02": "some unknown status"},
+		},
+		{
+			desc: "2 node MicroCloud with LXD, member is upgrading",
+			statuses: []types.Status{
+				{
+					Name:    "micro01",
+					Address: "10.0.0.101",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberNeedsUpgrade)},
+					},
+				},
+				{
+					Name:    "micro02",
+					Address: "10.0.0.102",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+					},
+				},
+			},
+			expectedWarnings: []Warning{
+				{Level: Warn, Message: "Reliability risk: 3 systems are required for effective fault tolerance"},
+				{Level: Warn, Message: "MicroOVN is not found on micro01, micro02"},
+				{Level: Warn, Message: "MicroCeph is not found on micro01, micro02"},
+				{Level: Warn, Message: "LXD upgrade in progress"},
+			},
+			expectedStatus: map[string]microTypes.MemberStatus{"micro01": microTypes.MemberOnline, "micro02": microTypes.MemberNeedsUpgrade},
+		},
+		{
+			desc: "2 node MicroCloud with LXD, offline node and upgrading node in the same cluster",
+			statuses: []types.Status{
+				{
+					Name:    "micro01",
+					Address: "10.0.0.101",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", "some unknown status"), genMember("micro02", microTypes.MemberNeedsUpgrade)},
+					},
+				},
+				{
+					Name:    "micro02",
+					Address: "10.0.0.102",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+					},
+				},
+			},
+			expectedWarnings: []Warning{
+				{Level: Warn, Message: "Reliability risk: 3 systems are required for effective fault tolerance"},
+				{Level: Warn, Message: "MicroOVN is not found on micro01, micro02"},
+				{Level: Warn, Message: "MicroCeph is not found on micro01, micro02"},
+				{Level: Error, Message: "LXD is not available on micro01"},
+				{Level: Warn, Message: "LXD upgrade in progress"},
+			},
+			expectedStatus: map[string]microTypes.MemberStatus{"micro01": "some unknown status", "micro02": microTypes.MemberNeedsUpgrade},
+		},
+		{
+			desc: "2 node MicroCloud with LXD, offline node and upgrading node across services",
+			statuses: []types.Status{
+				{
+					Name:    "micro01",
+					Address: "10.0.0.101",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberNeedsUpgrade), genMember("micro02", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", "some unknown status"), genMember("micro02", microTypes.MemberOnline)},
+					},
+				},
+				{
+					Name:    "micro02",
+					Address: "10.0.0.102",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+					},
+				},
+			},
+			expectedWarnings: []Warning{
+				{Level: Warn, Message: "Reliability risk: 3 systems are required for effective fault tolerance"},
+				{Level: Warn, Message: "MicroOVN is not found on micro01, micro02"},
+				{Level: Warn, Message: "MicroCeph is not found on micro01, micro02"},
+				{Level: Error, Message: "LXD is not available on micro01"},
+				{Level: Warn, Message: "MicroCloud upgrade in progress"},
+			},
+			expectedStatus: map[string]microTypes.MemberStatus{"micro01": "some unknown status", "micro02": microTypes.MemberOnline},
+		},
+		{
+			desc: "2 node MicroCloud with LXD, one node removed from LXD",
+			statuses: []types.Status{
+				{
+					Name:    "micro01",
+					Address: "10.0.0.101",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline)},
+					},
+				},
+				{
+					Name:    "micro02",
+					Address: "10.0.0.102",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+					},
+				},
+			},
+			expectedWarnings: []Warning{
+				{Level: Warn, Message: "Reliability risk: 3 systems are required for effective fault tolerance"},
+				{Level: Error, Message: "LXD is not found on micro02"},
+				{Level: Error, Message: "MicroCloud members not found in LXD: micro02"},
+				{Level: Warn, Message: "MicroOVN is not found on micro01, micro02"},
+				{Level: Warn, Message: "MicroCeph is not found on micro01, micro02"},
+			},
+			expectedStatus: map[string]microTypes.MemberStatus{"micro01": microTypes.MemberOnline, "micro02": microTypes.MemberOnline},
+		},
+		{
+			desc: "2 node MicroCloud with LXD and MicroCeph, one node removed from MicroCeph",
+			statuses: []types.Status{
+				{
+					Name:    "micro01",
+					Address: "10.0.0.101",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.MicroCeph:  {genMember("micro01", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+					},
+				},
+				{
+					Name:    "micro02",
+					Address: "10.0.0.102",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+					},
+				},
+			},
+			expectedWarnings: []Warning{
+				{Level: Warn, Message: "Reliability risk: 3 systems are required for effective fault tolerance"},
+				{Level: Error, Message: "MicroCloud members not found in MicroCeph: micro02"},
+				{Level: Warn, Message: "MicroOVN is not found on micro01, micro02"},
+				{Level: Warn, Message: "No MicroCeph OSDs configured"},
+				{Level: Warn, Message: "MicroCeph is not found on micro02"},
+			},
+			expectedStatus: map[string]microTypes.MemberStatus{"micro01": microTypes.MemberOnline, "micro02": microTypes.MemberOnline},
+		},
+		{
+			desc: "2 node MicroCloud with LXD and MicroCeph, no OSDs",
+			statuses: []types.Status{
+				{
+					Name:    "micro01",
+					Address: "10.0.0.101",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.MicroCeph:  {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+					},
+				},
+				{
+					Name:    "micro02",
+					Address: "10.0.0.102",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.MicroCeph:  {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+					},
+				},
+			},
+			expectedWarnings: []Warning{
+				{Level: Warn, Message: "Reliability risk: 3 systems are required for effective fault tolerance"},
+				{Level: Warn, Message: "MicroOVN is not found on micro01, micro02"},
+				{Level: Warn, Message: "No MicroCeph OSDs configured"},
+			},
+		},
+		{
+			desc: "2 node MicroCloud with LXD and MicroCeph, too few OSDs",
+			statuses: []types.Status{
+				{
+					Name:    "micro01",
+					Address: "10.0.0.101",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.MicroCeph:  {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+					},
+				},
+				{
+					Name:    "micro02",
+					Address: "10.0.0.102",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.MicroCeph:  {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+					},
+					OSDs: cephTypes.Disks{{OSD: 0}},
+				},
+			},
+			expectedWarnings: []Warning{
+				{Level: Warn, Message: "Reliability risk: 3 systems are required for effective fault tolerance"},
+				{Level: Warn, Message: "Data loss risk: MicroCeph OSD replication recommends at least 3 disks across 3 systems"},
+				{Level: Warn, Message: "MicroOVN is not found on micro01, micro02"},
+			},
+		},
+		{
+			desc: "2 node MicroCloud with LXD and MicroCeph, sufficient OSDs",
+			statuses: []types.Status{
+				{
+					Name:    "micro01",
+					Address: "10.0.0.101",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.MicroCeph:  {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+					},
+					OSDs: cephTypes.Disks{{OSD: 2}},
+				},
+				{
+					Name:    "micro02",
+					Address: "10.0.0.102",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.MicroCeph:  {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+					},
+					OSDs: cephTypes.Disks{{OSD: 0}, {OSD: 1}},
+				},
+			},
+			expectedWarnings: []Warning{
+				{Level: Warn, Message: "Reliability risk: 3 systems are required for effective fault tolerance"},
+				{Level: Warn, Message: "MicroOVN is not found on micro01, micro02"},
+			},
+		},
+		{
+			desc: "2 node MicroCloud with LXD and MicroCeph. Overloaded MicroCeph",
+			statuses: []types.Status{
+				{
+					Name:    "micro01",
+					Address: "10.0.0.101",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.MicroCeph:  {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline), genMember("micro03", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+					},
+					OSDs: cephTypes.Disks{{OSD: 2}},
+				},
+				{
+					Name:    "micro02",
+					Address: "10.0.0.102",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.MicroCeph:  {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline), genMember("micro03", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+					},
+					OSDs: cephTypes.Disks{{OSD: 0}, {OSD: 1}},
+				},
+			},
+			expectedWarnings: []Warning{
+				{Level: Warn, Message: "Reliability risk: 3 systems are required for effective fault tolerance"},
+				{Level: Warn, Message: "MicroOVN is not found on micro01, micro02"},
+				{Level: Warn, Message: "Found MicroCeph systems not managed by MicroCloud: micro03"},
+			},
+		},
+		{
+			desc: "2 node MicroCloud with LXD, MicroCeph, and MicroOVN",
+			statuses: []types.Status{
+				{
+					Name:    "micro01",
+					Address: "10.0.0.101",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.MicroCeph:  {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.MicroOVN:   {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+					},
+				},
+				{
+					Name:    "micro02",
+					Address: "10.0.0.102",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.MicroCeph:  {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.MicroOVN:   {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline)},
+					},
+				},
+			},
+			expectedWarnings: []Warning{
+				{Level: Warn, Message: "Reliability risk: 3 systems are required for effective fault tolerance"},
+				{Level: Warn, Message: "No MicroCeph OSDs configured"},
+			},
+		},
+		{
+			desc: "3 node MicroCloud with LXD",
+			statuses: []types.Status{
+				{
+					Name:    "micro01",
+					Address: "10.0.0.100",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline), genMember("micro03", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline), genMember("micro03", microTypes.MemberOnline)},
+					},
+				},
+				{
+					Name:    "micro02",
+					Address: "10.0.0.102",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline), genMember("micro03", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline), genMember("micro03", microTypes.MemberOnline)},
+					},
+				},
+				{
+					Name:    "micro03",
+					Address: "10.0.0.102",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline), genMember("micro03", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline), genMember("micro03", microTypes.MemberOnline)},
+					},
+				},
+			},
+			expectedWarnings: []Warning{
+				{Level: Warn, Message: "MicroOVN is not found on micro01, micro02, micro03"},
+				{Level: Warn, Message: "MicroCeph is not found on micro01, micro02, micro03"},
+			},
+		},
+		{
+			desc: "3 node MicroCloud with LXD, MicroCeph, MicroOVN, and sufficient OSDs (no warnings)",
+			statuses: []types.Status{
+				{
+					Name:    "micro01",
+					Address: "10.0.0.100",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline), genMember("micro03", microTypes.MemberOnline)},
+						types.MicroOVN:   {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline), genMember("micro03", microTypes.MemberOnline)},
+						types.MicroCeph:  {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline), genMember("micro03", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline), genMember("micro03", microTypes.MemberOnline)},
+					},
+					OSDs: cephTypes.Disks{{OSD: 0}},
+				},
+				{
+					Name:    "micro02",
+					Address: "10.0.0.102",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline), genMember("micro03", microTypes.MemberOnline)},
+						types.MicroOVN:   {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline), genMember("micro03", microTypes.MemberOnline)},
+						types.MicroCeph:  {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline), genMember("micro03", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline), genMember("micro03", microTypes.MemberOnline)},
+					},
+					OSDs: cephTypes.Disks{{OSD: 1}},
+				},
+				{
+					Name:    "micro03",
+					Address: "10.0.0.102",
+					Clusters: map[types.ServiceType][]microTypes.ClusterMember{
+						types.MicroCloud: {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline), genMember("micro03", microTypes.MemberOnline)},
+						types.MicroOVN:   {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline), genMember("micro03", microTypes.MemberOnline)},
+						types.MicroCeph:  {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline), genMember("micro03", microTypes.MemberOnline)},
+						types.LXD:        {genMember("micro01", microTypes.MemberOnline), genMember("micro02", microTypes.MemberOnline), genMember("micro03", microTypes.MemberOnline)},
+					},
+					OSDs: cephTypes.Disks{{OSD: 2}},
+				},
+			},
+			expectedWarnings: []Warning{},
+		},
+	}
+
+	for i, c := range cases {
+		s.T().Log(i, c.desc)
+		warnings := compileWarnings("micro01", c.statuses)
+
+		s.Equal(len(c.expectedWarnings), len(warnings))
+		for _, w := range warnings {
+			s.Contains(c.expectedWarnings, w)
+		}
+
+		for _, row := range c.statuses {
+			rows := formatStatusRow(c.statuses[0], row)
+			status := rows[len(rows)-1]
+
+			if c.expectedStatus != nil {
+				expectedStatus, ok := c.expectedStatus[row.Name]
+				s.True(ok)
+				s.Equal(string(expectedStatus), status)
+			}
+		}
+	}
+}

--- a/cmd/microcloudd/main.go
+++ b/cmd/microcloudd/main.go
@@ -109,6 +109,7 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 	}()
 
 	endpoints := []rest.Endpoint{
+		api.StatusCmd(s),
 		api.ServicesCmd(s),
 		api.ServiceTokensCmd(s),
 		api.ServicesClusterCmd(s),

--- a/cmd/tui/style.go
+++ b/cmd/tui/style.go
@@ -1,0 +1,152 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+const (
+	white       = "#a0a0a0"
+	brightWhite = "#ffffff"
+
+	black       = "#000000"
+	brightBlack = "#505050"
+
+	red       = "#c01c28"
+	brightRed = "#f66151"
+
+	green       = "#26a269"
+	brightGreen = "#33da7a"
+
+	yellow       = "#d97d0c"
+	brightYellow = "#f99d2c"
+)
+
+var (
+	// Yellow represents the common yellow color used throughout the CLI.
+	Yellow lipgloss.TerminalColor = lipgloss.AdaptiveColor{Dark: brightYellow, Light: yellow}
+
+	// Red represents the common red color used throughout the CLI.
+	Red lipgloss.TerminalColor = lipgloss.AdaptiveColor{Dark: brightRed, Light: red}
+
+	// Green represents the common green color used throughout the CLI.
+	Green lipgloss.TerminalColor = lipgloss.AdaptiveColor{Dark: brightGreen, Light: green}
+
+	// White represents white on a black background and black on a white background.
+	White lipgloss.TerminalColor = lipgloss.AdaptiveColor{Dark: white, Light: black}
+
+	// Bright represents bright white on a black background, or bright black on a white background.
+	Bright lipgloss.TerminalColor = lipgloss.AdaptiveColor{Dark: brightWhite, Light: brightBlack}
+
+	// Border represents the default border color used for tables.
+	Border lipgloss.TerminalColor = lipgloss.AdaptiveColor{Dark: brightBlack, Light: black}
+)
+
+// DisableColors globally disables colors.
+func DisableColors() {
+	Yellow = lipgloss.Color("")
+	Red = lipgloss.Color("")
+	Green = lipgloss.Color("")
+	White = lipgloss.Color("")
+	Bright = lipgloss.Color("")
+	Border = lipgloss.Color("")
+}
+
+// SetColor applies the color to the given text.
+func SetColor(color lipgloss.TerminalColor, str string, bold bool) string {
+	return lipgloss.NewStyle().Foreground(color).SetString(str).Bold(bold).String()
+}
+
+// SuccessColor sets the 8-bit color of the text to 82. Green color used for happy messages.
+func SuccessColor(text string, bold bool) string {
+	return SetColor(Green, text, bold)
+}
+
+// WarningColor sets the 8-bit color of the text to 214. Yellow color used for warning messages.
+func WarningColor(text string, bold bool) string {
+	return SetColor(Yellow, text, bold)
+}
+
+// ErrorColor sets the 8-bit color of the text to 197. Red color used for error messages.
+func ErrorColor(text string, bold bool) string {
+	return SetColor(Red, text, bold)
+}
+
+// WarningSymbol returns a Yellow colored ! symbol to use for warnings.
+func WarningSymbol() string {
+	return WarningColor("!", true)
+}
+
+// ErrorSymbol returns a Red colored ⨯ symbol to use for errors.
+func ErrorSymbol() string {
+	return ErrorColor("⨯", true)
+}
+
+// SuccessSymbol returns a Green colored ✓ symbol to use for success messages.
+func SuccessSymbol() string {
+	return SuccessColor("✓", true)
+}
+
+// ColorErr is an io.Writer wrapper around os.Stderr that prints the error with colored text.
+type ColorErr struct{}
+
+// Write colors the given error red and sends it to os.Stderr.
+func (*ColorErr) Write(p []byte) (n int, err error) {
+	return os.Stderr.WriteString(ErrorColor(strings.TrimSpace(string(p)), false) + "\n")
+}
+
+// PrintWarning calls Println but it appends "! Warning:" to the front of the message.
+func PrintWarning(s string) {
+	fmt.Printf("%s %s: %s\n", WarningSymbol(), WarningColor("Warning", true), s)
+}
+
+// Fmt represents the data supplied to ColorPrintf. In particular, it takes a color to apply to the text, and the text itself.
+type Fmt struct {
+	Color lipgloss.TerminalColor
+	Arg   any
+	Bold  bool
+}
+
+// Printf works like fmt.Sprintf except it applies custom coloring to each argument, and the main template body.
+func Printf(template Fmt, args ...Fmt) string {
+	var builder strings.Builder
+
+	// Match format directives.
+	re := regexp.MustCompile(`%[+]?[vTtbcdoqxXUeEfFgGsqp]`)
+
+	// Split the string on format directives
+	parts := re.Split(template.Arg.(string), -1)
+	directives := re.FindAllString(template.Arg.(string), -1)
+
+	if len(directives) != len(args) {
+		return fmt.Sprintf("Invalid format (expected %d args but found %d)", len(directives), len(args))
+	}
+
+	for i, part := range parts {
+		styledArg := ""
+
+		// The styling seems to cause newlines to print extra spaces so trim them.
+		preNL, ok := strings.CutSuffix(part, "\n ")
+		postNL := ""
+		if ok {
+			postNL = "\n "
+		}
+
+		styledTmpl := lipgloss.NewStyle().Bold(template.Bold).SetString(preNL)
+		styledTmpl = styledTmpl.Foreground(template.Color)
+		styledArg += styledTmpl.String()
+
+		_, _ = builder.WriteString(styledArg + postNL)
+		if i < len(args) {
+			styledTmpl := lipgloss.NewStyle().Bold(args[i].Bold)
+			styledTmpl = styledTmpl.Foreground(args[i].Color)
+			_, _ = builder.WriteString(styledTmpl.SetString(fmt.Sprintf(directives[i], args[i].Arg)).String())
+		}
+	}
+
+	return builder.String()
+}

--- a/cmd/tui/table.go
+++ b/cmd/tui/table.go
@@ -1,0 +1,34 @@
+package tui
+
+import (
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/table"
+)
+
+func baseTableTemplate(header []string) *table.Table {
+	t := table.New()
+	t = t.Headers(header...)
+	t = t.Border(lipgloss.NormalBorder())
+	t = t.BorderStyle(lipgloss.NewStyle().Foreground(Border))
+	t = t.StyleFunc(func(row, col int) lipgloss.Style {
+		tmpl := lipgloss.NewStyle()
+		tmpl = tmpl.Padding(0, 1)
+		tmpl = tmpl.Align(lipgloss.Center)
+
+		if row == 0 {
+			header[col] = lipgloss.NewStyle().Foreground(Bright).Bold(true).SetString(header[col]).String()
+		}
+
+		return tmpl
+	})
+
+	return t
+}
+
+// NewTable returns the string representation of a table with the given data.
+func NewTable(header []string, rows [][]string) string {
+	t := baseTableTemplate(header)
+	t = t.Rows(rows...)
+
+	return t.String()
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/canonical/microceph/microceph v0.0.0-20240912190827-ef42f096671e
 	github.com/canonical/microcluster/v2 v2.0.2
 	github.com/canonical/microovn/microovn v0.0.0-20240912142147-31ce8c71de4f
+	github.com/charmbracelet/lipgloss v0.13.0
 	github.com/creack/pty v1.1.21
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
@@ -31,7 +32,9 @@ require (
 require (
 	github.com/Rican7/retry v0.3.1 // indirect
 	github.com/armon/go-proxyproto v0.1.0 // indirect
+	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/canonical/go-dqlite v1.22.0 // indirect
+	github.com/charmbracelet/x/ansi v0.1.4 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/flosch/pongo2 v0.0.0-20200913210552-0d938eb266f3 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
@@ -46,12 +49,14 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/kr/fs v0.1.0 // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mattn/go-sqlite3 v1.14.23 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/miekg/dns v1.1.62 // indirect
+	github.com/muesli/termenv v0.15.2 // indirect
 	github.com/muhlemmer/gu v0.3.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/sftp v1.13.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-proxyproto v0.1.0 h1:TWWcSsjco7o2itn6r25/5AqKBiWmsiuzsUDLT/MTl7k=
 github.com/armon/go-proxyproto v0.1.0/go.mod h1:Xj90dce2VKbHzRAeiVQAMBtj4M5oidoXJ8lmgyW21mw=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
+github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=
@@ -67,6 +69,10 @@ github.com/canonical/microcluster/v2 v2.0.0-20240911074836-85e676b8f4bc/go.mod h
 github.com/canonical/microovn/microovn v0.0.0-20240912142147-31ce8c71de4f h1:PGrs8+znx4IqgwywlEljB9H7r/QEc6Pba6nVB7+VVRc=
 github.com/canonical/microovn/microovn v0.0.0-20240912142147-31ce8c71de4f/go.mod h1:e23IdSkgJMqi9gwNhCQPznblE0/X7KLVZUIOvkDYPa8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/charmbracelet/lipgloss v0.13.0 h1:4X3PPeoWEDCMvzDvGmTajSyYPcZM4+y8sCA/SsA3cjw=
+github.com/charmbracelet/lipgloss v0.13.0/go.mod h1:nw4zy0SBX/F/eAO1cWdcvy6qnkDUxr8Lw7dvFrAIbbY=
+github.com/charmbracelet/x/ansi v0.1.4 h1:IEU3D6+dWwPSgZ6HBH+v6oUuZ/nVawMiWj5831KfiLM=
+github.com/charmbracelet/x/ansi v0.1.4/go.mod h1:dk73KoMTT5AX5BsX0KrqhsTqAnhZZoCBjs7dGWp4Ktw=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -243,6 +249,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
+github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
@@ -279,6 +287,8 @@ github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo=
+github.com/muesli/termenv v0.15.2/go.mod h1:Epx+iuz8sNs7mNKhxzH4fWXGNpZwUaJKRS1noLXviQ8=
 github.com/muhlemmer/gu v0.3.1 h1:7EAqmFrW7n3hETvuAdmFmn4hS8W+z3LgKtrnow+YzNM=
 github.com/muhlemmer/gu v0.3.1/go.mod h1:YHtHR+gxM+bKEIIs7Hmi9sPT3ZDUvTN/i88wQpZkrdM=
 github.com/muhlemmer/httpforwarded v0.1.0 h1:x4DLrzXdliq8mprgUMR0olDvHGkou5BJsK/vWUetyzY=


### PR DESCRIPTION
Adds a status command usable with `microcloud status`.

A minimal example output is shown below:

```
 Status: ERROR

 ┃ ⨯ Reliability risk: 3 systems are required for effective fault tolerance
 ┃ ! MicroOVN is not installed on micro02, micro01
 ┃ ! MicroCeph is not installed on micro02, micro01

┌─────────┬────────────────┬───────────┬────────────────────┬───────────────────┬────────┐
│ Name    │ Address        │ OSD Disks │ MicroCeph Services │ MicroOVN Services │ Status │
├─────────┼────────────────┼───────────┼────────────────────┼───────────────────┼────────┤
│ micro02 │ 10.148.181.110 │ -         │ -                  │ -                 │ ONLINE │
│ micro01 │ 10.148.181.237 │ -         │ -                  │ -                 │ ONLINE │
└─────────┴────────────────┴───────────┴────────────────────┴───────────────────┴────────┘
```

The output is split into 3 parts:
* Status: ERROR 
  * Reports the overall summary of the cluster state. This depends on the list of warnings just below it.
* Warnings
  * These are a series of messages that appear with 2 levels of severity (warn/error) that dictate the `Status` value. These will report any issues with the cluster, like missing snaps, mismatched cluster members, schema upgrades, and incorrectly configured OSDs.
* Table
  * The table reports the current state of the cluster. OSDs and ceph/ovn services will only be populated if those services are installed. The overall status depends on how other cluster members reach out to the local system. The status will only report ONLINE if all snaps report ONLINE for that cluster member.