### PR TITLE
Remove unused preseed key

### DIFF
--- a/cmd/microcloud/preseed.go
+++ b/cmd/microcloud/preseed.go
@@ -29,17 +29,16 @@ import (
 
 // Preseed represents the structure of the supported preseed yaml.
 type Preseed struct {
-	LookupSubnet          string        `yaml:"lookup_subnet"`
-	LookupTimeout         int64         `yaml:"lookup_timeout"`
-	SessionPassphrase     string        `yaml:"session_passphrase"`
-	SessionTimeout        int64         `yaml:"session_timeout"`
-	ReuseExistingClusters bool          `yaml:"reuse_existing_clusters"`
-	Initiator             string        `yaml:"initiator"`
-	InitiatorAddress      string        `yaml:"initiator_address"`
-	Systems               []System      `yaml:"systems"`
-	OVN                   InitNetwork   `yaml:"ovn"`
-	Ceph                  CephOptions   `yaml:"ceph"`
-	Storage               StorageFilter `yaml:"storage"`
+	LookupSubnet      string        `yaml:"lookup_subnet"`
+	LookupTimeout     int64         `yaml:"lookup_timeout"`
+	SessionPassphrase string        `yaml:"session_passphrase"`
+	SessionTimeout    int64         `yaml:"session_timeout"`
+	Initiator         string        `yaml:"initiator"`
+	InitiatorAddress  string        `yaml:"initiator_address"`
+	Systems           []System      `yaml:"systems"`
+	OVN               InitNetwork   `yaml:"ovn"`
+	Ceph              CephOptions   `yaml:"ceph"`
+	Storage           StorageFilter `yaml:"storage"`
 }
 
 // System represents the structure of the systems we expect to find in the preseed yaml.
@@ -386,10 +385,6 @@ func (p *Preseed) validate(name string, bootstrap bool) error {
 		}
 
 		systemNames = append(systemNames, system.Name)
-	}
-
-	if !bootstrap && p.ReuseExistingClusters {
-		return fmt.Errorf("Additional cluster members cannot be part of a pre-existing cluster")
 	}
 
 	if bootstrap && !localInit {

--- a/cmd/microcloud/preseed_test.go
+++ b/cmd/microcloud/preseed_test.go
@@ -337,17 +337,6 @@ func (s *preseedSuite) Test_preseedMatchDisksMemory() {
 	s.Equal(results[0], disks[0])
 }
 
-// Tests that ReuseExistingClusters only works when initializing, not when growing the cluster.
-func (s *preseedSuite) Test_restrictClusterReuse() {
-	p := Preseed{SessionPassphrase: "foo", Initiator: "B", Systems: []System{{Name: "B"}, {Name: "C"}}}
-
-	s.NoError(p.validate("B", true))
-
-	s.Error(p.validate("A", false))
-
-	s.NoError(p.validate("A", false))
-}
-
 func (s *preseedSuite) Test_isInitiator() {
 	cases := []struct {
 		desc        string

--- a/cmd/microcloud/preseed_test.go
+++ b/cmd/microcloud/preseed_test.go
@@ -339,13 +339,12 @@ func (s *preseedSuite) Test_preseedMatchDisksMemory() {
 
 // Tests that ReuseExistingClusters only works when initializing, not when growing the cluster.
 func (s *preseedSuite) Test_restrictClusterReuse() {
-	p := Preseed{SessionPassphrase: "foo", Initiator: "B", ReuseExistingClusters: true, Systems: []System{{Name: "B"}, {Name: "C"}}}
+	p := Preseed{SessionPassphrase: "foo", Initiator: "B", Systems: []System{{Name: "B"}, {Name: "C"}}}
 
 	s.NoError(p.validate("B", true))
 
 	s.Error(p.validate("A", false))
 
-	p.ReuseExistingClusters = false
 	s.NoError(p.validate("A", false))
 }
 

--- a/doc/how-to/preseed.yaml
+++ b/doc/how-to/preseed.yaml
@@ -25,9 +25,6 @@ session_passphrase: 83P27XWKbDczUyE7xaX3pgVfaEacfQ2qiQ0r6gPb
 # It defaults to 60 minutes.
 session_timeout: 300
 
-# `reuse_existing_clusters` is optional and configures whether or not to reuse existing clusters.
-reuse_existing_clusters: true
-
 # `systems` lists the systems we expect to find by their host name.
 #   `name` represents the host name.
 #   `address` sets the address used for MicroCloud and is required in case `initiator_address` is present.


### PR DESCRIPTION
These keys were not properly used in MicroCloud, and so are being removed, rather than implemented.

Reusing existing clusters doesn't make a lot of sense for `preseed` mode because we can't ask the user how to resolve conflicts, and thus are forced to error out, outside of some narrow cases. 