### PR TITLE
Service: Set corret name of `instances_migration_stateful` extension (v2-edge)

### DIFF
--- a/service/lxd.go
+++ b/service/lxd.go
@@ -121,7 +121,7 @@ func (s LXDService) Bootstrap(ctx context.Context) error {
 	newServer := currentServer.Writable()
 	newServer.Config["core.https_address"] = "[::]:8443"
 	newServer.Config["cluster.https_address"] = addr
-	if client.HasExtension("migration_stateful_default") {
+	if client.HasExtension("instances_migration_stateful") {
 		newServer.Config["instances.migration.stateful"] = "true"
 	}
 


### PR DESCRIPTION
Signed-off-by: Julian Pelizäus <julian.pelizaeus@canonical.com>
(cherry picked from commit 2f4342c98f4470bd27698fbeed8c5899d7f4e44a)