### PR TITLE
github: Use cache when DB download fails

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,16 +30,33 @@ jobs:
       - name: Install Trivy
         uses: canonical/lxd/.github/actions/install-trivy@main
 
+      - name: Download Trivy DB
+        id: db_download
+        run: trivy fs --download-db-only --cache-dir /home/runner/vuln-cache
+        continue-on-error: true
+
+      - name: Use previous downloaded database
+        if: ${{ steps.db_download.outcome == 'failure' }}
+        uses: actions/cache/restore@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4.1.1
+        with:
+          path: /home/runner/vuln-cache
+          key: trivy-latest-cache
+
       - name: Run Trivy vulnerability scanner
         run: |
-          trivy fs --quiet --scanners vuln,secret,misconfig --format sarif --cache-dir /home/runner/vuln-cache \
-          --severity LOW,MEDIUM,HIGH,CRITICAL --output trivy-microcloud-repo-scan-results.sarif .
+          trivy fs --skip-db-update \
+          --scanners vuln,secret,misconfig \
+          --format sarif \
+          --cache-dir /home/runner/vuln-cache \
+          --severity LOW,MEDIUM,HIGH,CRITICAL \
+          --output trivy-microcloud-repo-scan-results.sarif .
 
-      - name: Cache trivy and vulnerability database
-        uses: actions/cache/save@v4
+      - name: Cache Trivy vulnerability database
+        if: ${{ steps.db_download.outcome == 'success' }}
+        uses: actions/cache/save@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4.1.1
         with:
-            path: /home/runner/vuln-cache
-            key: trivy-cache-${{ github.run_id }}
+          path: /home/runner/vuln-cache
+          key: trivy-latest-cache
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
@@ -70,7 +87,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: /home/runner/vuln-cache
-          key: trivy-cache-${{ github.run_id }}
+          key: trivy-latest-cache
 
       - name: Download snap for scan
         run: |
@@ -79,8 +96,12 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         run: |
-          trivy rootfs --quiet --scanners vuln,secret,misconfig --format sarif --cache-dir /home/runner/vuln-cache \
-          --severity LOW,MEDIUM,HIGH,CRITICAL --output ${{ matrix.version }}-stable.sarif squashfs-root
+          trivy rootfs --skip-db-update \
+          --scanners vuln,secret,misconfig \
+          --format sarif \
+          --cache-dir /home/runner/vuln-cache \
+          --severity LOW,MEDIUM,HIGH,CRITICAL \
+          --output ${{ matrix.version }}-stable.sarif squashfs-root
 
       - name: Flag snap scanning alerts
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   trivy-repo:
-    name: Trivy vulnerability scanner - Repository
+    name: Trivy - Repository
     runs-on: ubuntu-22.04
     if: ${{ github.ref_name == 'main' }}
     steps:
@@ -66,7 +66,7 @@ jobs:
           ref: refs/heads/main
 
   trivy-snap:
-    name: Trivy vulnerability scanner - Snap
+    name: Trivy - Snap
     runs-on: ubuntu-22.04
     if: ${{ github.ref_name == 'main' }}
     needs: trivy-repo


### PR DESCRIPTION
This updates the Trivy workflow to cache the vulnerability database when the download is successful and, when it is not, use the latest cached database instead. Motivated by some failures seen on some recent runs: https://github.com/canonical/microcloud/actions/runs/11638102909/job/32412374433