### PR TITLE
Service: Set corret name of `instances_migration_stateful` extension

### DIFF
--- a/service/lxd.go
+++ b/service/lxd.go
@@ -121,7 +121,7 @@ func (s LXDService) Bootstrap(ctx context.Context) error {
 	newServer := currentServer.Writable()
 	newServer.Config["core.https_address"] = "[::]:8443"
 	newServer.Config["cluster.https_address"] = addr
-	if client.HasExtension("migration_stateful_default") {
+	if client.HasExtension("instances_migration_stateful") {
 		newServer.Config["instances.migration.stateful"] = "true"
 	}
 


### PR DESCRIPTION
MicroCloud should configure the `instances.migration.stateful` and set it to `true` in case the server supports the `instances_migration_stateful`.

This fixes the check which was looking for `migration_stateful_default` instead.