### PR TITLE
GitHub: Let trivy scan the `2/stable` snap channel

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -75,7 +75,7 @@ jobs:
         include:
           - channel: "3/edge"
             branch: "main"
-          - channel: "2/candidate"
+          - channel: "2/stable"
             branch: "v2-edge"
     steps:
       - name: Checkout


### PR DESCRIPTION
Now after we have released `2/stable` we can move the trivy scans that were previously tracking `2/candidate`.