### PR TITLE
microcloud/cmd/microcloud: Use quincy client package (v1-edge)

### DIFF
--- a/microcloud/Makefile
+++ b/microcloud/Makefile
@@ -46,12 +46,8 @@ update-gomod:
 	# Grab MicroOVN from the corresponding support branch.
 	go get github.com/canonical/microovn/microovn@branch-22.03
 
-	# There is a reef branch, but its microcluster dependency has breaking changes.
-	# Also, the quincy branch has an outdated client for the MicroCeph API offered with reef/stable.
-	#
-	# As such, we have to grab the latest commit which uses a compatible microcluster,
-	# but recent enough to also account for reef's breaking API changes.
-	go get github.com/canonical/microceph/microceph@v0.0.0-20240610102219-bc3fe1e7b68f
+	# There is a reef branch, but its microcluster dependency has breaking changes, so use quincy instead.
+	go get github.com/canonical/microceph/microceph@quincy
 
 	# Branches named `vN` where N is a number are reserved by go for module versions,
 	# So we are forced to grab the corresponding commit hash for the `v1` branch instead.

--- a/microcloud/cmd/microcloud/ask.go
+++ b/microcloud/cmd/microcloud/ask.go
@@ -485,7 +485,7 @@ func askRemotePool(systems map[string]InitSystem, autoSetup bool, wipeAllDisks b
 			system.MicroCephDisks = []cephTypes.DisksPost{}
 		}
 
-		system.MicroCephDisks = append(system.MicroCephDisks, cephTypes.DisksPost{Path: []string{path}, Wipe: wipeMap[entry]})
+		system.MicroCephDisks = append(system.MicroCephDisks, cephTypes.DisksPost{Path: path, Wipe: wipeMap[entry]})
 
 		systems[target] = system
 	}

--- a/microcloud/cmd/microcloud/main_init.go
+++ b/microcloud/cmd/microcloud/main_init.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -446,15 +445,9 @@ func setupCluster(s *service.Handler, systems map[string]InitSystem) error {
 			}
 
 			logger.Debug("Adding disk to MicroCeph", logger.Ctx{"peer": s.Name, "disk": disk.Path})
-			resp, err := cephClient.AddDisk(context.Background(), c, &disk)
+			err := cephClient.AddDisk(context.Background(), c, &disk)
 			if err != nil {
 				return err
-			}
-
-			for _, r := range resp.Reports {
-				if r.Error != "" {
-					return errors.New(r.Error)
-				}
 			}
 		}
 	}

--- a/microcloud/cmd/microcloud/main_init_preseed.go
+++ b/microcloud/cmd/microcloud/main_init_preseed.go
@@ -486,7 +486,7 @@ func (p *Preseed) Parse(s *service.Handler, bootstrap bool) (map[string]InitSyst
 		}
 
 		for _, disk := range directCeph {
-			system.MicroCephDisks = append(system.MicroCephDisks, cephTypes.DisksPost{Path: []string{disk.Path}, Wipe: disk.Wipe})
+			system.MicroCephDisks = append(system.MicroCephDisks, cephTypes.DisksPost{Path: disk.Path, Wipe: disk.Wipe})
 		}
 
 		// Setup ceph pool for disks specified to MicroCeph.
