### PR TITLE
Add `--heartbeat` to `microcloudd`

### DIFF
--- a/cmd/microcloudd/main.go
+++ b/cmd/microcloudd/main.go
@@ -37,7 +37,8 @@ type cmdGlobal struct {
 type cmdDaemon struct {
 	global *cmdGlobal
 
-	flagMicroCloudDir string
+	flagMicroCloudDir     string
+	flagHeartbeatInterval time.Duration
 }
 
 func (c *cmdDaemon) Command() *cobra.Command {
@@ -139,7 +140,7 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 		api.OVNProxy(s),
 	}
 
-	return s.Services[types.MicroCloud].(*service.CloudService).StartCloud(context.Background(), s, endpoints, c.global.flagLogVerbose, c.global.flagLogDebug)
+	return s.Services[types.MicroCloud].(*service.CloudService).StartCloud(context.Background(), s, endpoints, c.global.flagLogVerbose, c.global.flagLogDebug, c.flagHeartbeatInterval)
 }
 
 func main() {
@@ -160,6 +161,7 @@ func main() {
 	app.PersistentFlags().BoolVarP(&daemonCmd.global.flagLogVerbose, "verbose", "v", false, "Show all information messages")
 
 	app.PersistentFlags().StringVar(&daemonCmd.flagMicroCloudDir, "state-dir", "", "Path to store state information for MicroCloud"+"``")
+	app.PersistentFlags().DurationVar(&daemonCmd.flagHeartbeatInterval, "heartbeat", time.Second*10, "Time between attempted heartbeats")
 
 	app.SetVersionTemplate("{{.Version}}\n")
 

--- a/service/microcloud.go
+++ b/service/microcloud.go
@@ -56,11 +56,13 @@ func NewCloudService(name string, addr string, dir string) (*CloudService, error
 }
 
 // StartCloud launches the MicroCloud daemon with the appropriate hooks.
-func (s *CloudService) StartCloud(ctx context.Context, service *Handler, endpoints []rest.Endpoint, verbose bool, debug bool) error {
+func (s *CloudService) StartCloud(ctx context.Context, service *Handler, endpoints []rest.Endpoint, verbose bool, debug bool, heartbeatInterval time.Duration) error {
 	args := microcluster.DaemonArgs{
-		Verbose:              verbose,
-		Debug:                debug,
-		Version:              version.Version,
+		Verbose:           verbose,
+		Debug:             debug,
+		Version:           version.Version,
+		HeartbeatInterval: heartbeatInterval,
+
 		PreInitListenAddress: "[::]:" + strconv.FormatInt(CloudPort, 10),
 		Hooks: &state.Hooks{
 			PostBootstrap: func(ctx context.Context, s state.State, cfg map[string]string) error { return service.StopBroadcast() },

--- a/test/suites/recover.sh
+++ b/test/suites/recover.sh
@@ -50,7 +50,7 @@ test_recover() {
   done
 
   # microcluster takes a long time to update the member roles in the core_cluster_members table
-  sleep 90
+  sleep 30
 
   for m in micro01 micro02; do
     cluster_list=$(lxc exec "${m}" --env "TEST_CONSOLE=0" -- microcloud cluster list -f csv)


### PR DESCRIPTION
Microcluster supports it so we might as well pass it through. If we're able to configure this for the snap service as well it would let us sleep for less time in the recovery tests.