### PR TITLE
doc/howto: fix broken link to microceph docs

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -227,7 +227,7 @@ custom_tags = []
 if ('SINGLE_BUILD' in os.environ and os.environ['SINGLE_BUILD'] == 'True'):
     intersphinx_mapping = {
         'lxd': ('https://documentation.ubuntu.com/lxd/en/latest/', None),
-        'microceph': ('https://canonical-microceph.readthedocs-hosted.com/en/reef-stable/', None),
+        'microceph': ('https://canonical-microceph.readthedocs-hosted.com/en/latest/', None),
         'microovn': ('https://canonical-microovn.readthedocs-hosted.com/en/latest/', None),
         'ceph': ('https://docs.ceph.com/en/latest/', None),
     }

--- a/doc/how-to/update_upgrade.md
+++ b/doc/how-to/update_upgrade.md
@@ -101,7 +101,7 @@ Upgrading the dependencies can be done by running `snap refresh --channel <new t
 
 Make sure to consult the dedicated upgrade guides of each dependency before you perform the actual upgrade:
 
-* {doc}`How to upgrade MicroCeph <microceph:how-to/reef-upgrade>`
+* {doc}`How to upgrade MicroCeph <microceph:how-to/major-upgrade>`
 * {doc}`How to upgrade MicroOVN <microovn:how-to/major-upgrades>`
 * {doc}`How to upgrade LXD <lxd:howto/cluster_manage>`
 


### PR DESCRIPTION
Link to https://canonical-microceph.readthedocs-hosted.com/en/latest/how-to/reef-upgrade/ is now https://canonical-microceph.readthedocs-hosted.com/en/latest/how-to/major-upgrade/ (using Intersphinx syntax `<microceph:how-to/major-upgrade>`).