### PR TITLE
github: switch to standard (free) runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,7 +127,7 @@ jobs:
       SKIP_VM_LAUNCH: "1"
       SNAPSHOT_RESTORE: "1"
     name: System
-    runs-on: GitHubMicrocloud
+    runs-on: ubuntu-22.04
     needs: code-tests
     strategy:
       fail-fast: false


### PR DESCRIPTION
Here are the time each test take when using standard (free) runners:

[System (add, 24.04, latest/edge, latest/edge, 5.21/edge, latest/edge)](https://github.com/canonical/microcloud/actions/runs/11981234199/job/33411411317?pr=508#logs): 24m
[System (instances, 24.04, latest/edge, latest/edge, 5.21/edge, latest/edge)](https://github.com/canonical/microcloud/actions/runs/11981234199/job/33411411475?pr=508#logs): 54m
[System (basic, 24.04, latest/edge, latest/edge, 5.21/edge, latest/edge)](https://github.com/canonical/microcloud/actions/runs/11981234199/job/33411411605?pr=508#logs) : 1h29m
[System (recover, 24.04, latest/edge, latest/edge, 5.21/edge, latest/edge)](https://github.com/canonical/microcloud/actions/runs/11981234199/job/33411411811?pr=508#logs): 21m
[System (interactive, 24.04, latest/edge, latest/edge, 5.21/edge, latest/edge)](https://github.com/canonical/microcloud/actions/runs/11981234199/job/33411411981?pr=508#logs): 2h8m
[System (mismatch, 24.04, latest/edge, latest/edge, 5.21/edge, latest/edge)](https://github.com/canonical/microcloud/actions/runs/11981234199/job/33411412149?pr=508#logs): 20m
[System (preseed, 24.04, latest/edge, latest/edge, 5.21/edge, latest/edge)](https://github.com/canonical/microcloud/actions/runs/11981234199/job/33411412291?pr=508#logs): 28m
[System (upgrade, 22.04, reef/stable, 22.03/stable, 5.21/stable, 1/stable)](https://github.com/canonical/microcloud/actions/runs/11981234199/job/33411412434?pr=508#logs): 21m
[System (upgrade, 24.04, 5.21/stable, reef/stable, 22.03/stable, 1/stable)](https://github.com/canonical/microcloud/actions/runs/11981234199/job/33411412548?pr=508#logs): 29m
[System (upgrade, 22.04, quincy/stable, 22.03/stable, 5.21/stable, 1/stable)](https://github.com/canonical/microcloud/actions/runs/11981234199/job/33411412701?pr=508#logs): 30m
[System (upgrade, 24.04, 5.21/stable, quincy/stable, 22.03/stable, 1/stable)](https://github.com/canonical/microcloud/actions/runs/11981234199/job/33411412849?pr=508#logs): 21m

Only the `basic, 24.04, latest/edge, latest/edge, 5.21/edge, latest/edge` needed a retry due to a failure 56m in.


Now with the large ($$) runners:

[System (add, 24.04, latest/edge, latest/edge, 5.21/edge, latest/edge)](https://github.com/canonical/microcloud/actions/runs/11959272116/job/33340786892#logs): 21m
[System (instances, 24.04, latest/edge, latest/edge, 5.21/edge, latest/edge)](https://github.com/canonical/microcloud/actions/runs/11959272116/job/33340787386#logs): 39m
[System (basic, 24.04, latest/edge, latest/edge, 5.21/edge, latest/edge)](https://github.com/canonical/microcloud/actions/runs/11959272116/job/33340787694#logs): 1h20m
[System (recover, 24.04, latest/edge, latest/edge, 5.21/edge, latest/edge)](https://github.com/canonical/microcloud/actions/runs/11959272116/job/33340788037#logs): 19m
[System (interactive, 24.04, latest/edge, latest/edge, 5.21/edge, latest/edge)](https://github.com/canonical/microcloud/actions/runs/11959272116/job/33340788416#logs): 1h54m
[System (mismatch, 24.04, latest/edge, latest/edge, 5.21/edge, latest/edge)](https://github.com/canonical/microcloud/actions/runs/11959272116/job/33340789046#logs): 24m
[System (preseed, 24.04, latest/edge, latest/edge, 5.21/edge, latest/edge)](https://github.com/canonical/microcloud/actions/runs/11959272116/job/33340789386#logs): 19m
[System (upgrade, 22.04, reef/stable, 22.03/stable, 5.21/stable, 1/stable)](https://github.com/canonical/microcloud/actions/runs/11959272116/job/33340789820#logs): 25m
[System (upgrade, 24.04, 5.21/stable, reef/stable, 22.03/stable, 1/stable)](https://github.com/canonical/microcloud/actions/runs/11959272116/job/33340790353#logs): 24m
[System (upgrade, 22.04, quincy/stable, 22.03/stable, 5.21/stable, 1/stable)](https://github.com/canonical/microcloud/actions/runs/11959272116/job/33340790756#logs): 25m
[System (upgrade, 24.04, 5.21/stable, quincy/stable, 22.03/stable, 1/stable)](https://github.com/canonical/microcloud/actions/runs/11959272116/job/33340791106#logs): 24m

# Summary

| Test  | Standard (free) | Large ($$)
| ------------- | ------------- | ------------- |
|System (add, 24.04, latest/edge, latest/edge, 5.21/edge, latest/edge)| 24m  | 21m |
|System (instances, 24.04, latest/edge, latest/edge, 5.21/edge, latest/edge)| 54m | 39m |
|System (basic, 24.04, latest/edge, latest/edge, 5.21/edge, latest/edge)|1h29m|1h20m|
|System (recover, 24.04, latest/edge, latest/edge, 5.21/edge, latest/edge)|21m|19m|
|System (interactive, 24.04, latest/edge, latest/edge, 5.21/edge, latest/edge)|2h8m|1h54m|
|System (mismatch, 24.04, latest/edge, latest/edge, 5.21/edge, latest/edge)|20m|24m|
|System (preseed, 24.04, latest/edge, latest/edge, 5.21/edge, latest/edge)|28m|19m|
|System (upgrade, 22.04, reef/stable, 22.03/stable, 5.21/stable, 1/stable)|21m|25m|
|System (upgrade, 24.04, 5.21/stable, reef/stable, 22.03/stable, 1/stable|29m|24m|
|System (upgrade, 22.04, quincy/stable, 22.03/stable, 5.21/stable, 1/stable)|30m|25m|
|System (upgrade, 24.04, 5.21/stable, quincy/stable, 22.03/stable, 1/stable)|21m|24m|

# Conclusion

The large runners are not worth it if we consider speed. Back when we made the switch, reliability was an issue that we hoped the larger runner would help with. It seems the standard runners might be good enough now or maybe MC improved.

Another conclusion is that since the `Prepare for system tests` phase takes 9-10m, we could group more of the quick tests and save CI time without delaying the full feedback loop.