### PR TITLE
Service: Exlude disks of type `cdrom`

### DIFF
--- a/service/system_information.go
+++ b/service/system_information.go
@@ -106,6 +106,11 @@ func (sh *Handler) CollectSystemInformation(ctx context.Context, connectInfo mul
 				continue
 			}
 
+			// Exclude cdrom drives as viable storage disk.
+			if disk.Type == "cdrom" {
+				continue
+			}
+
 			s.AvailableDisks[disk.ID] = disk
 		}
 	}

--- a/service/system_information.go
+++ b/service/system_information.go
@@ -101,9 +101,12 @@ func (sh *Handler) CollectSystemInformation(ctx context.Context, connectInfo mul
 
 	if allResources != nil {
 		for _, disk := range allResources.Storage.Disks {
-			if len(disk.Partitions) == 0 {
-				s.AvailableDisks[disk.ID] = disk
+			// Exclude non-pristine disks with partitions.
+			if len(disk.Partitions) != 0 {
+				continue
 			}
+
+			s.AvailableDisks[disk.ID] = disk
 		}
 	}
 


### PR DESCRIPTION
When creating local and remote storage pools the list of disks should not contain any cdrom drive.

Fixes https://github.com/canonical/microcloud/issues/566