### PR TITLE
github: update of .jira_sync_config.yaml

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -9,9 +9,8 @@ settings:
     
   # (Optional) Jira project components that should be attached to the created issue
   # Component names are case-sensitive
-  # components:
-  #  - LXD
-  #  - MicroCloud
+  components:
+    - MicroCloud
       
   # (Optional) GitHub labels. Only issues with one of those labels will be synchronized.
   # If not specified, all issues will be synchronized


### PR DESCRIPTION
I changed  the 'components' element in .jira_sync_config.yaml configuration file for the synchronization with Jira. to allow filtering by 'MicroCloud' key