### PR TITLE
Release MicroCloud 2.1 LTS

### DIFF
--- a/cmd/microcloud/main.go
+++ b/cmd/microcloud/main.go
@@ -68,7 +68,7 @@ EOF`)
 	app := &cobra.Command{
 		Use:               "microcloud",
 		Short:             "Command for managing the MicroCloud daemon",
-		Version:           version.Version,
+		Version:           version.Version(),
 		SilenceUsage:      true,
 		CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {

--- a/cmd/microcloudd/main.go
+++ b/cmd/microcloudd/main.go
@@ -49,7 +49,7 @@ func (c *cmdDaemon) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "microcloudd",
 		Short:   "MicroCloud daemon",
-		Version: version.Version,
+		Version: version.Version(),
 	}
 
 	cmd.RunE = c.Run

--- a/service/microcloud.go
+++ b/service/microcloud.go
@@ -70,7 +70,7 @@ func (s *CloudService) StartCloud(ctx context.Context, service *Handler, endpoin
 	args := microcluster.DaemonArgs{
 		Verbose:           verbose,
 		Debug:             debug,
-		Version:           version.Version,
+		Version:           version.RawVersion,
 		HeartbeatInterval: heartbeatInterval,
 
 		PreInitListenAddress: "[::]:" + strconv.FormatInt(CloudPort, 10),

--- a/service/version_test.go
+++ b/service/version_test.go
@@ -40,7 +40,7 @@ func (s *versionSuite) Test_validateVersions() {
 		},
 		{
 			desc:      "Valid MicroCloud",
-			version:   version.Version,
+			version:   version.RawVersion,
 			service:   types.MicroCloud,
 			expectErr: false,
 		},

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,21 @@
 // Package version provides shared version information.
 package version
 
-// Version is the current version of MicroCloud.
-const Version = "1.1"
+import (
+	"fmt"
+)
+
+// RawVersion is the current daemon version of MicroCloud.
+const RawVersion = "2.1"
+
+// LTS should be set if the current version is an LTS (long-term support) version.
+const LTS = true
+
+// Version appends "LTS" to the raw version string if MicroCloud is an LTS version.
+func Version() string {
+	if LTS {
+		return fmt.Sprintf("%s LTS", RawVersion)
+	}
+
+	return RawVersion
+}


### PR DESCRIPTION
Ideally, this should be merged after updating go module dependencies and finishing up the last few bugfixes.