### PR TITLE
Mitigate ovn alarm clock errors

### DIFF
--- a/cmd/microcloud/main_init.go
+++ b/cmd/microcloud/main_init.go
@@ -673,7 +673,7 @@ func (c *initConfig) setupCluster(s *service.Handler) error {
 
 	fmt.Println("Initializing new services")
 	mu := sync.Mutex{}
-	err = s.RunConcurrent(types.MicroCloud, "", func(s service.Service) error {
+	err = s.RunConcurrent(types.MicroCloud, types.LXD, func(s service.Service) error {
 		// If there's already an initialized system for this service, we don't need to bootstrap it.
 		if initializedServices[s.Type()] != "" {
 			return nil

--- a/cmd/microcloud/main_init.go
+++ b/cmd/microcloud/main_init.go
@@ -924,25 +924,18 @@ func (c *initConfig) setupCluster(s *service.Handler) error {
 
 		targetClient := lxdClient.UseTarget(name)
 
-		for _, network := range system.TargetNetworks {
-			err = targetClient.CreateNetwork(network)
-			if err != nil {
-				return err
-			}
-		}
-
 		for _, pool := range system.TargetStoragePools {
 			err = targetClient.CreateStoragePool(pool)
 			if err != nil {
 				return err
 			}
 		}
-	}
 
-	for _, network := range system.Networks {
-		err = lxdClient.CreateNetwork(network)
-		if err != nil {
-			return err
+		for _, network := range system.TargetNetworks {
+			err = targetClient.CreateNetwork(network)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -966,6 +959,13 @@ func (c *initConfig) setupCluster(s *service.Handler) error {
 
 	if cephFSPool.Driver != "" {
 		err = lxdClient.CreateStoragePool(cephFSPool)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, network := range system.Networks {
+		err = lxdClient.CreateNetwork(network)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Couple changes to reduce the frequency of the MicroOVN alarm clock errors.

* Ensure LXD is always bootstrapped last, so MicroOVN has time to breathe. 
* Ensure we try to create storage pools before networks, so MicroOVN has even more time to breathe. 