### PR TITLE
github: Run code/system tests for non doc changes only

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,9 +25,27 @@ defaults:
     shell: bash
 
 jobs:
+  changes:
+    name: Changes
+    runs-on: ubuntu-22.04
+    outputs:
+      except_docs: ${{ steps.filter.outputs.except_docs }}
+    steps:
+      - name: Check for changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            except_docs:
+              # Match all changes except 'doc/**'.
+              # If no files outside of 'doc/**' are changed except_docs is set to 'false'.
+              - '!(doc/**)'
+
   code-tests:
     name: Code
     runs-on: ubuntu-22.04
+    needs: [changes]
+    if: ${{ needs.changes.outputs.except_docs == 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -398,7 +398,8 @@ jobs:
           calc: ALL
           tmpdir: /tmp/tics
 
-  documentation-checks:
+  doc-tests:
+    name: Documentation
     uses: canonical/documentation-workflows/.github/workflows/documentation-checks.yaml@main
     with:
       working-directory: './doc'
@@ -407,7 +408,7 @@ jobs:
   snap:
     name: Trigger snap edge build
     runs-on: ubuntu-22.04
-    needs: [code-tests, system-tests, documentation-checks]
+    needs: [code-tests, system-tests, doc-tests]
     if: ${{ github.repository == 'canonical/microcloud' && github.event_name == 'push' && github.actor != 'dependabot[bot]' }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
To prevent spending to much CI time running code/system tests for doc only changes, this PR introduces another job which can identify changes made in the pull request.

The code tests (and their system tests dependency) are now getting executed only if there were changes made outside of the `doc/**` directory. 