### PR TITLE
Revert "github: stop running weekly tests"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,7 @@
 name: Tests
 on:
+  schedule:
+    - cron: '0 0 * * 0' # Weekly on Sunday at 00:00 UTC
   push:
     branches:
       - main


### PR DESCRIPTION
This reverts commit 203e34eee5c60e00937cbe8200b4175b51388452 after we have switched back to the free runners.