### PR TITLE
Join: Remove `--auto` and `--wipe` flag

### DIFF
--- a/cmd/microcloud/join.go
+++ b/cmd/microcloud/join.go
@@ -18,7 +18,6 @@ import (
 type cmdJoin struct {
 	common *CmdControl
 
-	flagAutoSetup        bool
 	flagWipe             bool
 	flagLookupTimeout    int64
 	flagSessionTimeout   int64
@@ -32,7 +31,6 @@ func (c *cmdJoin) Command() *cobra.Command {
 		RunE:  c.Run,
 	}
 
-	cmd.Flags().BoolVar(&c.flagAutoSetup, "auto", false, "Automatic setup with default configuration")
 	cmd.Flags().BoolVar(&c.flagWipe, "wipe", false, "Wipe disks to add to MicroCeph")
 	cmd.Flags().Int64Var(&c.flagLookupTimeout, "lookup-timeout", 0, "Amount of seconds to wait when finding systems on the network. Defaults: 60s")
 	cmd.Flags().Int64Var(&c.flagSessionTimeout, "session-timeout", 0, "Amount of seconds to wait for the trust establishment session. Defaults: 10m")
@@ -48,7 +46,6 @@ func (c *cmdJoin) Run(cmd *cobra.Command, args []string) error {
 
 	cfg := initConfig{
 		bootstrap:    false,
-		autoSetup:    c.flagAutoSetup,
 		wipeAllDisks: c.flagWipe,
 		common:       c.common,
 		asker:        &c.common.asker,

--- a/cmd/microcloud/join.go
+++ b/cmd/microcloud/join.go
@@ -18,7 +18,6 @@ import (
 type cmdJoin struct {
 	common *CmdControl
 
-	flagWipe             bool
 	flagLookupTimeout    int64
 	flagSessionTimeout   int64
 	flagInitiatorAddress string
@@ -31,7 +30,6 @@ func (c *cmdJoin) Command() *cobra.Command {
 		RunE:  c.Run,
 	}
 
-	cmd.Flags().BoolVar(&c.flagWipe, "wipe", false, "Wipe disks to add to MicroCeph")
 	cmd.Flags().Int64Var(&c.flagLookupTimeout, "lookup-timeout", 0, "Amount of seconds to wait when finding systems on the network. Defaults: 60s")
 	cmd.Flags().Int64Var(&c.flagSessionTimeout, "session-timeout", 0, "Amount of seconds to wait for the trust establishment session. Defaults: 10m")
 	cmd.Flags().StringVar(&c.flagInitiatorAddress, "initiator-address", "", "Address of the trust establishment session's initiator")
@@ -45,12 +43,11 @@ func (c *cmdJoin) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	cfg := initConfig{
-		bootstrap:    false,
-		wipeAllDisks: c.flagWipe,
-		common:       c.common,
-		asker:        &c.common.asker,
-		systems:      map[string]InitSystem{},
-		state:        map[string]service.SystemInformation{},
+		bootstrap: false,
+		common:    c.common,
+		asker:     &c.common.asker,
+		systems:   map[string]InitSystem{},
+		state:     map[string]service.SystemInformation{},
 	}
 
 	cfg.lookupTimeout = DefaultLookupTimeout


### PR DESCRIPTION
The `--auto` and `--wipe` flags seem to be a left over of from the `init` command when crafting the skeleton for the new `join` command introduced with https://github.com/canonical/microcloud/pull/383.

This PR removes the flags that don't have any value for the `join` command.