### PR TITLE
doc: clarify microcloud behavior when snaps are not in sync

### DIFF
--- a/doc/how-to/update_upgrade.md
+++ b/doc/how-to/update_upgrade.md
@@ -2,73 +2,71 @@
 # How to update and upgrade
 
 MicroCloud is made of several snaps that are closely coupled with each other.
-The cluster members that are part of the MicroCloud deployment must always run the same version of the snaps.
-This means that when the snaps on one of the cluster members are refreshed, they must also be refreshed on all other cluster members before MicroCloud is operational again.
+The cluster members that are part of a MicroCloud deployment must always run the same version of the snaps. Thus, when the snaps on one of the cluster members are refreshed, they must also be refreshed on all other cluster members. Until this happens, MicroCloud will continue to function as normal in regards to its data plane. However, its control plane will be inoperable, meaning that its configuration cannot be updated. For example, you will not be able to add or remove cluster members or instances.
+
 See {ref}`howto-update-upgrade-deps` for the recommended order.
 
-Before performing an update or upgrade make sure to backup your data to prevent any data loss in case of failure.
+Before performing an update or upgrade, make sure to backup your data to prevent any data loss in case of failure.
 See the following backup guides for each of the snaps:
 
 * {doc}`How to backup MicroCeph <microceph:explanation/taking-snapshots>`
 * {ref}`How to backup LXD <lxd:backups>`
 
-In case of error see {ref}`howto-recover` for troubleshooting details.
+In case of error, see {ref}`howto-recover` for troubleshooting details.
 
 (howto-update-upgrade-update)=
 ## Update MicroCloud
 
-Updating MicroCloud allows getting the latest set of features and fixes in the tracked channels for the various snaps.
-Performing an update requires going through the list of snaps one after another and update each of the individual cluster members.
+Updating MicroCloud allows access to the latest set of features and fixes in the tracked channels for the various snaps.
+Performing an update requires going through the list of snaps one after another and updating each of the individual cluster members.
 
 ```{note}
-Depending on which snap gets updated, some services of this snap (e.g. API endpoints) might not be available whilst performing the update.
-Check the respective services documentation on updates for more information.
+Depending on which snap gets updated, some services of this snap (such as API endpoints) might not be available while performing the update. Check the respective services' documentation on updates for more information.
 ```
 
-During an update the snaps channel won't be modified so the snaps get updated to the last available version inside of the current channel.
-This does not introduce breaking changes and can be used on a regular basis to update the MicroCloud.
+During an update, the snaps channel won't be modified, so the snaps are updated to the last available version inside the current channel.
+This does not introduce breaking changes and can be used on a regular basis to update a MicroCloud deployment.
 
-As MicroCloud consumes the services offered by the dependant snaps (MicroCeph, MicroOVN and LXD), the update procedure starts by updating
-the list of dependencies first.
+As MicroCloud consumes the services offered by the dependant snaps (MicroCeph, MicroOVN, and LXD), the update procedure starts by updating the list of dependencies first.
 
 (howto-update-upgrade-deps)=
-### Update dependency snaps
+### Update the dependency snaps
 
 Updating the dependencies can be done by running `snap refresh` against the respective snap.
-For MicroCloud automatic snap refreshes are put on hold. See {ref}`howto-snap-control-updates` for more information.
+For MicroCloud, automatic snap refreshes are put on hold. See {ref}`howto-snap-control-updates` for more information.
 
 To start the update procedure, enter the following command on the first machine:
 
     sudo snap refresh microceph --cohort="+"
 
-If the command has succeeded, run the same command on the next machine and so on.
+If the command succeeds, run the same command on the next machine, and so on.
 
 ```{note}
 Make sure to validate the health of the recently updated dependency before continuing with the next one.
 ```
 
-After successfully updating MicroCeph continue with MicroOVN.
+After successfully updating MicroCeph, continue with MicroOVN.
 Again enter the following command on the first machine:
 
     sudo snap refresh microovn --cohort="+"
 
-As before run the command on all the other machines one after another if you don't observe any errors.
-Next we can continue to update LXD.
+Run the same command on the remaining machines, one after another, unless an error is encountered.
 
-The refresh will block until each of the LXD cluster members is updated so make sure to perform the following
+Next, update LXD. The refresh will block until each of the LXD cluster members is updated, so make sure to perform the following
 command on all machines in parallel:
 
     sudo snap refresh lxd --cohort="+"
 
