### PR TITLE
Go: Update `charmbracelet/x/ansi` and replace deprecated consts/funcs

### DIFF
--- a/cmd/tui/asker.go
+++ b/cmd/tui/asker.go
@@ -122,9 +122,9 @@ func (a *asker) Init() tea.Cmd {
 // Instead, by appending it to the front of the string, the cursor will reset the previously rendered line only.
 func (a *asker) Write(b []byte) (int, error) {
 	str := string(b)
-	str, ok := strings.CutSuffix(str, ansi.CursorLeft(a.windowWidth))
+	str, ok := strings.CutSuffix(str, ansi.CursorBackward(a.windowWidth))
 	if ok {
-		str = ansi.CursorLeft(a.windowWidth) + str
+		str = ansi.CursorBackward(a.windowWidth) + str
 	}
 
 	return a.File.Write([]byte(str))

--- a/cmd/tui/console.go
+++ b/cmd/tui/console.go
@@ -109,13 +109,13 @@ func (c *testConsole) parseInput(handler *InputHandler) error {
 	var action string
 	switch input {
 	case "table:down":
-		action = ansi.CursorDown1
+		action = ansi.CUD1
 	case "table:up":
-		action = ansi.CursorUp1
+		action = ansi.CUU1
 	case "table:select-none":
-		action = ansi.CursorLeft1
+		action = ansi.CUB1
 	case "table:select-all":
-		action = ansi.CursorRight1
+		action = ansi.CUF1
 	case "table:select":
 		action = " "
 	case "table:done":

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/canonical/microovn/microovn v0.0.0-20241101125123-0d5d663f6575
 	github.com/charmbracelet/bubbletea v1.2.3
 	github.com/charmbracelet/lipgloss v1.0.0
-	github.com/charmbracelet/x/ansi v0.4.5
+	github.com/charmbracelet/x/ansi v0.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/charmbracelet/lipgloss v1.0.0 h1:O7VkGDvqEdGi93X+DeqsQ7PKHDgtQfF8j8/O
 github.com/charmbracelet/lipgloss v1.0.0/go.mod h1:U5fy9Z+C38obMs+T+tJqst9VGzlOYGj4ri9reL3qUlo=
 github.com/charmbracelet/x/ansi v0.4.5 h1:LqK4vwBNaXw2AyGIICa5/29Sbdq58GbGdFngSexTdRM=
 github.com/charmbracelet/x/ansi v0.4.5/go.mod h1:dk73KoMTT5AX5BsX0KrqhsTqAnhZZoCBjs7dGWp4Ktw=
+github.com/charmbracelet/x/ansi v0.6.0 h1:qOznutrb93gx9oMiGf7caF7bqqubh6YIM0SWKyA08pA=
+github.com/charmbracelet/x/ansi v0.6.0/go.mod h1:KBUFw1la39nl0dLl10l5ORDAqGXaeurTQmwyyVKse/Q=
 github.com/charmbracelet/x/exp/golden v0.0.0-20240806155701-69247e0abc2a h1:G99klV19u0QnhiizODirwVksQB91TJKV/UaTnACcG30=
 github.com/charmbracelet/x/exp/golden v0.0.0-20240806155701-69247e0abc2a/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
 github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQaGIAQ=


### PR DESCRIPTION
Closes https://github.com/canonical/microcloud/pull/547

The new version of `charmbracelet/x/ansi` has deprecated some funcs and consts.