### PR TITLE
.github/workflows: Refresh snapd before installing LXD

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -211,7 +211,19 @@ jobs:
       - name: "Setup host LXD"
         run: |
           set -eux
-          sudo snap install lxd --channel latest/edge || sudo snap refresh lxd --channel latest/edge
+
+          if snap list snapd > /dev/null ; then
+            sudo snap refresh snapd
+          else
+            snap install snapd
+          fi
+
+          if snap list lxd > /dev/null ; then
+            sudo snap refresh lxd --channel latest/edge
+          else
+            snap install lxd --channel latest/edge
+          fi
+
           sudo lxd init --auto
 
       - name: "Prepare for system tests"


### PR DESCRIPTION
Attempt to fix this error in gh workflows:

```
error: cannot install "lxd": snap "lxd" assumes unsupported features: snapd2.65
       (try to refresh snapd)
```