@@ -555,7 +555,7 @@ func (p *Preseed) Parse(s *service.Handler, bootstrap bool) (map[string]InitSyst
 			}
 
 			for _, disk := range matched {
-				system.MicroCephDisks = append(system.MicroCephDisks, cephTypes.DisksPost{Path: []string{parseDiskPath(disk)}, Wipe: filter.Wipe})
+				system.MicroCephDisks = append(system.MicroCephDisks, cephTypes.DisksPost{Path: parseDiskPath(disk), Wipe: filter.Wipe})
 				// There should only be one ceph pool per system.
 				if !addedCephPool {
 					if bootstrap {

--- a/microcloud/go.mod
+++ b/microcloud/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
 	github.com/canonical/lxd v0.0.0-20241209143752-5a8ba0bdd60b
-	github.com/canonical/microceph/microceph v0.0.0-20240610102219-bc3fe1e7b68f
+	github.com/canonical/microceph/microceph v0.0.0-20231201205217-287ee689aa80
 	github.com/canonical/microcluster v0.0.0-20241212191815-dba2a1b44d4d
 	github.com/canonical/microovn/microovn v0.0.0-20241022125142-cad8ee9dc5e7
 	github.com/creack/pty v1.1.24

--- a/microcloud/go.sum
+++ b/microcloud/go.sum
@@ -12,8 +12,8 @@ github.com/canonical/go-dqlite/v2 v2.0.0 h1:RNFcFVhHMh70muKKErbW35rSzqmAFswheHdA
 github.com/canonical/go-dqlite/v2 v2.0.0/go.mod h1:IaIC8u4Z1UmPjuAqPzA2r83YMaMHRLoKZdHKI5uHCJI=
 github.com/canonical/lxd v0.0.0-20241209143752-5a8ba0bdd60b h1:xrdihzBO8sC+dARb+g6qryKoWzrPA13qB37nSmA1xBo=
 github.com/canonical/lxd v0.0.0-20241209143752-5a8ba0bdd60b/go.mod h1:2pcjouGIaU1Qv4q6gYzs+x3WCRqB8T2aTpRKHOK2RZo=
-github.com/canonical/microceph/microceph v0.0.0-20240610102219-bc3fe1e7b68f h1:MYdE0HCKBclQPhkfvVhhNPOK5ofJ8WOzKBWdhyPtQrQ=
-github.com/canonical/microceph/microceph v0.0.0-20240610102219-bc3fe1e7b68f/go.mod h1:rDBLUPhZuzxKnMVUmiucGsNz0mo9Tvg0QYL6ClJCln8=
+github.com/canonical/microceph/microceph v0.0.0-20231201205217-287ee689aa80 h1:gqmSBYiCP1JKzviIq0dnJ1wm8vsupu7dvYWTAGQHlAE=
+github.com/canonical/microceph/microceph v0.0.0-20231201205217-287ee689aa80/go.mod h1:tF7FxOcZrF7z9ZZ02oGOthRlZrvuSyDCFCCENm3aOMQ=
 github.com/canonical/microcluster v0.0.0-20241212191815-dba2a1b44d4d h1:vHo2iYyK097ttggmtxWfx9glHMsPhTLqSfGXwoYz+Qg=
 github.com/canonical/microcluster v0.0.0-20241212191815-dba2a1b44d4d/go.mod h1:1LFvUQ7h/6MQzDDmqbSTuYMHSbTAZtbvKSEIE3hADm8=
 github.com/canonical/microovn/microovn v0.0.0-20241022125142-cad8ee9dc5e7 h1:b6qzw7P6lbVn8kP5v2buFQAfmNCdHhFSVdErhIJCaMw=

--- a/microcloud/service/microceph.go
+++ b/microcloud/service/microceph.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -122,15 +121,9 @@ func (s CephService) Join(ctx context.Context, joinConfig JoinConfig) error {
 	}
 
 	for _, disk := range joinConfig.CephConfig {
-		resp, err := cephClient.AddDisk(ctx, c, &disk)
+		err := cephClient.AddDisk(ctx, c, &disk)
 		if err != nil {
 			return err
-		}
-
-		for _, r := range resp.Reports {
-			if r.Error != "" {
-				return errors.New(r.Error)
-			}
 		}
 	}
 


### PR DESCRIPTION
The OSD API was changed with reef, but there is a manual patch that makes it compatible with the quincy Go client.
https://github.com/canonical/microceph/blob/2bddc9d6280d903dcb52a993833e991873565550/microceph/api/disks.go#L163-L172

So we can use that instead to support both reef and quincy.