### PR TITLE
Cmd: Use service type name instead of version

### DIFF
--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -1666,7 +1666,7 @@ func (c *initConfig) askJoinConfirmation(gw *cloudClient.WebsocketGateway, servi
 
 	if len(newServices) > 0 {
 		var servicesStr []string
-		for _, service := range newServices {
+		for service := range newServices {
 			servicesStr = append(servicesStr, string(service))
 		}
 


### PR DESCRIPTION
This fixes a small regression introduced with the snap version enforcement which now causes the list of services that are going to be joined to display their version instead of the name:

`Commencing cluster join of the remaining services (ceph-version: 19.2.0~git20240301.4c76c50-0ubuntu6.1; microceph-git: c76c1f5fe9, 24.03, 5.21.2)`