### PR TITLE
Discovery: Have a dedicated `StopResponder` to not rely on the context

### DIFF
--- a/multicast/discovery_test.go
+++ b/multicast/discovery_test.go
@@ -2,8 +2,10 @@ package multicast
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -20,11 +22,18 @@ func (m *multicastSuite) Test_Lookup() {
 	cases := []struct {
 		desc          string
 		lookupVersion string
+		lookupIface   string
+		lookupPort    int64
 		responseInfo  ServerInfo
+		lookupErr     error
+		lookupTimeout time.Duration
+		modifier      func(server *Discovery)
 	}{
 		{
 			desc:          "System with matching version can be looked up",
 			lookupVersion: "2.0",
+			lookupIface:   "lo",
+			lookupPort:    9444,
 			responseInfo: ServerInfo{
 				Version: "2.0",
 				Name:    "foo",
@@ -34,11 +43,47 @@ func (m *multicastSuite) Test_Lookup() {
 		{
 			desc:          "System with maximum allowed server name length, IPv6 address and high version number can be looked up",
 			lookupVersion: "142.0",
+			lookupIface:   "lo",
+			lookupPort:    9444,
 			responseInfo: ServerInfo{
 				Version: "142.0",
 				Name:    strings.Repeat("a", 255),
 				Address: "fd42:c4cc:2e1d:132d:a216:3eff:fecd:9d15",
 			},
+		},
+		{
+			desc:        "Cannot lookup system if invalid interface is given",
+			lookupIface: "invalid-interface",
+			lookupErr:   fmt.Errorf(`Failed to resolve lookup interface "invalid-interface": route ip+net: no such network interface`),
+		},
+		{
+			desc:          "Cannot lookup system if the responder is offline",
+			lookupVersion: "2.0",
+			lookupIface:   "lo",
+			lookupPort:    9444,
+			responseInfo: ServerInfo{
+				Version: "2.0",
+				Name:    "foo",
+				Address: "1.2.3.4",
+			},
+			lookupTimeout: 500 * time.Microsecond,
+			modifier: func(server *Discovery) {
+				_ = server.StopResponder()
+			},
+			lookupErr: fmt.Errorf("Failed to read from multicast network endpoint: Timeout exceeded"),
+		},
+		{
+			desc:          "Cannot lookup system if the responder uses a different version",
+			lookupVersion: "3.0",
+			lookupIface:   "lo",
+			lookupPort:    9444,
+			responseInfo: ServerInfo{
+				Version: "2.0",
+				Name:    "foo",
+				Address: "1.2.3.4",
+			},
+			lookupTimeout: 500 * time.Microsecond,
+			lookupErr:     fmt.Errorf("Failed to read from multicast network endpoint: Timeout exceeded"),
 		},
 	}
 
@@ -48,15 +93,31 @@ func (m *multicastSuite) Test_Lookup() {
 		// Use the loopback interface as it should always be there on any test system.
 		discovery := NewDiscovery("lo", 9444)
 
-		ctx, cancel := context.WithCancel(context.Background())
-		err := discovery.Respond(ctx, c.responseInfo)
+		err := discovery.Respond(context.Background(), c.responseInfo)
 		m.Require().NoError(err)
 
-		receivedInfo, err := discovery.Lookup(ctx, c.lookupVersion)
-		m.Require().NoError(err)
-		m.Require().Equal(&c.responseInfo, receivedInfo)
+		if c.modifier != nil {
+			c.modifier(discovery)
+		}
+
+		testDiscovery := NewDiscovery(c.lookupIface, c.lookupPort)
+
+		ctx := context.Background()
+		if c.lookupTimeout > 0 {
+			ctx, _ = context.WithTimeoutCause(ctx, c.lookupTimeout, fmt.Errorf("Timeout exceeded"))
+		}
+
+		receivedInfo, err := testDiscovery.Lookup(ctx, c.lookupVersion)
+		if c.lookupErr == nil {
+			m.Require().NoError(err)
+			m.Require().Equal(&c.responseInfo, receivedInfo)
+		} else {
+			m.Require().Error(err)
+			m.Require().Equal(c.lookupErr.Error(), err.Error())
+		}
 
 		// Stop the responder.
-		cancel()
+		err = discovery.StopResponder()
+		m.Require().NoError(err)
 	}
 }


### PR DESCRIPTION
In one run of the unit tests on GH [an error surfaced](https://github.com/canonical/microcloud/actions/runs/11327243960/job/31497901025?pr=426) that has shown that subsequent starts of the responder might collide which each other if the connection hasn't yet been cleaned up successfully when cancelling the context.

By having a dedicated `StopResponder` func we can make sure that the underlying connection is closed before starting a new one.
As before with mDNS we now track the server in the session so we can close it when the session gets closed.