### PR TITLE
Report if skipping local storage & ovn config

### DIFF
--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -244,7 +244,8 @@ func (c *initConfig) askLocalPool(sh *service.Handler) error {
 	for _, info := range c.state {
 		hasPool, supportsPool := info.SupportsLocalPool()
 		if !supportsPool {
-			logger.Warn("Skipping local storage pool setup, some systems don't support it")
+			fmt.Println("Skipping local storage pool setup, some systems don't support it")
+
 			return nil
 		}
 
@@ -268,13 +269,10 @@ func (c *initConfig) askLocalPool(sh *service.Handler) error {
 		}
 	}
 
-	// Local storage is already set up on every system.
-	if len(askSystems) == 0 {
-		return nil
-	}
+	// Local storage is already set up on every system, or if not every system has a disk.
+	if len(askSystems) == 0 || len(availableDisks) != len(askSystems) {
+		fmt.Println("No disks available for local storage. Skipping configuration")
 
-	// We can't setup a local pool if not every system has a disk.
-	if len(availableDisks) != len(askSystems) {
 		return nil
 	}
 

--- a/test/includes/microcloud.sh
+++ b/test/includes/microcloud.sh
@@ -127,10 +127,16 @@ $(true)                                                 # workaround for set -e
 "
 fi
 
+if [ -n "${OVN_WARNING}" ] ; then
+  setup="${setup}
+${OVN_WARNING}                                         # continue with some peers missing an interface? (yes/no)
+$(true)                                                 # workaround for set -e
+"
+fi
+
 if [ -n "${SETUP_OVN}" ]; then
   setup="${setup}
 ${SETUP_OVN}                                           # agree to setup OVN
-${OVN_WARNING}                                         # continue with some peers missing an interface? (yes/no)
 $([ "${SETUP_OVN}" = "yes" ] && printf "wait 300ms")   # wait for the table to populate
 ${OVN_FILTER}                                          # filter interfaces
 $([ "${SETUP_OVN}" = "yes" ] && printf "select-all")   # select all interfaces matching the filter

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -940,6 +940,8 @@ _test_case() {
       else
         export SETUP_OVN="no"
       fi
+    else
+      export OVN_WARNING="yes"
     fi
 
     join_systems=""

--- a/test/suites/recover.sh
+++ b/test/suites/recover.sh
@@ -9,9 +9,7 @@ test_recover() {
   export MULTI_NODE="yes"
   export LOOKUP_IFACE="enp5s0"
   export EXPECT_PEERS=3
-  export SETUP_ZFS="no"
-  export SETUP_CEPH="no"
-  export SETUP_OVN="no"
+  export OVN_WARNING="yes"
 
   microcloud_interactive init micro01 | capture_and_join micro02 micro03 micro04
   lxc exec micro01 -- tail -1 out | grep "MicroCloud is ready" -q


### PR DESCRIPTION
Prints a message rather than a log when skipping local storage. I thought to avoid a question in this case because the immediate question is for remote storage, and a user may not have enough disks for both.

For OVN config, we do ask a question because FAN networks are being phased out and is not an ideal alternative to MicroOVN anyway. Now, if any systems are ineligible, we immediately ask if the user wants to abort setup. If they choose to continue, we fallback to a FAN network.