### PR TITLE
CLI: Remove redundant flags

### DIFF
--- a/cmd/microcloud/add.go
+++ b/cmd/microcloud/add.go
@@ -18,7 +18,6 @@ import (
 type cmdAdd struct {
 	common *CmdControl
 
-	flagWipe           bool
 	flagSessionTimeout int64
 }
 
@@ -29,7 +28,6 @@ func (c *cmdAdd) Command() *cobra.Command {
 		RunE:  c.Run,
 	}
 
-	cmd.Flags().BoolVar(&c.flagWipe, "wipe", false, "Wipe disks to add to MicroCeph")
 	cmd.Flags().Int64Var(&c.flagSessionTimeout, "session-timeout", 0, "Amount of seconds to wait for the trust establishment session. Defaults: 60m")
 
 	return cmd
@@ -41,13 +39,12 @@ func (c *cmdAdd) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	cfg := initConfig{
-		bootstrap:    false,
-		setupMany:    true,
-		wipeAllDisks: c.flagWipe,
-		common:       c.common,
-		asker:        &c.common.asker,
-		systems:      map[string]InitSystem{},
-		state:        map[string]service.SystemInformation{},
+		bootstrap: false,
+		setupMany: true,
+		common:    c.common,
+		asker:     &c.common.asker,
+		systems:   map[string]InitSystem{},
+		state:     map[string]service.SystemInformation{},
 	}
 
 	cfg.sessionTimeout = DefaultSessionTimeout

--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -346,7 +346,7 @@ func (c *initConfig) askLocalPool(sh *service.Handler) error {
 			return fmt.Errorf("Failed to add local storage pool: Some peers don't have an available disk")
 		}
 
-		if !c.wipeAllDisks && wipeable {
+		if wipeable {
 			fmt.Println("Select which disks to wipe:")
 			err := table.Render(selectedRows)
 			if err != nil {
@@ -377,7 +377,7 @@ func (c *initConfig) askLocalPool(sh *service.Handler) error {
 		return nil
 	}
 
-	if c.wipeAllDisks && wipeable {
+	if wipeable {
 		toWipe = selectedDisks
 	}
 
@@ -638,11 +638,6 @@ func (c *initConfig) askRemotePool(sh *service.Handler) error {
 
 			sort.Sort(cli.SortColumnsNaturally(data))
 			table := NewSelectableTable(header, data)
-			selected := table.rows
-			var toWipe []string
-			if c.wipeAllDisks {
-				toWipe = selected
-			}
 
 			if len(table.rows) == 0 {
 				return nil
@@ -654,12 +649,13 @@ func (c *initConfig) askRemotePool(sh *service.Handler) error {
 				return err
 			}
 
-			selected, err = table.GetSelections()
+			selected, err := table.GetSelections()
 			if err != nil {
 				return fmt.Errorf("Invalid disk configuration: %w", err)
 			}
 
-			if len(selected) > 0 && !c.wipeAllDisks {
+			var toWipe []string
+			if len(selected) > 0 {
 				fmt.Println("Select which disks to wipe:")
 				err := table.Render(selected)
 				if err != nil {

--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -724,8 +724,8 @@ func (c *initConfig) askRemotePool(sh *service.Handler) error {
 		}
 	}
 
-	encryptDisks := c.encryptAllDisks
-	if !c.encryptAllDisks && len(selectedDisks) > 0 {
+	encryptDisks := false
+	if len(selectedDisks) > 0 {
 		var err error
 		encryptDisks, err = c.asker.AskBool("Do you want to encrypt the selected disks? (yes/no) [default=no]: ", "no")
 		if err != nil {

--- a/cmd/microcloud/main_init.go
+++ b/cmd/microcloud/main_init.go
@@ -103,9 +103,6 @@ type initConfig struct {
 	// sessionTimeout is the duration to wait for the trust establishment session to complete.
 	sessionTimeout time.Duration
 
-	// wipeAllDisks indicates whether all disks should be wiped, or if the user should be prompted.
-	wipeAllDisks bool
-
 	// encryptAllDisks indicates whether all disks should be encrypted, or if the user should be prompted.
 	encryptAllDisks bool
 

--- a/cmd/microcloud/main_init.go
+++ b/cmd/microcloud/main_init.go
@@ -126,10 +126,7 @@ type initConfig struct {
 type cmdInit struct {
 	common *CmdControl
 
-	flagSessionTimeout  int64
-	flagWipeAllDisks    bool
-	flagEncryptAllDisks bool
-	flagAddress         string
+	flagSessionTimeout int64
 }
 
 func (c *cmdInit) Command() *cobra.Command {
@@ -140,9 +137,6 @@ func (c *cmdInit) Command() *cobra.Command {
 		RunE:    c.Run,
 	}
 
-	cmd.Flags().BoolVar(&c.flagWipeAllDisks, "wipe", false, "Wipe disks to add to MicroCeph")
-	cmd.Flags().BoolVar(&c.flagEncryptAllDisks, "encrypt", false, "Encrypt disks to add to MicroCeph")
-	cmd.Flags().StringVar(&c.flagAddress, "address", "", "Address to use for MicroCloud")
 	cmd.Flags().Int64Var(&c.flagSessionTimeout, "session-timeout", 0, "Amount of seconds to wait for the trust establishment session. Defaults: 60m")
 
 	return cmd
@@ -154,15 +148,12 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	cfg := initConfig{
-		bootstrap:       true,
-		setupMany:       true,
-		address:         c.flagAddress,
-		wipeAllDisks:    c.flagWipeAllDisks,
-		encryptAllDisks: c.flagEncryptAllDisks,
-		common:          c.common,
-		asker:           &c.common.asker,
-		systems:         map[string]InitSystem{},
-		state:           map[string]service.SystemInformation{},
+		bootstrap: true,
+		setupMany: true,
+		common:    c.common,
+		asker:     &c.common.asker,
+		systems:   map[string]InitSystem{},
+		state:     map[string]service.SystemInformation{},
 	}
 
 	cfg.sessionTimeout = DefaultSessionTimeout

--- a/cmd/microcloud/main_init.go
+++ b/cmd/microcloud/main_init.go
@@ -103,9 +103,6 @@ type initConfig struct {
 	// sessionTimeout is the duration to wait for the trust establishment session to complete.
 	sessionTimeout time.Duration
 
-	// encryptAllDisks indicates whether all disks should be encrypted, or if the user should be prompted.
-	encryptAllDisks bool
-
 	// lookupIface is the interface used for multicast lookup.
 	lookupIface *net.Interface
 


### PR DESCRIPTION
Whilst the `--auto` features was present having `--address`, `--wipe` and `--encrypt` made sense to influence what is happening in the auto mode.

Now after the auto mode is gone those flags have to be removed too.
This is a leftover.

Automating those settings can be done by using the preseed support.