### PR TITLE
Check microcloud exit codes

### DIFF
--- a/test/includes/microcloud.sh
+++ b/test/includes/microcloud.sh
@@ -1031,6 +1031,7 @@ restore_system() {
     done
   )
 
+  set_debug_binaries "${name}"
   echo "==> Restored ${name}"
 }
 

--- a/test/main.sh
+++ b/test/main.sh
@@ -123,7 +123,7 @@ trap cleanup EXIT HUP INT TERM
 # Import all the testsuites
 import_subdir_files suites
 
-LXD_SNAP_CHANNEL="${LXD_SNAP_CHANNEL:-5.21/candidate}"
+LXD_SNAP_CHANNEL="${LXD_SNAP_CHANNEL:-5.21/edge}"
 export LXD_SNAP_CHANNEL
 
 MICROCEPH_SNAP_CHANNEL="${MICROCEPH_SNAP_CHANNEL:-latest/edge}"

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -1009,7 +1009,7 @@ test_service_mismatch() {
   # Init should fail to find the other systems as they don't have the same services.
   # The error is reported on the joining side.
   echo "Peers with missing services cannot join"
-  microcloud_interactive init micro01 | capture_and_join micro02 micro03
+  ! microcloud_interactive init micro01 | capture_and_join micro02 micro03 || false
 
   # Ensure the joiners exited due to missing services.
   # The initiator exits automatically after the session timeout.
@@ -1196,7 +1196,7 @@ test_reuse_cluster() {
   lxc exec micro02 -- microceph cluster bootstrap
   token="$(lxc exec micro02 -- microceph cluster add micro04)"
   lxc exec micro04 -- microceph cluster join "${token}"
-  microcloud_interactive init micro01 | capture_and_join micro02 micro03 micro04
+  microcloud_interactive init micro01 | capture_and_join micro02 micro03
   services_validator
   validate_system_microceph micro04 1
 
@@ -1204,7 +1204,7 @@ test_reuse_cluster() {
   echo "Fail to create a MicroCloud due to conflicting existing services"
   lxc exec micro02 -- microceph cluster bootstrap
   lxc exec micro03 -- microceph cluster bootstrap
-  microcloud_interactive init micro01 | capture_and_join micro02 micro03
+  ! microcloud_interactive init micro01 | capture_and_join micro02 micro03 || false
   lxc exec micro01 -- tail -1 out | grep "Some systems are already part of different MicroCeph clusters. Aborting initialization" -q
 
   reset_systems 3 3 3


### PR DESCRIPTION
The new `capture_and_join` pattern seems to ignore the exit codes returned by the microcloud commands, so we can't check if the command actually errored without reading the output. 

Instead, this stores the exit code from each command in a `code` file, which is then checked for `0` in `capture_and_join` before unblocking.

* Also updates the tests to use `5.21/edge` to catch regressions earlier.
* Also makes sure debug binaries are updated on subsequent test runs. This slows down the test suite slightly, but is quite helpful for local debugging, as you can just rebuild your binaries and run a single test again.