### PR TITLE
docs: add docs triage workflow using labeler action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+Documentation:
+- changed-files:
+  - any-glob-to-any-file:
+    - doc/**/*

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,24 @@
+name: Triaging
+on:
+  pull_request_target:
+  issues:
+    types:
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+
+jobs:
+  label:
+    if: github.event.pull_request
+    permissions:
+      contents: read  # for actions/labeler to determine modified files
+      pull-requests: write  # for actions/labeler to add labels to PRs
+    name: PR labels
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true


### PR DESCRIPTION
This replicates the auto-labeling of PRs that affect Documentation in the LXD repo. 

To add more automated labels aside from Documentation, update `.github/labeler.yml`. See [the version in the LXD repo](https://github.com/canonical/lxd/blob/main/.github/labeler.yml) for examples.