### PR TITLE
Doc: Remove redundant device 'name' property

### DIFF
--- a/doc/tutorial/get_started.md
+++ b/doc/tutorial/get_started.md
@@ -182,10 +182,10 @@ Complete the following steps:
 
 1. Create and add network interfaces that use the dedicated MicroCloud network to each VM:
 
-       lxc config device add micro1 eth1 nic network=microbr0 name=eth1
-       lxc config device add micro2 eth1 nic network=microbr0 name=eth1
-       lxc config device add micro3 eth1 nic network=microbr0 name=eth1
-       lxc config device add micro4 eth1 nic network=microbr0 name=eth1
+       lxc config device add micro1 eth1 nic network=microbr0
+       lxc config device add micro2 eth1 nic network=microbr0
+       lxc config device add micro3 eth1 nic network=microbr0
+       lxc config device add micro4 eth1 nic network=microbr0
 
 1. Start the VMs:
 


### PR DESCRIPTION
For virtual machines setting the `name=eth1` property doesn't make any difference as the NIC naming inside of the VM is detached from that. 
As the device itself is already named `eth1` we don't loose any information on the host side.