### PR TITLE
Trivy vulnerability scanning

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,48 @@
+name: Vulnerability Scanning with Trivy
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'  # Test Trivy daily at midnight
+
+permissions:
+  contents: read
+  security-events: write # for uploading SARIF results to the security tab
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  trivy-repo:
+    name: Trivy vulnerability scanner - Repository
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Install Trivy
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p /home/runner/vuln-cache
+          latest=$(gh release view --repo aquasecurity/trivy --json tagName -q '.tagName' | head -n 1)
+          wget https://github.com/aquasecurity/trivy/releases/download/${latest}/trivy_${latest#v}_Linux-64bit.deb
+          sudo dpkg -i trivy_${latest#v}_Linux-64bit.deb
+
+      - name: Run Trivy vulnerability scanner
+        run: |
+          trivy fs --quiet --scanners vuln,secret,misconfig --format sarif --cache-dir /home/runner/vuln-cache \
+          --severity LOW,MEDIUM,HIGH,CRITICAL --output trivy-microcloud-repo-scan-results.sarif .
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: "trivy-microcloud-repo-scan-results.sarif"
+          sha: ${{ github.sha }}
+          ref: refs/heads/main

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           ref: main
 
+      # We are using the deb package instead of the trivy action because we need to point to the cache directory
+      # with cache-dir, and there is currently a bug in that functionality on the Trivy GitHub action.
+      # See https://github.com/aquasecurity/trivy-action/issues/12.
       - name: Install Trivy
         env:
           GH_TOKEN: ${{ github.token }}
@@ -40,9 +43,65 @@ jobs:
           trivy fs --quiet --scanners vuln,secret,misconfig --format sarif --cache-dir /home/runner/vuln-cache \
           --severity LOW,MEDIUM,HIGH,CRITICAL --output trivy-microcloud-repo-scan-results.sarif .
 
+      - name: Cache trivy and vulnerability database
+        uses: actions/cache/save@v4
+        with:
+            path: /home/runner/vuln-cache
+            key: trivy-cache
+
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: "trivy-microcloud-repo-scan-results.sarif"
           sha: ${{ github.sha }}
           ref: refs/heads/main
+
+  trivy-snap:
+    name: Trivy vulnerability scanner - Snap
+    runs-on: ubuntu-22.04
+    needs: trivy-repo
+    strategy:
+      matrix:
+        version:
+          - "latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ (matrix.version == 'latest' && 'main') || format('stable-{0}', matrix.version) }}
+
+      - name: Install Trivy
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          latest=$(gh release view --repo aquasecurity/trivy --json tagName -q '.tagName' | head -n 1)
+          wget https://github.com/aquasecurity/trivy/releases/download/${latest}/trivy_${latest#v}_Linux-64bit.deb
+          sudo dpkg -i trivy_${latest#v}_Linux-64bit.deb
+
+      - name: Restore cached Trivy vulnerability database
+        uses: actions/cache/restore@v4
+        with:
+          path: /home/runner/vuln-cache
+          key: trivy-cache-${{ github.run_id }}
+
+      - name: Download snap for scan
+        run: |
+          snap download microcloud --channel=${{ matrix.version }}/stable
+          unsquashfs ./microcloud*.snap
+
+      - name: Run Trivy vulnerability scanner
+        run: |
+          trivy rootfs --quiet --scanners vuln,secret,misconfig --format sarif --cache-dir /home/runner/vuln-cache \
+          --severity LOW,MEDIUM,HIGH,CRITICAL --output ${{ matrix.version }}-stable.sarif squashfs-root
+
+      - name: Flag snap scanning alerts
+        run: |
+          jq '.runs[].tool.driver.rules[] |= (.shortDescription.text |= "Snap scan - " + .)' ${{ matrix.version }}-stable.sarif > tmp.json
+          mv tmp.json ${{ matrix.version }}-stable.sarif
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: "${{ matrix.version }}-stable.sarif"
+          sha: ${{ github.sha }}
+          ref: refs/heads/${{ (matrix.version == 'latest' && 'main') || format('stable-{0}', matrix.version) }}


### PR DESCRIPTION
This adds two jobs to our workflows. One uses Trivy to scan MicroCloud's dependencies and the other scans the snap.