### PR TITLE
Add dqlite build step in Makefile

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,10 @@ on:
   workflow_dispatch:
 
 env:
+  CGO_CFLAGS: -I/home/runner/go/deps/dqlite/include/
+  CGO_LDFLAGS: -L/home/runner/go/deps/dqlite/.libs/
+  LD_LIBRARY_PATH: /home/runner/go/deps/dqlite/.libs/
+  CGO_LDFLAGS_ALLOW: (-Wl,-wrap,pthread_create)|(-Wl,-z,now)
   GOCOVERDIR: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ) && '/home/runner/work/microcloud/microcloud/cover' || '' }}
 
 permissions:
@@ -86,12 +90,13 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo add-apt-repository ppa:dqlite/dev -y --no-update
           sudo apt-get update
-          sudo apt-get install --no-install-recommends -y libdqlite-dev pkg-config
+          sudo apt-get install --no-install-recommends -y pkg-config autoconf automake libtool make libuv1-dev libsqlite3-dev liblz4-dev
 
       - name: Build
-        run: make
+        run: |
+          make deps
+          make
 
       - name: Run static analysis
         run: make check-static
@@ -119,6 +124,7 @@ jobs:
           path: |
             /home/runner/go/bin/microcloud
             /home/runner/go/bin/microcloudd
+            /home/runner/go/bin/dqlite
           retention-days: 1
 
   system-tests:
@@ -357,9 +363,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo add-apt-repository ppa:dqlite/dev -y --no-update
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends -y libdqlite-dev pkg-config
           go install github.com/axw/gocov/gocov@latest
           go install github.com/AlekSi/gocov-xml@latest
           go install honnef.co/go/tools/cmd/staticcheck@latest

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,28 @@
 GOMIN=1.22.7
 GOCOVERDIR ?= $(shell go env GOCOVERDIR)
+GOPATH ?= $(shell go env GOPATH)
+DQLITE_PATH=$(GOPATH)/deps/dqlite
+DQLITE_BRANCH=master
 
 .PHONY: default
 default: build
+
+# Build dependencies
+.PHONY: deps
+deps:
+	# dqlite (+raft)
+	@if [ ! -e "$(DQLITE_PATH)" ]; then \
+		echo "Retrieving dqlite from ${DQLITE_BRANCH} branch"; \
+		git clone --depth=1 --branch "${DQLITE_BRANCH}" "https://github.com/canonical/dqlite" "$(DQLITE_PATH)"; \
+	elif [ -e "$(DQLITE_PATH)/.git" ]; then \
+		echo "Updating existing dqlite branch"; \
+		cd "$(DQLITE_PATH)"; git pull; \
+	fi
+
+	cd "$(DQLITE_PATH)" && \
+		autoreconf -i && \
+		./configure --enable-build-raft && \
+		make
 
 # Build targets.
 .PHONY: build


### PR DESCRIPTION
Don't install dqlite from apt but instead build it from source when running the tests.
This is the same approach as in Microcluster.