### PR TITLE
github: Refresh commits job from LXD's

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -1,14 +1,36 @@
 name: Commits
 on:
-  - pull_request
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
   commits:
-    name: Canonical CLA signed
-    runs-on: ubuntu-22.04
+    name: Branch target and CLA
+    runs-on: ubuntu-latest
     steps:
+      - name: Check branch target
+        env:
+          TARGET: ${{ github.event.pull_request.base.ref }}
+          TITLE: ${{ github.event.pull_request.title }}
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        run: |
+          set -eux
+          TARGET_FROM_PR_TITLE="$(echo "${TITLE}" | sed -n 's/.*(\(v[0-9]-\(edge\|candidate\)\))$/\1/p')"
+          if [ -z "${TARGET_FROM_PR_TITLE}" ]; then
+            TARGET_FROM_PR_TITLE="main"
+          else
+            echo "Branch target overridden from PR title"
+          fi
+          [ "${TARGET}" = "${TARGET_FROM_PR_TITLE}" ] && exit 0
+
+          echo "Invalid branch target: ${TARGET} != ${TARGET_FROM_PR_TITLE}"
+          exit 1
+
       - name: Check if CLA signed
-        uses: canonical/has-signed-canonical-cla@main
+        uses: canonical/has-signed-canonical-cla@046337b42822b7868ad62970988929c79f9c1d40 # 1.2.3


### PR DESCRIPTION
Adds a check for the target branch. Also uses SHA1 commit pinning for the CLA action.