### PR TITLE
Daemon version enforcement

### DIFF
--- a/api/types/session.go
+++ b/api/types/session.go
@@ -18,25 +18,25 @@ const (
 // Session represents the websocket protocol used during trust establishment between the client and server.
 // Empty fields are omitted to require sending only the necessary information.
 type Session struct {
-	Address              string            `json:"address,omitempty"`
-	InitiatorAddress     string            `json:"initiator_address,omitempty"`
-	InitiatorName        string            `json:"initiator_name,omitempty"`
-	InitiatorFingerprint string            `json:"initiator_fingerprint,omitempty"`
-	Interface            string            `json:"interface,omitempty"`
-	Passphrase           string            `json:"passphrase,omitempty"`
-	Services             []ServiceType     `json:"services,omitempty"`
-	Intent               SessionJoinPost   `json:"intent,omitempty"`
-	ConfirmedIntents     []SessionJoinPost `json:"confirmed_intents,omitempty"`
-	Accepted             bool              `json:"accepted,omitempty"`
-	LookupTimeout        time.Duration     `json:"lookup_timeout,omitempty"`
-	Error                string            `json:"error,omitempty"`
+	Address              string                 `json:"address,omitempty"`
+	InitiatorAddress     string                 `json:"initiator_address,omitempty"`
+	InitiatorName        string                 `json:"initiator_name,omitempty"`
+	InitiatorFingerprint string                 `json:"initiator_fingerprint,omitempty"`
+	Interface            string                 `json:"interface,omitempty"`
+	Passphrase           string                 `json:"passphrase,omitempty"`
+	Services             map[ServiceType]string `json:"services,omitempty"`
+	Intent               SessionJoinPost        `json:"intent,omitempty"`
+	ConfirmedIntents     []SessionJoinPost      `json:"confirmed_intents,omitempty"`
+	Accepted             bool                   `json:"accepted,omitempty"`
+	LookupTimeout        time.Duration          `json:"lookup_timeout,omitempty"`
+	Error                string                 `json:"error,omitempty"`
 }
 
 // SessionJoinPost represents a request made to join an active session.
 type SessionJoinPost struct {
-	Name        string        `json:"name" yaml:"name"`
-	Version     string        `json:"version" yaml:"version"`
-	Address     string        `json:"address" yaml:"address"`
-	Certificate string        `json:"certificate" yaml:"certificate"`
-	Services    []ServiceType `json:"services" yaml:"services"`
+	Name        string                 `json:"name" yaml:"name"`
+	Version     string                 `json:"version" yaml:"version"`
+	Address     string                 `json:"address" yaml:"address"`
+	Certificate string                 `json:"certificate" yaml:"certificate"`
+	Services    map[ServiceType]string `json:"services" yaml:"services"`
 }

--- a/cmd/microcloud/session.go
+++ b/cmd/microcloud/session.go
@@ -29,7 +29,7 @@ func (c *initConfig) runSession(ctx context.Context, s *service.Handler, role ty
 	return f(cloudClient.NewWebsocketGateway(ctx, conn))
 }
 
-func (c *initConfig) initiatingSession(gw *cloudClient.WebsocketGateway, sh *service.Handler, services []types.ServiceType, passphrase string, expectedSystems []string) error {
+func (c *initConfig) initiatingSession(gw *cloudClient.WebsocketGateway, sh *service.Handler, services map[types.ServiceType]string, passphrase string, expectedSystems []string) error {
 	session := types.Session{
 		Address:    c.address,
 		Interface:  c.lookupIface.Name,
@@ -139,7 +139,7 @@ func (c *initConfig) initiatingSession(gw *cloudClient.WebsocketGateway, sh *ser
 	return nil
 }
 
-func (c *initConfig) joiningSession(gw *cloudClient.WebsocketGateway, sh *service.Handler, services []types.ServiceType, initiatorAddress string, passphrase string) error {
+func (c *initConfig) joiningSession(gw *cloudClient.WebsocketGateway, sh *service.Handler, services map[types.ServiceType]string, initiatorAddress string, passphrase string) error {
 	session := types.Session{
 		Passphrase:       passphrase,
 		Address:          sh.Address,

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.6
 
 toolchain go1.23.1
 
-replace github.com/canonical/microcluster/v2 => github.com/canonical/microcluster/v2 v2.0.0-20240911074836-85e676b8f4bc
+replace github.com/canonical/microcluster/v2 => github.com/canonical/microcluster/v2 v2.0.0-20241010184845-bc97112f9a28
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
@@ -24,7 +24,7 @@ require (
 	golang.org/x/mod v0.21.0
 	golang.org/x/net v0.29.0
 	golang.org/x/sync v0.8.0
-	golang.org/x/sys v0.25.0
+	golang.org/x/sys v0.26.0
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -53,7 +53,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
-	github.com/mattn/go-sqlite3 v1.14.23 // indirect
+	github.com/mattn/go-sqlite3 v1.14.24 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/muesli/termenv v0.15.2 // indirect
 	github.com/muhlemmer/gu v0.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/canonical/lxd v0.0.0-20241001102405-5bba53b1ecd4 h1:dVHeJJSpW7jFqC96s
 github.com/canonical/lxd v0.0.0-20241001102405-5bba53b1ecd4/go.mod h1:UyjqYS/HZYiXb+kjpnYUphDy5wewkdVs7+ZnXUGpzq0=
 github.com/canonical/microceph/microceph v0.0.0-20240912190827-ef42f096671e h1:enQgR0bgyQ1SfYIvYx5rU4n0OLjtpbIraGiwzqBtpYk=
 github.com/canonical/microceph/microceph v0.0.0-20240912190827-ef42f096671e/go.mod h1:l/yzvjl6FsuNClbYx2VffcL4QZsYff5qElaKWFqktjc=
-github.com/canonical/microcluster/v2 v2.0.0-20240911074836-85e676b8f4bc h1:nFhj6x5C7syjO1BoxBCWlRexxRa18H1Ema6RsMJePr8=
-github.com/canonical/microcluster/v2 v2.0.0-20240911074836-85e676b8f4bc/go.mod h1:XNhXLFX75lmDbFAggZ4oDgJRWO9xLdhDcDfWTOEgzSQ=
+github.com/canonical/microcluster/v2 v2.0.0-20241010184845-bc97112f9a28 h1:wcWkJtNGe+Tvxyqcb3otxwmDAJlD5BAKYR3ZANt1rxg=
+github.com/canonical/microcluster/v2 v2.0.0-20241010184845-bc97112f9a28/go.mod h1:+Zb+8JiZREtxm8kMbk4IwPwwI67c/GOcSemCn5l3LH4=
 github.com/canonical/microovn/microovn v0.0.0-20240912142147-31ce8c71de4f h1:PGrs8+znx4IqgwywlEljB9H7r/QEc6Pba6nVB7+VVRc=
 github.com/canonical/microovn/microovn v0.0.0-20240912142147-31ce8c71de4f/go.mod h1:e23IdSkgJMqi9gwNhCQPznblE0/X7KLVZUIOvkDYPa8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -265,8 +265,8 @@ github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v1.14.7/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
-github.com/mattn/go-sqlite3 v1.14.23 h1:gbShiuAP1W5j9UOksQ06aiiqPMxYecovVGwmTxWtuw0=
-github.com/mattn/go-sqlite3 v1.14.23/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/mattn/go-sqlite3 v1.14.24 h1:tpSp2G2KyMnnQu99ngJ47EIkWVmliIizyZBfPrBWDRM=
+github.com/mattn/go-sqlite3 v1.14.24/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -547,8 +547,8 @@ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
-golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
+golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/multicast/discovery.go
+++ b/multicast/discovery.go
@@ -17,11 +17,11 @@ import (
 
 // ServerInfo is information about the server that is discovered using multicast.
 type ServerInfo struct {
-	Version     string              `json:"version"`
-	Name        string              `json:"name,omitempty"`
-	Address     string              `json:"address,omitempty"`
-	Services    []types.ServiceType `json:"services,omitempty"`
-	Certificate *x509.Certificate   `json:"certificates,omitempty"`
+	Version     string                       `json:"version"`
+	Name        string                       `json:"name,omitempty"`
+	Address     string                       `json:"address,omitempty"`
+	Services    map[types.ServiceType]string `json:"services,omitempty"`
+	Certificate *x509.Certificate            `json:"certificates,omitempty"`
 }
 
 // Discovery represents the information used for discovering peers using multicast.

--- a/service/interface.go
+++ b/service/interface.go
@@ -27,4 +27,5 @@ type Service interface {
 	Port() int64
 	SetConfig(config map[string]string)
 	SupportsFeature(ctx context.Context, feature string) (bool, error)
+	GetVersion(ctx context.Context) (string, error)
 }

--- a/service/lxd.go
+++ b/service/lxd.go
@@ -638,6 +638,26 @@ func (s *LXDService) ValidateCephInterfaces(cephNetworkSubnetStr string, peerInt
 	return data, nil
 }
 
+// GetVersion gets the installed daemon version of the service, and returns an error if the version is not supported.
+func (s LXDService) GetVersion(ctx context.Context) (string, error) {
+	client, err := s.Client(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	server, _, err := client.GetServer()
+	if err != nil {
+		return "", fmt.Errorf("Failed to retrieve current server configuration: %w", err)
+	}
+
+	err = validateVersion(s.Type(), server.Environment.ServerVersion)
+	if err != nil {
+		return "", err
+	}
+
+	return server.Environment.ServerVersion, nil
+}
+
 // isInitialized checks if LXD is initialized by fetching the storage pools.
 // If none exist, that means LXD has not yet been set up.
 func (s *LXDService) isInitialized(c lxd.InstanceServer) (bool, error) {

--- a/service/lxd_config.go
+++ b/service/lxd_config.go
@@ -11,9 +11,6 @@ import (
 	"github.com/canonical/lxd/shared/api"
 )
 
-// lxdMinVersion is the minimum version of LXD that fully supports all MicroCloud features.
-const lxdMinVersion = "5.21"
-
 // DefaultFANNetwork is the name of the default FAN network.
 const DefaultFANNetwork = "lxdfan0"
 

--- a/service/microceph.go
+++ b/service/microceph.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 	cephTypes "github.com/canonical/microceph/microceph/api/types"
 	cephClient "github.com/canonical/microceph/microceph/client"
@@ -260,6 +261,25 @@ func (s CephService) Address() string {
 // Port returns the port of this Service instance.
 func (s CephService) Port() int64 {
 	return s.port
+}
+
+// GetVersion gets the installed daemon version of the service, and returns an error if the version is not supported.
+func (s CephService) GetVersion(ctx context.Context) (string, error) {
+	status, err := s.m.Status(ctx)
+	if err != nil && api.StatusErrorCheck(err, http.StatusNotFound) {
+		return "", fmt.Errorf("The installed version of %s is not supported", s.Type())
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	err = validateVersion(s.Type(), status.Version)
+	if err != nil {
+		return "", err
+	}
+
+	return status.Version, nil
 }
 
 // SetConfig sets the config of this Service instance.

--- a/service/microcloud.go
+++ b/service/microcloud.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -349,6 +350,20 @@ func (s *CloudService) SetConfig(config map[string]string) {
 	for key, value := range config {
 		s.config[key] = value
 	}
+}
+
+// GetVersion gets the installed daemon version of the service, and returns an error if the version is not supported.
+func (s CloudService) GetVersion(ctx context.Context) (string, error) {
+	status, err := s.client.Status(ctx)
+	if err != nil && api.StatusErrorCheck(err, http.StatusNotFound) {
+		return "", fmt.Errorf("The installed version of %s is not supported", s.Type())
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	return status.Version, nil
 }
 
 // SupportsFeature checks if the specified API feature of this Service instance if supported.

--- a/service/microovn.go
+++ b/service/microovn.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/microcluster/v2/client"
 	"github.com/canonical/microcluster/v2/microcluster"
@@ -183,6 +184,25 @@ func (s OVNService) Address() string {
 // Port returns the port of this Service instance.
 func (s OVNService) Port() int64 {
 	return s.port
+}
+
+// GetVersion gets the installed daemon version of the service, and returns an error if the version is not supported.
+func (s OVNService) GetVersion(ctx context.Context) (string, error) {
+	status, err := s.m.Status(ctx)
+	if err != nil && api.StatusErrorCheck(err, http.StatusNotFound) {
+		return "", fmt.Errorf("The installed version of %s is not supported", s.Type())
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	err = validateVersion(s.Type(), status.Version)
+	if err != nil {
+		return "", err
+	}
+
+	return status.Version, nil
 }
 
 // SetConfig sets the config of this Service instance.

--- a/service/system_information.go
+++ b/service/system_information.go
@@ -310,10 +310,10 @@ func (s *SystemInformation) ServiceClustered(service types.ServiceType) bool {
 
 // ClustersConflict compares the cluster members reported by each system in the list of systems, for each given service.
 // If two distinct clusters exist for any service, this function returns true, with the name of the service.
-func ClustersConflict(systems map[string]SystemInformation, services []types.ServiceType) (bool, types.ServiceType) {
+func ClustersConflict(systems map[string]SystemInformation, services map[types.ServiceType]string) (bool, types.ServiceType) {
 	firstEncounteredClusters := map[types.ServiceType]map[string]string{}
 	for _, info := range systems {
-		for _, service := range services {
+		for service := range services {
 			// If a service is not clustered, it cannot conflict.
 			if !info.ServiceClustered(service) {
 				continue

--- a/service/version.go
+++ b/service/version.go
@@ -1,0 +1,55 @@
+package service
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/mod/semver"
+
+	"github.com/canonical/microcloud/microcloud/api/types"
+)
+
+const (
+	// lxdMinVersion is the minimum version of LXD that fully supports all MicroCloud features.
+	lxdMinVersion = "5.21"
+
+	// microCephMinVersion is the minimum version of MicroCeph that fully supports all MicroCloud features.
+	microCephMinVersion = "19.2"
+
+	// microOVNMinVersion is the minimum version of MicroOVN that fully supports all MicroCloud features.
+	microOVNMinVersion = "24.03"
+)
+
+// validateVersion checks that the daemon version for the given service is at a supported version for this version of MicroCloud.
+func validateVersion(serviceType types.ServiceType, daemonVersion string) error {
+	switch serviceType {
+	case types.LXD:
+		lxdVersion := semver.Canonical(fmt.Sprintf("v%s", daemonVersion))
+		expectedVersion := semver.Canonical(fmt.Sprintf("v%s", lxdMinVersion))
+		if semver.Compare(semver.MajorMinor(lxdVersion), semver.MajorMinor(expectedVersion)) != 0 {
+			return fmt.Errorf("%s version %q is not supported", serviceType, daemonVersion)
+		}
+
+	case types.MicroOVN:
+		if daemonVersion != microOVNMinVersion {
+			return fmt.Errorf("%s version %q is not supported", serviceType, daemonVersion)
+		}
+
+	case types.MicroCeph:
+		// Parse out the underlying ceph version from the version string.
+		before, after, ok := strings.Cut(daemonVersion, "ceph-version: ")
+		cephVersion := strings.Split(after, "~")
+		if !ok || before != "" || !strings.Contains(after, "~") || len(cephVersion) != 2 || cephVersion[0] == "" {
+			return fmt.Errorf("%s version format not supported (%s)", serviceType, daemonVersion)
+		}
+
+		daemonVersion = cephVersion[0]
+		daemonVersion = semver.Canonical(fmt.Sprintf("v%s", daemonVersion))
+		expectedVersion := semver.Canonical(fmt.Sprintf("v%s", microCephMinVersion))
+		if semver.Compare(semver.MajorMinor(daemonVersion), semver.MajorMinor(expectedVersion)) != 0 {
+			return fmt.Errorf("%s version %q is not supported", serviceType, daemonVersion)
+		}
+	}
+
+	return nil
+}

--- a/service/version_test.go
+++ b/service/version_test.go
@@ -1,0 +1,138 @@
+package service
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/canonical/microcloud/microcloud/api/types"
+	"github.com/canonical/microcloud/microcloud/version"
+)
+
+type versionSuite struct {
+	suite.Suite
+}
+
+func TestVersionSuite(t *testing.T) {
+	suite.Run(t, new(versionSuite))
+}
+
+func (s *versionSuite) Test_validateVersions() {
+	cases := []struct {
+		desc      string
+		version   string
+		service   types.ServiceType
+		expectErr bool
+	}{
+		{
+			desc:      "Valid MicroCeph",
+			version:   fmt.Sprintf("ceph-version: %s.0~git", microCephMinVersion),
+			service:   types.MicroCeph,
+			expectErr: false,
+		},
+		{
+			desc:      "Valid MicroOVN",
+			version:   microOVNMinVersion,
+			service:   types.MicroOVN,
+			expectErr: false,
+		},
+		{
+			desc:      "Valid MicroCloud",
+			version:   version.Version,
+			service:   types.MicroCloud,
+			expectErr: false,
+		},
+		{
+			desc:      "Valid LXD",
+			version:   lxdMinVersion,
+			service:   types.LXD,
+			expectErr: false,
+		},
+		{
+			desc:      "Invalid MicroCeph",
+			version:   microCephMinVersion,
+			service:   types.MicroCeph,
+			expectErr: true,
+		},
+		{
+			desc:      "Valid LXD with different patch version",
+			version:   fmt.Sprintf("%s.999", lxdMinVersion),
+			service:   types.LXD,
+			expectErr: false,
+		},
+		{
+			desc:      "Valid MicroCeph with different patch version",
+			version:   fmt.Sprintf("ceph-version: %s.999~git", microCephMinVersion),
+			service:   types.MicroCeph,
+			expectErr: false,
+		},
+		{
+			desc:      "MicroCloud is always valid because it's local",
+			version:   "",
+			service:   types.MicroCloud,
+			expectErr: false,
+		},
+		{
+			desc:      "Unsupported LXD with different minor version",
+			version:   fmt.Sprintf("%s.999", strings.Split(lxdMinVersion, ".")[0]),
+			service:   types.LXD,
+			expectErr: true,
+		},
+		{
+			desc:      "Unsupported MicroCeph with larger minor version",
+			version:   fmt.Sprintf("ceph-version: %s.999~git", strings.Split(microCephMinVersion, ".")[0]),
+			service:   types.MicroCeph,
+			expectErr: true,
+		},
+		{
+			desc:      "Unsupported MicroCeph with smaller minor version",
+			version:   fmt.Sprintf("ceph-version: %s.0~git", strings.Split(microCephMinVersion, ".")[0]),
+			service:   types.MicroCeph,
+			expectErr: true,
+		},
+		{
+			desc:      "Unsupported LXD with larger major version",
+			version:   "999.0",
+			service:   types.LXD,
+			expectErr: true,
+		},
+		{
+			desc:      "Unsupported LXD with smaller major version",
+			version:   "1.0",
+			service:   types.LXD,
+			expectErr: true,
+		},
+		{
+			desc:      "Unsupported MicroCeph with larger major version",
+			version:   "ceph-version: 999.0.0~git",
+			service:   types.MicroCeph,
+			expectErr: true,
+		},
+		{
+			desc:      "Unsupported MicroCeph with smaller major version",
+			version:   "ceph-version: 1.0.0~git",
+			service:   types.MicroCeph,
+			expectErr: true,
+		},
+
+		{
+			desc:      "Unsupported MicroOVN (direct string comparison)",
+			version:   microOVNMinVersion + ".0",
+			service:   types.MicroOVN,
+			expectErr: true,
+		},
+	}
+
+	for i, c := range cases {
+		s.T().Logf("%d: %s", i, c.desc)
+
+		err := validateVersion(c.service, c.version)
+		if c.expectErr {
+			s.Error(err)
+		} else {
+			s.NoError(err)
+		}
+	}
+}

--- a/test/main.sh
+++ b/test/main.sh
@@ -123,7 +123,7 @@ trap cleanup EXIT HUP INT TERM
 # Import all the testsuites
 import_subdir_files suites
 
-LXD_SNAP_CHANNEL="${LXD_SNAP_CHANNEL:-latest/edge}"
+LXD_SNAP_CHANNEL="${LXD_SNAP_CHANNEL:-5.21/candidate}"
 export LXD_SNAP_CHANNEL
 
 MICROCEPH_SNAP_CHANNEL="${MICROCEPH_SNAP_CHANNEL:-latest/edge}"

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -1033,6 +1033,18 @@ test_service_mismatch() {
     validate_system_microovn "${m}"
   done
 
+  reset_systems 1 3 1
+
+  lxc exec micro01 -- sh -c "echo 1 > /proc/sys/net/ipv6/conf/enp5s0/disable_ipv6"
+  lxc exec micro01 -- snap refresh microceph --channel reef/stable
+
+  microcloud_interactive init micro01
+  lxc exec micro01 -- tail -1 out | grep -q "The installed version of MicroCeph is not supported"
+
+  lxc exec micro01 -- rm -rf out
+  ! lxc exec micro01 --env "TEST_CONSOLE=0" -- sh -c "microcloud join 2> out" || false
+  lxc exec micro01 -- tail -1 out | grep -q "The installed version of MicroCeph is not supported"
+
   # Try to set up a LXD-only MicroCloud while some systems have other services present.
   reset_systems 3 3 1
 


### PR DESCRIPTION
Adds version enforcement to MicroCloud.

The `services` list used to keep track of the set of installed services is repurposed as a `map[types.ServiceType]string` which maps each installed service to the version it's installed at. Then, when validating the set of services when receiving a join intent, we also check that the versions match exactly.

When running any `microcloud` initialization command, we first compile the list of installed services, along with their versions, and check that they match the pre-defined minimum versions. For semantic versions like LXD and MicroCloud, we only check against the major and minor versions, so patch versions are acceptable. Patch versions must still match between initiators and joiners.

For MicroCeph, we parse out the ceph version. This is not a standard semantic version (see: https://docs.ceph.com/en/latest/releases/general/#understanding-the-release-cycle), however, we can treat it like one because we require the first 2 numbers to be equal, and the last represents bugfixes which are allowed.

MicroOVN uses a named version, represented by the release window (for example 24.03), so we can use direct string comparison here. 
