### PR TITLE
doc: updated the MicroCloud installation instructions to remove dependency on two NICs

### DIFF
--- a/doc/how-to/install.md
+++ b/doc/how-to/install.md
@@ -18,7 +18,7 @@ A physical or virtual machine intended for use as a MicroCloud cluster member mu
 
 - Networking:
   - Fixed IP addresses (DHCP not supported)
-  - At least two network interfaces per cluster member: one for intra-cluster communication and one for external connectivity to the uplink network
+  - At least one network interfaces per cluster member for intra-cluster communication and a bridge in front of the network interface for external connectivity to the uplink network
     - Partially or fully disaggregated networking setups require more interfaces; see: {ref}`howto-ceph-networking`
     - To use a {ref}`dedicated underlay network for OVN traffic <microcloud-networking-underlay>`, an additional interface per cluster member is required
   - Uplink network must support both broadcast and multicast

--- a/doc/how-to/install.md
+++ b/doc/how-to/install.md
@@ -18,7 +18,7 @@ A physical or virtual machine intended for use as a MicroCloud cluster member mu
 
 - Networking:
   - Fixed IP addresses (DHCP not supported)
-  - At least one network interfaces per cluster member for intra-cluster communication and a bridge in front of the network interface for external connectivity to the uplink network
+  - At least one network interface per cluster member for intra-cluster communication, and a bridge in front of each network interface for external connectivity to the uplink network
     - Partially or fully disaggregated networking setups require more interfaces; see: {ref}`howto-ceph-networking`
     - To use a {ref}`dedicated underlay network for OVN traffic <microcloud-networking-underlay>`, an additional interface per cluster member is required
   - Uplink network must support both broadcast and multicast


### PR DESCRIPTION
In the MicroCloud installation instruction, the network section implies a dependency on hardware with more than one NIC, which is not needed.