### PR TITLE
cmd/microcloudd: Set minimum heartbeat value

### DIFF
--- a/cmd/microcloudd/main.go
+++ b/cmd/microcloudd/main.go
@@ -18,6 +18,10 @@ import (
 	"github.com/canonical/microcloud/microcloud/version"
 )
 
+// MinimumHeartbeatInterval is used to prevent a user from setting the MicroCluster
+// heartbeat to 0.
+const MinimumHeartbeatInterval = time.Millisecond * 200
+
 // Debug indicates whether to log debug messages or not.
 var Debug bool
 
@@ -56,6 +60,10 @@ func (c *cmdDaemon) Command() *cobra.Command {
 func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 	if len(args) != 0 {
 		return cmd.Help()
+	}
+
+	if c.flagHeartbeatInterval < MinimumHeartbeatInterval {
+		return fmt.Errorf("Invalid heartbeat interval: Must be >%s", MinimumHeartbeatInterval)
 	}
 
 	addr := util.NetworkInterfaceAddress()


### PR DESCRIPTION
Follow-up from #407 

200ms is somewhat arbitrary; we want to explicitly disallow 0 but still let fairly small values through for future use in the test suite.