### PR TITLE
Version: Set the .0 patch number for the 2.1.0 LTS

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,8 @@ import (
 )
 
 // RawVersion is the current daemon version of MicroCloud.
-const RawVersion = "2.1"
+// LTS versions also include the patch number.
+const RawVersion = "2.1.0"
 
 // LTS should be set if the current version is an LTS (long-term support) version.
 const LTS = true


### PR DESCRIPTION
Use the same LTS versioning scheme as LXD and include the .0 patch number for LTS versions.