### PR TITLE
Cmd: Wait for the local daemon to become ready

### DIFF
--- a/cmd/microcloud/add.go
+++ b/cmd/microcloud/add.go
@@ -60,6 +60,11 @@ func (c *cmdAdd) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	err = cloudApp.Ready(context.Background())
+	if err != nil {
+		return fmt.Errorf("Failed to wait for MicroCloud to get ready: %w", err)
+	}
+
 	status, err := cloudApp.Status(context.Background())
 	if err != nil {
 		return fmt.Errorf("Failed to get MicroCloud status: %w", err)

--- a/cmd/microcloud/join.go
+++ b/cmd/microcloud/join.go
@@ -71,6 +71,11 @@ func (c *cmdJoin) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	err = cloudApp.Ready(context.Background())
+	if err != nil {
+		return fmt.Errorf("Failed to wait for MicroCloud to get ready: %w", err)
+	}
+
 	status, err := cloudApp.Status(context.Background())
 	if err != nil {
 		return fmt.Errorf("Failed to get MicroCloud status: %w", err)

--- a/cmd/microcloud/preseed.go
+++ b/cmd/microcloud/preseed.go
@@ -171,6 +171,11 @@ func (c *initConfig) RunPreseed(cmd *cobra.Command) error {
 		return err
 	}
 
+	err = cloudApp.Ready(context.Background())
+	if err != nil {
+		return fmt.Errorf("Failed to wait for MicroCloud to get ready: %w", err)
+	}
+
 	status, err := cloudApp.Status(context.Background())
 	if err != nil {
 		return fmt.Errorf("Failed to get MicroCloud status: %w", err)

--- a/cmd/microcloud/remove.go
+++ b/cmd/microcloud/remove.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/canonical/microcluster/v2/microcluster"
 	"github.com/spf13/cobra"
@@ -37,6 +38,11 @@ func (c *cmdRemove) Run(cmd *cobra.Command, args []string) error {
 	m, err := microcluster.App(options)
 	if err != nil {
 		return err
+	}
+
+	err = m.Ready(context.Background())
+	if err != nil {
+		return fmt.Errorf("Failed to wait for MicroCloud to get ready: %w", err)
 	}
 
 	client, err := m.LocalClient()

--- a/cmd/microcloud/services.go
+++ b/cmd/microcloud/services.go
@@ -66,6 +66,11 @@ func (c *cmdServiceList) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	err = cloudApp.Ready(context.Background())
+	if err != nil {
+		return fmt.Errorf("Failed to wait for MicroCloud to get ready: %w", err)
+	}
+
 	// Fetch the name and address, and ensure we're initialized.
 	status, err := cloudApp.Status(context.Background())
 	if err != nil {
@@ -221,6 +226,11 @@ func (c *cmdServiceAdd) Run(cmd *cobra.Command, args []string) error {
 	cloudApp, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagMicroCloudDir})
 	if err != nil {
 		return err
+	}
+
+	err = cloudApp.Ready(context.Background())
+	if err != nil {
+		return fmt.Errorf("Failed to wait for MicroCloud to get ready: %w", err)
 	}
 
 	// Fetch the name and address, and ensure we're initialized.

--- a/cmd/microcloud/shutdown.go
+++ b/cmd/microcloud/shutdown.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/canonical/microcluster/v2/microcluster"
 	"github.com/spf13/cobra"
@@ -30,6 +31,11 @@ func (c *cmdShutdown) Run(cmd *cobra.Command, args []string) error {
 	m, err := microcluster.App(options)
 	if err != nil {
 		return err
+	}
+
+	err = m.Ready(context.Background())
+	if err != nil {
+		return fmt.Errorf("Failed to wait for MicroCloud to get ready: %w", err)
 	}
 
 	client, err := m.LocalClient()

--- a/cmd/microcloud/sql.go
+++ b/cmd/microcloud/sql.go
@@ -42,6 +42,11 @@ func (c *cmdSQL) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	err = m.Ready(context.Background())
+	if err != nil {
+		return fmt.Errorf("Failed to wait for MicroCloud to get ready: %w", err)
+	}
+
 	query := args[0]
 	dump, batch, err := m.SQL(context.Background(), query)
 	if err != nil {

--- a/cmd/microcloud/status.go
+++ b/cmd/microcloud/status.go
@@ -111,6 +111,11 @@ func (c *cmdStatus) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	err = cloudApp.Ready(context.Background())
+	if err != nil {
+		return fmt.Errorf("Failed to wait for MicroCloud to get ready: %w", err)
+	}
+
 	status, err := cloudApp.Status(context.Background())
 	if err != nil {
 		return fmt.Errorf("Failed to get MicroCloud status: %w", err)

--- a/cmd/microcloud/tokens.go
+++ b/cmd/microcloud/tokens.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"sort"
 
 	cli "github.com/canonical/lxd/shared/cmd"
@@ -61,6 +62,11 @@ func (c *cmdTokensList) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	err = m.Ready(context.Background())
+	if err != nil {
+		return fmt.Errorf("Failed to wait for MicroCloud to get ready: %w", err)
+	}
+
 	records, err := m.ListJoinTokens(context.Background())
 	if err != nil {
 		return err
@@ -100,6 +106,11 @@ func (c *cmdTokensRevoke) Run(cmd *cobra.Command, args []string) error {
 	m, err := microcluster.App(options)
 	if err != nil {
 		return err
+	}
+
+	err = m.Ready(context.Background())
+	if err != nil {
+		return fmt.Errorf("Failed to wait for MicroCloud to get ready: %w", err)
 	}
 
 	err = m.RevokeJoinToken(context.Background(), args[0])


### PR DESCRIPTION
I have seen [this](https://github.com/canonical/microcloud/actions/runs/11404169982/job/31732770512?pr=436) error multiple times now in the pipeline which indicates that the local microcluster daemon isn't yet ready and therefore hasn't yet setup its socket.

This PR puts a check in each CLI command to wait until the daemon is ready.