### PR TITLE
github: Checkout repo to identify changes on main branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,9 @@ jobs:
     outputs:
       except_docs: ${{ steps.filter.outputs.except_docs }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Check for changes
         uses: dorny/paths-filter@v3
         id: filter


### PR DESCRIPTION
The dorny/paths-filter dependency looks to consult the GitHub API for a list of changed files when executing within a PR.
When running on the main branch it needs to have access to the actual repository.

This currently fails on `main` https://github.com/canonical/microcloud/actions/runs/11743704790/job/32717168492#step:2:18