### PR TITLE
Various print fixes

### DIFF
--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -609,6 +609,7 @@ func (c *initConfig) askRemotePool(sh *service.Handler) error {
 			return nil
 		}
 
+		var insufficientDisks bool
 		err = c.askRetry("Change disk selection?", func() error {
 			selectedDisks = map[string][]string{}
 			wipeDisks = map[string]map[string]bool{}
@@ -696,7 +697,7 @@ func (c *initConfig) askRemotePool(sh *service.Handler) error {
 				return fmt.Errorf("No disks were selected")
 			}
 
-			insufficientDisks := !useJoinConfigRemote && len(targetDisks) < RecommendedOSDHosts
+			insufficientDisks = !useJoinConfigRemote && len(targetDisks) < RecommendedOSDHosts
 
 			if insufficientDisks {
 				// This error will be printed to STDOUT as a normal message, so it includes a new-line for readability.
@@ -711,15 +712,18 @@ func (c *initConfig) askRemotePool(sh *service.Handler) error {
 
 		if len(selectedDisks) == 0 {
 			return nil
-		}
-
-		for target, disks := range selectedDisks {
-			if len(disks) > 0 {
-				fmt.Printf(" Using %d disk(s) on %q for remote storage pool\n", len(disks), target)
+		} else {
+			// If we had to warn about insufficient disks, the table spacing will be overwritten so add a new-line.
+			if insufficientDisks {
+				fmt.Println()
 			}
-		}
 
-		if len(selectedDisks) > 0 {
+			for target, disks := range selectedDisks {
+				if len(disks) > 0 {
+					fmt.Printf(" Using %d disk(s) on %q for remote storage pool\n", len(disks), target)
+				}
+			}
+
 			fmt.Println()
 		}
 	}

--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -1578,7 +1578,7 @@ func (c *initConfig) askJoinIntents(gw *cloudClient.WebsocketGateway, expectedSy
 				retry = true
 			}()
 
-			fmt.Println("Select which systems you want to join:")
+			fmt.Println("Select the systems that should join the cluster:")
 
 			if retry {
 				err := table.Render(table.rows)

--- a/cmd/microcloud/preseed.go
+++ b/cmd/microcloud/preseed.go
@@ -667,6 +667,19 @@ func (p *Preseed) Parse(s *service.Handler, c *initConfig, installedServices map
 	}
 
 	if len(expectedSystems) > 0 {
+		if initiator {
+			joiners := []string{}
+			for _, name := range expectedSystems {
+				if name == s.Name {
+					continue
+				}
+
+				joiners = append(joiners, name)
+			}
+
+			fmt.Printf("Searching for joining systems (%s)\n", strings.Join(joiners, ", "))
+		}
+
 		err = c.runSession(context.Background(), s, types.SessionInitiating, c.sessionTimeout, func(gw *cloudClient.WebsocketGateway) error {
 			return c.initiatingSession(gw, s, installedServices, p.SessionPassphrase, expectedSystems)
 		})

--- a/cmd/microcloud/preseed.go
+++ b/cmd/microcloud/preseed.go
@@ -1070,7 +1070,7 @@ func (p *Preseed) Parse(s *service.Handler, c *initConfig, installedServices map
 		}
 
 		if internalCephNetwork != "" {
-			err = validateCephInterfacesForSubnet(lxd, c.systems, addressedInterfaces, internalCephNetwork)
+			err = c.validateCephInterfacesForSubnet(lxd, addressedInterfaces, internalCephNetwork)
 			if err != nil {
 				return nil, err
 			}
@@ -1088,7 +1088,7 @@ func (p *Preseed) Parse(s *service.Handler, c *initConfig, installedServices map
 		}
 
 		if publicCephNetwork != "" {
-			err = validateCephInterfacesForSubnet(lxd, c.systems, addressedInterfaces, publicCephNetwork)
+			err = c.validateCephInterfacesForSubnet(lxd, addressedInterfaces, publicCephNetwork)
 			if err != nil {
 				return nil, err
 			}
@@ -1104,14 +1104,14 @@ func (p *Preseed) Parse(s *service.Handler, c *initConfig, installedServices map
 		}
 
 		if localInternalCephNetwork.String() != "" && localInternalCephNetwork.String() != c.lookupSubnet.String() {
-			err = validateCephInterfacesForSubnet(lxd, c.systems, addressedInterfaces, localInternalCephNetwork.String())
+			err = c.validateCephInterfacesForSubnet(lxd, addressedInterfaces, localInternalCephNetwork.String())
 			if err != nil {
 				return nil, err
 			}
 		}
 
 		if localPublicCephNetwork.String() != "" && localPublicCephNetwork.String() != c.lookupSubnet.String() {
-			err = validateCephInterfacesForSubnet(lxd, c.systems, addressedInterfaces, localPublicCephNetwork.String())
+			err = c.validateCephInterfacesForSubnet(lxd, addressedInterfaces, localPublicCephNetwork.String())
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/microcloud/session.go
+++ b/cmd/microcloud/session.go
@@ -86,6 +86,16 @@ func (c *initConfig) initiatingSession(gw *cloudClient.WebsocketGateway, sh *ser
 		return err
 	}
 
+	if c.autoSetup {
+		for _, info := range confirmedIntents {
+			if info.Name == c.name {
+				continue
+			}
+
+			fmt.Printf("Detected joining system %q at %q\n", info.Name, info.Address)
+		}
+	}
+
 	err = gw.Write(types.Session{
 		ConfirmedIntents: confirmedIntents,
 	})
@@ -172,6 +182,8 @@ func (c *initConfig) joiningSession(gw *cloudClient.WebsocketGateway, sh *servic
 
 		fmt.Printf("\n Found system %q at %q using fingerprint %q\n\n", session.InitiatorName, session.InitiatorAddress, fingerprint)
 		fmt.Printf("Select %q on %q to let it join the cluster\n", sh.Name, session.InitiatorName)
+	} else {
+		fmt.Printf("Connected to initiator %q\n", session.InitiatorName)
 	}
 
 	return c.askJoinConfirmation(gw, services)


### PR DESCRIPTION
* Corrects spacing for OVN underlay selection summary
* Corrects spacing for OSD selections if the recommended disks warning is rejected
* Mentions "OVN" in the underlay question
* Changes up the grammar of the system selection prompt
* Adds text feedback to the `preseed` command to display which systems are expected and give feedback once the initiator detects them, and vice versa. 
* Omits an extraneous ceph cluster network log that was showing up in the preseed command.