### PR TITLE
Fix underlay configuration for `preseed.yaml`

### DIFF
--- a/cmd/microcloud/main_init_preseed.go
+++ b/cmd/microcloud/main_init_preseed.go
@@ -797,19 +797,6 @@ func (p *Preseed) Parse(s *service.Handler, c *initConfig) (map[string]InitSyste
 			}
 		}
 
-		if c.bootstrap {
-			osdHosts := 0
-			for _, system := range c.systems {
-				if len(system.MicroCephDisks) > 0 {
-					osdHosts++
-				}
-			}
-
-			if osdHosts < RecommendedOSDHosts {
-				fmt.Printf("Warning: OSD host count is less than %d. Distributed storage is not fault-tolerant\n", RecommendedOSDHosts)
-			}
-		}
-
 		for _, filter := range p.Storage.Local {
 			// No need to check filters anymore if each machine has a disk.
 			if len(zfsMachines) == len(c.systems) {
@@ -837,6 +824,19 @@ func (p *Preseed) Parse(s *service.Handler, c *initConfig) (map[string]InitSyste
 		}
 
 		c.systems[peer] = system
+	}
+
+	if c.bootstrap {
+		osdHosts := 0
+		for _, system := range c.systems {
+			if len(system.MicroCephDisks) > 0 {
+				osdHosts++
+			}
+		}
+
+		if osdHosts < RecommendedOSDHosts {
+			fmt.Printf("Warning: OSD host count is less than %d. Distributed storage is not fault-tolerant\n", RecommendedOSDHosts)
+		}
 	}
 
 	// Initialize Ceph network if specified.

--- a/cmd/microcloud/main_init_preseed.go
+++ b/cmd/microcloud/main_init_preseed.go
@@ -38,7 +38,7 @@ type Preseed struct {
 type System struct {
 	Name            string      `yaml:"name"`
 	UplinkInterface string      `yaml:"ovn_uplink_interface"`
-	UnderlayIP      string      `yaml:"underlay_ip"`
+	UnderlayIP      string      `yaml:"ovn_underlay_ip"`
 	Storage         InitStorage `yaml:"storage"`
 }
 
@@ -66,13 +66,13 @@ type InitNetwork struct {
 // CephOptions represents the structure of the ceph options in the preseed yaml.
 type CephOptions struct {
 	InternalNetwork string `yaml:"internal_network"`
+	CephFS          bool   `yaml:"cephfs"`
 }
 
 // StorageFilter separates the filters used for local and ceph disks.
 type StorageFilter struct {
-	CephFS bool         `yaml:"cephfs"`
-	Local  []DiskFilter `yaml:"local"`
-	Ceph   []DiskFilter `yaml:"ceph"`
+	Local []DiskFilter `yaml:"local"`
+	Ceph  []DiskFilter `yaml:"ceph"`
 }
 
 // DiskFilter is the optional filter for finding disks according to their fields in api.ResourcesStorageDisk in LXD.
@@ -907,7 +907,7 @@ func (p *Preseed) Parse(s *service.Handler, c *initConfig) (map[string]InitSyste
 	}
 
 	hasCephFS, _ := localInfo.SupportsRemoteFSPool()
-	if (len(cephMatches)+len(directCephMatches) > 0 && p.Storage.CephFS) || hasCephFS {
+	if (len(cephMatches)+len(directCephMatches) > 0 && p.Ceph.CephFS) || hasCephFS {
 		for name, system := range c.systems {
 			if c.bootstrap {
 				system.TargetStoragePools = append(system.TargetStoragePools, lxd.DefaultPendingCephFSStoragePool())

--- a/cmd/microcloud/main_init_preseed.go
+++ b/cmd/microcloud/main_init_preseed.go
@@ -244,9 +244,9 @@ func (p *Preseed) validate(name string, bootstrap bool) error {
 		}
 
 		if system.UnderlayIP != "" {
-			_, _, err := net.ParseCIDR(system.UnderlayIP)
-			if err != nil {
-				return fmt.Errorf("Invalid underlay IP: %w", err)
+			ip := net.ParseIP(system.UnderlayIP)
+			if ip == nil {
+				return fmt.Errorf("Invalid underlay IP %q", system.UnderlayIP)
 			}
 
 			underlayCount++
@@ -519,9 +519,9 @@ func (p *Preseed) Parse(s *service.Handler, c *initConfig) (map[string]InitSyste
 	// If an uplink interface was explicitly chosen, we will try to set up an OVN network.
 	explicitOVN := len(ifaceByPeer) > 0
 
-	cephInterfaces := map[string]map[string]service.DedicatedInterface{}
+	addressedInterfaces := map[string]map[string]service.DedicatedInterface{}
 	for _, system := range c.systems {
-		uplinkIfaces, cephIfaces, _, err := lxd.GetNetworkInterfaces(context.Background(), system.ServerInfo.Name, system.ServerInfo.Address, system.ServerInfo.AuthSecret)
+		uplinkIfaces, dedicatedIfaces, _, err := lxd.GetNetworkInterfaces(context.Background(), system.ServerInfo.Name, system.ServerInfo.Address, system.ServerInfo.AuthSecret)
 		if err != nil {
 			return nil, err
 		}
@@ -536,12 +536,12 @@ func (p *Preseed) Parse(s *service.Handler, c *initConfig) (map[string]InitSyste
 			}
 		}
 
-		for ifaceName, iface := range cephIfaces {
-			if cephInterfaces[system.ServerInfo.Name] == nil {
-				cephInterfaces[system.ServerInfo.Name] = map[string]service.DedicatedInterface{}
+		for ifaceName, iface := range dedicatedIfaces {
+			if addressedInterfaces[system.ServerInfo.Name] == nil {
+				addressedInterfaces[system.ServerInfo.Name] = map[string]service.DedicatedInterface{}
 			}
 
-			cephInterfaces[system.ServerInfo.Name][ifaceName] = iface
+			addressedInterfaces[system.ServerInfo.Name][ifaceName] = iface
 		}
 	}
 
@@ -564,55 +564,42 @@ func (p *Preseed) Parse(s *service.Handler, c *initConfig) (map[string]InitSyste
 			c.systems[peer] = system
 		}
 
-		// Check the preseed underlay network configuration against the available ips.
+		// TODO: call `s.Services[types.MicroOVN].(*service.OVNService).SupportsFeature(context.Background(), "custom_encapsulation_ip")`
+		// when MicroCloud will be updated with microcluster/v2
+		// Check the preseed underlay network configuration against the available ifaces.
 		if ovnUnderlayNeeded {
-			canOVNUnderlay := true
-			for peer, system := range c.state {
-				if len(system.AvailableOVNInterfaces) == 0 {
-					fmt.Printf("Not enough interfaces available on %s to create an underlay network, skipping\n", peer)
-					canOVNUnderlay = false
-					break
-				}
-			}
-
-			if canOVNUnderlay {
-				// TODO: call `s.Services[types.MicroOVN].(*service.OVNService).SupportsFeature(context.Background(), "custom_encapsulation_ip")`
-				// when MicroCloud will be updated with microcluster/v2
-				underlays := make(map[string]string, len(p.Systems))
-				for _, sys := range p.Systems {
-					underlays[sys.Name] = sys.UnderlayIP
+			assignedSystems := map[string]bool{}
+			for _, sys := range p.Systems {
+				if sys.UnderlayIP == "" {
+					return nil, fmt.Errorf("Underlay IP is not defined for %q", sys.Name)
 				}
 
-				underlayCount := 0
-				for _, sys := range p.Systems {
-					for _, net := range c.state[sys.Name].AvailableOVNInterfaces {
-						if len(net.Addresses) != 0 {
-							for _, cidrAddr := range net.Addresses {
-								if underlays[sys.Name] == cidrAddr {
-									underlayCount = underlayCount + 1
-									goto out
-								}
-							}
+				underlayIP := net.ParseIP(sys.UnderlayIP)
+				if underlayIP == nil {
+					return nil, fmt.Errorf("Failed to parse supplied underlay IP %q", sys.UnderlayIP)
+				}
+
+				for _, iface := range addressedInterfaces[sys.Name] {
+					for _, cidr := range iface.Addresses {
+						_, subnet, err := net.ParseCIDR(cidr)
+						if err != nil {
+							return nil, fmt.Errorf("Failed to parse available network interface %q CIDR address: %q: %w", iface.Network.Name, cidr, err)
+						}
+
+						if subnet.Contains(underlayIP) {
+							assignedSystems[sys.Name] = true
+							break
 						}
 					}
-
-				out:
 				}
 
-				if underlayCount != len(p.Systems) {
-					return nil, fmt.Errorf("Failed to find all underlay IPs on the network")
+				if !assignedSystems[sys.Name] {
+					return nil, fmt.Errorf("No available interface found for OVN underlay IP %q", sys.UnderlayIP)
 				}
 
-				// Apply the underlay IPs to the systems.
-				for peer, system := range c.systems {
-					ip, _, err := net.ParseCIDR(underlays[peer])
-					if err != nil {
-						return nil, fmt.Errorf("Failed to parse underlay IP: %w", err)
-					}
-
-					system.OVNGeneveAddr = ip.String()
-					c.systems[peer] = system
-				}
+				system := c.systems[sys.Name]
+				system.OVNGeneveAddr = sys.UnderlayIP
+				c.systems[sys.Name] = system
 			}
 		}
 	} else {
@@ -871,7 +858,7 @@ func (p *Preseed) Parse(s *service.Handler, c *initConfig) (map[string]InitSyste
 		}
 
 		if internalCephNetwork != "" {
-			err = validateCephInterfacesForSubnet(lxd, c.systems, cephInterfaces, internalCephNetwork)
+			err = validateCephInterfacesForSubnet(lxd, c.systems, addressedInterfaces, internalCephNetwork)
 			if err != nil {
 				return nil, err
 			}
@@ -887,7 +874,7 @@ func (p *Preseed) Parse(s *service.Handler, c *initConfig) (map[string]InitSyste
 		}
 
 		if localInternalCephNetwork.String() != "" && localInternalCephNetwork.String() != c.lookupSubnet.String() {
-			err = validateCephInterfacesForSubnet(lxd, c.systems, cephInterfaces, localInternalCephNetwork.String())
+			err = validateCephInterfacesForSubnet(lxd, c.systems, addressedInterfaces, localInternalCephNetwork.String())
 			if err != nil {
 				return nil, err
 			}

--- a/doc/how-to/preseed.yaml
+++ b/doc/how-to/preseed.yaml
@@ -6,12 +6,15 @@ lookup_interface: eth0
 # `systems` lists the systems we expect to find by their host name.
 #   `name` represents the host name
 #   `ovn_uplink_interface` is optional and represents the name of the interface reserved for use with OVN.
+#   `ovn_underlay_ip` is optional and represents the Geneve Encap IP for each system.
 #   `storage` is optional and represents explicit paths to disks for each system.
 systems:
 - name: micro01
   ovn_uplink_interface: eth1
+  ovn_underlay_ip: 10.0.2.101
 - name: micro02
   ovn_uplink_interface: eth1
+  ovn_underlay_ip: 10.0.2.102
   storage:
     local:
       path: /dev/nvme5n1
@@ -24,13 +27,16 @@ systems:
         encrypt: true
 - name: micro03
   ovn_uplink_interface: eth1
+  ovn_underlay_ip: 10.0.2.103
 - name: micro04
   ovn_uplink_interface: eth1
 
 # `ceph` is optional and represents the Ceph global configuration
+# `cephfs: true` can be used to optionally set up a CephFS file system alongside Ceph distributed storage.
+# `internal_network: subnet` optionally specifies the internal cluster network for the Ceph cluster.
 ceph:
+  cephfs: true
   internal_network: 10.0.1.0/24
-  public_network: 10.0.2.0/24
 
 # `ovn` is optional and represents the OVN & uplink network configuration for LXD.
 ovn:
@@ -48,9 +54,7 @@ ovn:
 # String values must not be in quotes unless the string contains a space.
 # Single quotes are fine, but double quotes must be escaped.
 # `find_min` and `find_max` can be used to validate the number of disks each filter finds.
-# `cephfs: true` can be used to optionally set up a CephFS file system alongside Ceph distributed storage.
 storage:
-  cephfs: true
   local:
     - find: size > 10GiB && size < 50GiB && type == nvme
       find_min: 1

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -390,7 +390,7 @@ ovn:
   ipv4_gateway: 10.1.123.1/24
   ipv4_range: 10.1.123.100-10.1.123.254
   ipv6_gateway: fd42:1:1234:1234::1/64
-storage:
+ceph:
   cephfs: true
 EOF
 
@@ -525,7 +525,7 @@ ovn:
   ipv4_gateway: 10.1.123.1/24
   ipv4_range: 10.1.123.100-10.1.123.254
   ipv6_gateway: fd42:1:1234:1234::1/64
-storage:
+ceph:
   cephfs: true
 EOF
 
@@ -661,7 +661,6 @@ ovn:
   ipv6_gateway: fd42:1:1234:1234::1/64
 ceph:
   internal_network: ${ceph_dedicated_subnet_prefix}.0/24
-storage:
   cephfs: true
 EOF
 
@@ -1144,6 +1143,8 @@ ovn:
   ipv4_range: 10.1.123.100-10.1.123.254
   ipv6_gateway: fd42:1:1234:1234::1/64
   dns_servers: 10.1.123.1,8.8.8.8
+ceph:
+  cephfs: true
 storage:
   local:
     - find: device_id == *lxd_disk1
@@ -1152,7 +1153,6 @@ storage:
     - find: device_id == *lxd_disk2
       find_min: 3
       wipe: true
-  cephfs: true
 EOF
 
   services_validator
@@ -1563,7 +1563,7 @@ ovn:
   ipv4_range: 10.1.123.100-10.1.123.254
   ipv6_gateway: fd42:1:1234:1234::1/64
   dns_servers: 10.1.123.1,8.8.8.8
-storage:
+ceph:
   cephfs: true
 EOF
 
@@ -1617,7 +1617,7 @@ ovn:
   ipv4_range: 10.1.123.100-10.1.123.254
   ipv6_gateway: fd42:1:1234:1234::1/64
   dns_servers: 10.1.123.1,8.8.8.8
-storage:
+ceph:
   cephfs: true
 EOF
 

--- a/test/suites/preseed.sh
+++ b/test/suites/preseed.sh
@@ -33,8 +33,10 @@ ovn:
   ipv6_gateway: fd42:1:1234:1234::1/64
   dns_servers: 10.1.123.1,8.8.8.8,fd42:1:1234:1234::1
 
-storage:
+ceph:
   cephfs: true
+
+storage:
   local:
     - find: device_id == *lxd_disk1
       find_min: 2
@@ -71,8 +73,9 @@ lookup_interface: enp5s0
 systems:
 - name: micro04
   ovn_uplink_interface: enp6s0
-storage:
+ceph:
   cephfs: true
+storage:
   local:
     - find: device_id == *lxd_disk1
       find_min: 1


### PR DESCRIPTION
The logic for detecting the OVN underlay configuration for preseed was not correct, it was relying on `c.state` which contains the resources available and already set up on existing cluster members, as well as new cluster members. It is used in interactive setup to manage additional configuration being supplied to the existing systems.

In preseed, we don't populate it yet because we only want to apply the precise recipe that is defined in the preseed, and not change any other cluster information implicitly (in interactive setup we can ask the user). 

Additionally, the input parsing was not correct, since it expected a CIDR per system however the ovn encap configuration wants an IP.

So this addresses that by instead using the list of systems parsed from the yaml itself in `p.Systems`, and uses the same set of interfaces that were detected for the internal ceph cluster network, since they have the same restrictions.  Also, rather than specifying a CIDR per system, instead we can specify the encap IP directly, and validate that it fits in one of the available subnets.

Preseed tests have also been updated for the new key, which is prefixed with `ovn_` now to be clear what it affects. The `cephfs ` key has also been moved into the global ceph configuration because it's not system-specific. 