### PR TITLE
service: Explicitly set config on joiners

### DIFF
--- a/service/lxd.go
+++ b/service/lxd.go
@@ -215,8 +215,13 @@ func (s LXDService) Join(ctx context.Context, joinConfig JoinConfig) error {
 		return fmt.Errorf("Failed to retrieve LXD config: %w", err)
 	}
 
+	addr := util.CanonicalNetworkAddress(s.address, s.port)
 	newServer := currentServer.Writable()
 	newServer.Config["core.https_address"] = "[::]:8443"
+	newServer.Config["cluster.https_address"] = addr
+	if client.HasExtension("migration_stateful_default") {
+		newServer.Config["instances.migration.stateful"] = "true"
+	}
 
 	err = client.UpdateServer(newServer, etag)
 	if err != nil {


### PR DESCRIPTION
When removing a node from MicroCloud, and then adding it back, an error will be returned:

```
Error: System "n3" failed to join the cluster: Failed to update cluster status of services: Failed to join "LXD" cluster: Failed to join cluster: Cannot set "cluster.https_address" to "[::]:8443": Wildcard addresses aren't allowed
```

We should be able to fix this by manually populating these configs when we join the cluster again.