### PR TITLE
test/includes/microcloud: install yq from deb now that we are on 24.04

### DIFF
--- a/test/includes/microcloud.sh
+++ b/test/includes/microcloud.sh
@@ -1164,13 +1164,12 @@ setup_system() {
     # Install the snaps.
     lxc exec "${name}" -- apt-get update
     if [ -n "${CLOUD_INSPECT:-}" ] || [ "${SNAPSHOT_RESTORE}" = 0 ]; then
-      lxc exec "${name}" -- apt-get install --no-install-recommends -y jq zfsutils-linux htop
+      lxc exec "${name}" -- apt-get install --no-install-recommends -y jq yq zfsutils-linux htop
     else
-      lxc exec "${name}" -- apt-get install --no-install-recommends -y jq
+      lxc exec "${name}" -- apt-get install --no-install-recommends -y jq yq
     fi
 
     lxc exec "${name}" -- snap install snapd
-    lxc exec "${name}" -- snap install yq
 
     # Free disk blocks
     lxc exec "${name}" -- apt-get clean


### PR DESCRIPTION
Installing from deb should be faster than pulling from the snapstore. Before switching to 24.04, this was not possible as Noble is the first release with a yq deb.