### PR TITLE
renovate: Move the file and disable

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "enabled": false,
+    "dependencyDashboard": false,
+    "extends": [
+      "config:recommended",
+      ":disableDependencyDashboard"
+    ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base",
-    "schedule:earlyMondays"
-  ]
-}


### PR DESCRIPTION
This is using the same structure as microcluster to disable renovate and to place the configuration inside of `.github/`

Closes https://github.com/canonical/microcloud/issues/279