### PR TITLE
doc: Add network requirement notes

### DIFF
--- a/doc/reference/index.md
+++ b/doc/reference/index.md
@@ -28,9 +28,9 @@ Also see Ceph's {ref}`ceph:hardware-recommendations`.
 
 ### Networking requirements
 
-For networking, MicroCloud requires two dedicated network interfaces: one for intra-cluster communication and one for external connectivity.
-To allow for external connectivity, MicroCloud requires an uplink network that supports broadcast and multicast.
-See {ref}`explanation-networking` for more information.
+For networking, MicroCloud requires at least two dedicated network interfaces: one for intra-cluster communication and one for external connectivity. If you want to segregate the Ceph networks and the OVN underlay network, you might need more dedicated interfaces.
+
+To allow for external connectivity, MicroCloud requires an uplink network that supports broadcast and multicast. See {ref}`explanation-networking` for more information.
 
 The IP addresses of the machines must not change after installation, so DHCP is not supported.
 


### PR DESCRIPTION
JIRA ticket: https://warthogs.atlassian.net/browse/LXD-2117

Now that MicroCloud can be configured with Ceph disaggregated nets and an OVN underlay, we need to tell the user that the number of required net interfaces is **at least** 2.