### PR TITLE
doc/howto/initialise: Update initialise instructions

### DIFF
--- a/doc/.custom_wordlist.txt
+++ b/doc/.custom_wordlist.txt
@@ -10,6 +10,7 @@ CIDR
 DCO
 DHCP
 DNS
+FDE
 GiB
 HWE
 intra

--- a/doc/how-to/initialise.md
+++ b/doc/how-to/initialise.md
@@ -8,7 +8,7 @@ You run the initialisation on one of the machines, and it configures the require
 ## Interactive configuration
 
 If you run the initialisation process in interactive mode (the default), you are prompted for information about your machines and how you want to set them up.
-The questions that you are asked might differ depending on your setup; for example, if you do not have the MicroOVN snap installed, you will not be prompted to configure your network, and if your machines don't have local disks, you will not be prompted to set up local storage.
+The questions that you are asked might differ depending on your setup. For example, if you do not have the MicroOVN snap installed, you will not be prompted to configure your network; if your machines don't have local disks, you will not be prompted to set up storage.
 
 The following instructions show the full initialisation process.
 
@@ -30,7 +30,7 @@ Complete the following steps to initialise MicroCloud:
 
 1. Select whether you want to set up more than one machine.
 
-   This allows you to create a MicroCloud using a single node.
+   This allows you to create a MicroCloud using a single cluster member.
    It will skip the {ref}`trust-establishment-session` if no more machines should be part of the MicroCloud.
 
    Additional machines can always be added at a later point in time.
@@ -67,7 +67,8 @@ Complete the following steps to initialise MicroCloud:
 1. Select whether you want to set up distributed storage (using MicroCeph).
 
    ```{note}
-   - To set up distributed storage, you need at least three additional disks on at least three different machines.
+   - You can set up distributed storage on a single cluster member.
+   - High availability requires a minimum of 3 cluster members, with 3 separate disks across 3 different cluster members.
    - The disks must not contain any partitions.
    - A disk that was previously selected for local storage will not be shown for distributed storage.
    ```
@@ -76,7 +77,7 @@ Complete the following steps to initialise MicroCloud:
 
    1. Select the disks that you want to use for distributed storage.
 
-      You must select at least three disks.
+      You must select at least one disk.
    1. Select whether you want to wipe any of the disks.
       Wiping a disk will destroy all data on it.
 

--- a/doc/how-to/initialise.md
+++ b/doc/how-to/initialise.md
@@ -4,6 +4,12 @@
 The {ref}`initialisation process <explanation-initialisation>` bootstraps the MicroCloud cluster.
 You run the initialisation on one of the machines, and it configures the required services on all of the machines that have been joined.
 
+## Pre-initialisation requirements
+
+- Complete the steps in {ref}`howto-install` before initialisation.
+- If you intend to use full disk encryption (FDE) on any cluster member, that member must meet the prerequisites listed on this page: {doc}`microceph:explanation/full-disk-encryption`. 
+  - Follow only the instructions in the Prerequisites section on that page. Skip its Usage section; the MicroCloud initialisation process handles the disk encryption.
+
 (howto-initialise-interactive)=
 ## Interactive configuration
 
@@ -84,9 +90,11 @@ Complete the following steps to initialise MicroCloud:
    1. Select whether you want to encrypt any of the disks.
       Encrypting a disk will store the encryption keys in the Ceph key ring inside the Ceph configuration folder.
 
-      ```{note}
-      Encryption requires a kernel with `dm_crypt` enabled.
-      See {doc}`how full disk encryption works <microceph:explanation/full-disk-encryption>` in the MicroCeph documentation for more information.
+      ```{warning}
+      Cluster members with disks to be encrypted require a kernel with `dm-crypt` enabled. The snap `dm-crypt` plug must also be connected. See the Prerequisites section of this page for more information: {doc}`microceph:explanation/full-disk-encryption`.
+
+      If you have not enabled and connected `dm-crypt` on any cluster member that you want to encrypt, do so now before you continue.
+
       ```
 
    1. You can choose to optionally set up a CephFS distributed file system.


### PR DESCRIPTION
- Replace `node` with `cluster member` for consistent terminology
- Add pre-initialisation requirements to follow install steps & prep for any FDE encryption
- Update the Note annotation in the disk encryption step to advise what to do if disk wasn't prepped