### PR TITLE
Test: Don't use `--accept-certificate` when using token

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -217,7 +217,7 @@ jobs:
       - name: "Setup host LXD"
         run: |
           set -eux
-          sudo snap install lxd --channel latest/edge || sudo snap refresh lxd --channel latest/edge
+          sudo snap install lxd --channel 5.21/edge || sudo snap refresh lxd --channel 5.21/edge
           sudo lxd init --auto
 
       - name: "Prepare for system tests"

--- a/test/includes/microcloud.sh
+++ b/test/includes/microcloud.sh
@@ -290,19 +290,18 @@ set_debug_binaries() {
 set_remote() {
   remote="${1}"
   name="${2}"
+  client="${3}"
 
   lxc remote switch local
-
-  addr="$(lxc exec "${name}" -- lxc config get cluster.https_address)"
 
   if lxc remote list -f csv | cut -d',' -f1 | grep -qwF "${remote}" ; then
     lxc remote remove "${remote}"
   fi
 
-  token="$(lxc exec "${name}" -- lxc config trust add --name test --quiet)"
+  token="$(lxc exec "${name}" -- lxc config trust add --name "${client}" --quiet)"
 
   # Suppress the confirmation as it's noisy.
-  lxc remote add "${remote}" "https://${addr}" --token "${token}" > /dev/null 2>&1
+  lxc remote add "${remote}" "${token}" > /dev/null 2>&1
   lxc remote switch "${remote}"
 }
 
@@ -580,8 +579,8 @@ validate_system_lxd() {
 
     lxc remote switch local
 
-    # Add the peer as a remote.
-    set_remote microcloud-test "${name}"
+    # Add the peer as a remote using the name test for the trust.
+    set_remote microcloud-test "${name}" test
 
     # Ensure we are clustered and online.
     lxc cluster list -f csv | sed -e 's/,\?database-leader,\?//' | cut -d',' -f1,7 | grep -qxF "${name},ONLINE"
@@ -629,6 +628,12 @@ validate_system_lxd() {
     fi
 
     lxc remote switch local
+
+    # Remove the trust on the remote which was added when adding the remote.
+    fingerprint="$(lxc query microcloud-test:/1.0/certificates?recursion=1 | jq -r '.[] | select(.name=="test") | .fingerprint')"
+    lxc config trust remove "microcloud-test:${fingerprint}"
+
+    # Remove the remote.
     lxc remote remove microcloud-test
 
     echo "==> ${name} Validated LXD"

--- a/test/includes/microcloud.sh
+++ b/test/includes/microcloud.sh
@@ -302,7 +302,7 @@ set_remote() {
   token="$(lxc exec "${name}" -- lxc config trust add --name test --quiet)"
 
   # Suppress the confirmation as it's noisy.
-  lxc remote add "${remote}" "https://${addr}" --token "${token}" --accept-certificate > /dev/null 2>&1
+  lxc remote add "${remote}" "https://${addr}" --token "${token}" > /dev/null 2>&1
   lxc remote switch "${remote}"
 }
 

--- a/test/includes/microcloud.sh
+++ b/test/includes/microcloud.sh
@@ -503,7 +503,6 @@ validate_system_lxd_ovn() {
   dns_namesersers=${7:-}
 
   echo "    ${name} Validating OVN network"
-  addr=$(lxc exec local:"${name}" -- lxc config get cluster.https_address)
 
   num_conns=3
   if [ "${num_peers}" -lt "${num_conns}" ]; then


### PR DESCRIPTION
After https://github.com/canonical/lxd/pull/14149 got merged in LXD we should not anymore use `--accept-certificate` when using the token as the token itself already contains the fingerprint which is enough.

This currently leads to failures in the test suite, see https://github.com/canonical/microcloud/actions/runs/11324655287/job/31553675652?pr=425.