-### Update MicroCloud snap
+### Update the MicroCloud snap
 
-Last but not least we can update MicroCloud.
-As before enter the following command on the first machine:
+Last but not least, we can update MicroCloud.
+As before, enter the following command on the first machine:
 
     sudo snap refresh microcloud --cohort="+"
 
 Continue running the command on the rest of the machines to finish the update.
-You can confirm a healthy state of the MicroCloud after the update by running the following command:
+
+Confirm that the MicroCloud deployment is in a healthy state after the update by running the following command:
 
     sudo microcloud status
 
@@ -81,21 +79,19 @@ See {ref}`howto-update-upgrade-upgrade` on how to upgrade to another track.
 ## Upgrade MicroCloud
 
 Upgrading MicroCloud allows switching to another track with major improvements and enhanced functionality.
-Performing an upgrade requires going through the list of snaps one after another and upgrade each of the individual cluster members.
+Performing an upgrade requires going through the list of snaps one after another and upgrading each of the individual cluster members.
 
 ```{note}
-Depending on which snap gets upgraded, some services of this snap (e.g. API endpoints) might not be available whilst performing the upgrade.
-Check the respective services documentation on upgrades for more information.
+Depending on which snap gets upgraded, some services of this snap (such as API endpoints) might not be available while performing the upgrade. Check the respective services' documentation on upgrades for more information.
 ```
 
-During an upgrade the snaps channel will be switched to another track.
+During an upgrade, the snaps channel will be switched to another track.
 This might introduce breaking changes for MicroCloud and its dependencies and should be done with care.
 See {ref}`howto-update-upgrade-update` for regular non-breaking updates.
 
-As MicroCloud consumes the services offered by the dependant snaps (MicroCeph, MicroOVN and LXD), the update procedure starts by updating
-the list of dependencies first.
+As MicroCloud consumes the services offered by the dependant snaps (MicroCeph, MicroOVN and LXD), the update procedure starts by updating the list of dependencies first.
 
-### Upgrade dependency snaps
+### Upgrade the dependency snaps
 
 Upgrading the dependencies can be done by running `snap refresh --channel <new track/stable>` against the respective snap.
 
@@ -109,33 +105,32 @@ To start the upgrade procedure, enter the following command on the first machine
 
     sudo snap refresh microceph --channel "squid/stable" --cohort="+"
 
-If the command has succeeded, run the same command on the next machine and so on.
+If the command succeeds, run the same command on the next machine, and so on.
 
 ```{note}
 Make sure to validate the health of the recently upgraded dependency before continuing with the next one.
 ```
 
-After successfully upgrading MicroCeph continue with MicroOVN.
-Again enter the following command on the first machine:
+After successfully upgrading MicroCeph, continue with MicroOVN.
+Again, enter the following command on the first machine:
 
     sudo snap refresh microovn --channel "24.03/stable" --cohort="+"
 
-As before run the command on all the other machines one after another if you don't observe any errors.
-Next we can continue to upgrade LXD.
+Run the same command on the remaining machines, one after another, unless an error is encountered, 
 
-The installer will block until each of the LXD cluster members is upgraded so make sure to perform the following
+Next, update LXD. The installer will block until each of the LXD cluster members is upgraded, so make sure to perform the following
 command on all machines in parallel:
 
     sudo snap refresh lxd --channel "5.21/stable" --cohort="+"
 
 ### Upgrade MicroCloud snap
 
-Last but not least we can upgrade MicroCloud.
-As before enter the following command on the first machine:
+Last but not least, we can upgrade MicroCloud.
+As before, enter the following command on the first machine:
 
     sudo snap refresh microcloud --channel "2/stable" --cohort="+"
 
 Continue running the command on the rest of the machines to finish the upgrade.
-You can confirm a healthy state of the MicroCloud after the upgrade by running the following command:
+Confirm that the MicroCloud deployment is in a healthy state after the update by running the following command:
 
     sudo microcloud status


### PR DESCRIPTION
* Clarify confusing wording that suggests that MicroCloud is completely inoperable if snaps are not in sync in all cluster members. It's only the control plane that is inoperable, not the data plane; MicroCloud will continue to function as before, but no configuration changes can be made. 
* Misc small updates for readability / grammar fixes.