### PR TITLE
Update service handler address after init

### DIFF
--- a/cmd/microcloud/main_init.go
+++ b/cmd/microcloud/main_init.go
@@ -582,7 +582,7 @@ func (c *initConfig) validateSystems(s *service.Handler) (err error) {
 		// If the system is ourselves, we don't have a multicast discovery payload so grab the address locally.
 		addr := system.ServerInfo.Address
 		if systemName == s.Name {
-			addr = s.Address
+			addr = s.Address()
 		}
 
 		systemAddr := net.ParseIP(addr)
@@ -836,7 +836,7 @@ func (c *initConfig) setupCluster(s *service.Handler) error {
 		conns := []string{}
 		for _, service := range services {
 			if service.Service == "central" {
-				addr := s.Address
+				addr := s.Address()
 				if service.Location != s.Name {
 					addr = clusterMap[service.Location]
 				}

--- a/cmd/microcloud/session.go
+++ b/cmd/microcloud/session.go
@@ -152,7 +152,7 @@ func (c *initConfig) initiatingSession(gw *cloudClient.WebsocketGateway, sh *ser
 func (c *initConfig) joiningSession(gw *cloudClient.WebsocketGateway, sh *service.Handler, services map[types.ServiceType]string, initiatorAddress string, passphrase string) error {
 	session := types.Session{
 		Passphrase:       passphrase,
-		Address:          sh.Address,
+		Address:          sh.Address(),
 		InitiatorAddress: initiatorAddress,
 		Interface:        c.lookupIface.Name,
 		Services:         services,

--- a/service/microcloud.go
+++ b/service/microcloud.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/canonical/lxd/lxd/util"
@@ -15,14 +14,11 @@ import (
 	cephTypes "github.com/canonical/microceph/microceph/api/types"
 	microClient "github.com/canonical/microcluster/v2/client"
 	"github.com/canonical/microcluster/v2/microcluster"
-	"github.com/canonical/microcluster/v2/rest"
-	"github.com/canonical/microcluster/v2/state"
 	"github.com/gorilla/websocket"
 
 	"github.com/canonical/microcloud/microcloud/api/types"
 	"github.com/canonical/microcloud/microcloud/client"
 	cloudClient "github.com/canonical/microcloud/microcloud/client"
-	"github.com/canonical/microcloud/microcloud/version"
 )
 
 // CloudService is a MicroCloud service.
@@ -66,44 +62,7 @@ func NewCloudService(name string, addr string, dir string) (*CloudService, error
 }
 
 // StartCloud launches the MicroCloud daemon with the appropriate hooks.
-func (s *CloudService) StartCloud(ctx context.Context, service *Handler, endpoints []rest.Endpoint, verbose bool, debug bool, heartbeatInterval time.Duration) error {
-	args := microcluster.DaemonArgs{
-		Verbose:           verbose,
-		Debug:             debug,
-		Version:           version.RawVersion,
-		HeartbeatInterval: heartbeatInterval,
-
-		PreInitListenAddress: "[::]:" + strconv.FormatInt(CloudPort, 10),
-		Hooks: &state.Hooks{
-			PostJoin: func(ctx context.Context, s state.State, cfg map[string]string) error {
-				// If the node has joined close the session.
-				// This will signal to the client to exit out gracefully
-				// and ultimately lead to the closing of the websocket connection.
-				// Prevent blocking of the hook by also watching the outer context.
-				select {
-				case service.Session.ExitCh() <- true:
-				case <-ctx.Done():
-				}
-
-				return nil
-			},
-			OnStart: service.Start,
-		},
-		ExtensionServers: map[string]rest.Server{
-			"microcloud": {
-				CoreAPI:   true,
-				PreInit:   true,
-				ServeUnix: true,
-				Resources: []rest.Resources{
-					{
-						PathPrefix: types.APIVersion,
-						Endpoints:  endpoints,
-					},
-				},
-			},
-		},
-	}
-
+func (s *CloudService) StartCloud(ctx context.Context, args microcluster.DaemonArgs) error {
 	return s.client.Start(ctx, args)
 }
 

--- a/service/service_handler.go
+++ b/service/service_handler.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"context"
 	"crypto/x509"
 	"fmt"
 	"net/http"
@@ -10,7 +9,6 @@ import (
 	"sync"
 
 	"github.com/canonical/lxd/shared/api"
-	"github.com/canonical/microcluster/v2/state"
 
 	"github.com/canonical/microcloud/microcloud/api/types"
 	cloudClient "github.com/canonical/microcloud/microcloud/client"
@@ -76,17 +74,6 @@ func NewHandler(name string, addr string, stateDir string, services ...types.Ser
 		address:  addr,
 		Port:     CloudPort,
 	}, nil
-}
-
-// Start is run after the MicroCloud daemon has started.
-func (s *Handler) Start(ctx context.Context, state state.State) error {
-	// If we are already initialized, there's nothing to do.
-	err := state.Database().IsOpen(context.Background())
-	if err == nil {
-		return nil
-	}
-
-	return nil
 }
 
 // RunConcurrent runs the given hook concurrently across all services.


### PR DESCRIPTION
Adds thread safe helpers to get/set the service handler address. 

The address is updated in `PostBootstrap` and `PostJoin` after the MicroCloud daemon is initialized. 