### PR TITLE
Add daemon cleanup logging

### DIFF
--- a/test/main.sh
+++ b/test/main.sh
@@ -94,6 +94,9 @@ cleanup() {
       lxc exec "${name}" -- cat -v debug | sed -e 's/\^M$//g' -e 's/.*\^M//g' -e 's/\^\[\[D//' -e 's/^\^\[.*//g' -e '/^$/d'
     fi
     echo
+
+    echo -n "${name} MicroCloud daemon log:"
+    lxc exec "${name}" -- snap logs microcloud -n 200
   done
 
   if [ ${enable_xtrace} = 1 ]; then

--- a/test/main.sh
+++ b/test/main.sh
@@ -71,30 +71,30 @@ cleanup() {
     set +x
   fi
 
-	for name in $(lxc list -c n -f csv micro); do
-		echo -n "${name} CLI stdout:"
-        if ! lxc exec "${name}" -- test -e out; then
-            echo " was not found"
-        elif ! lxc exec "${name}" -- test -s out; then
-            echo " was empty"
-        else
-          echo
-		      lxc exec "${name}" -- cat out
-        fi
+  for name in $(lxc list -c n -f csv micro); do
+    echo -n "${name} CLI stdout:"
+    if ! lxc exec "${name}" -- test -e out; then
+        echo " was not found"
+    elif ! lxc exec "${name}" -- test -s out; then
+        echo " was empty"
+    else
+      echo
+      lxc exec "${name}" -- cat out
+    fi
+    echo
 
-    echo
     echo -n "${name} Debug output:"
-        if ! lxc exec "${name}" -- test -e debug; then
-            echo " was not found"
-        elif ! lxc exec "${name}" -- test -s debug; then
-            echo " was empty"
-        else
-          echo
-          # The github console can't interpret the escape sequences baked into the output, so omit them manually.
-          lxc exec "${name}" -- cat -v debug | sed -e 's/\^M$//g' -e 's/.*\^M//g' -e 's/\^\[\[D//' -e 's/^\^\[.*//g' -e '/^$/d'
-        fi
+    if ! lxc exec "${name}" -- test -e debug; then
+        echo " was not found"
+    elif ! lxc exec "${name}" -- test -s debug; then
+        echo " was empty"
+    else
+      echo
+      # The github console can't interpret the escape sequences baked into the output, so omit them manually.
+      lxc exec "${name}" -- cat -v debug | sed -e 's/\^M$//g' -e 's/.*\^M//g' -e 's/\^\[\[D//' -e 's/^\^\[.*//g' -e '/^$/d'
+    fi
     echo
-	done
+  done
 
   if [ ${enable_xtrace} = 1 ]; then
     set -x

--- a/test/suites/instances.sh
+++ b/test/suites/instances.sh
@@ -642,6 +642,12 @@ EOF
   check_instance_connectivity "c1" "c2" "0"
   check_instance_connectivity "v1" "c1" "1"
 
+  # We're done with c2 so we can delete it now, and free up space on the runners for more instances.
+  lxc exec micro01 -- lxc delete c2 -f
+
+  # Flush the neighbour cache in the remaining container so that it can ping new containers via hostname quicker.
+  lxc exec micro01 -- lxc exec c1 -- ip neigh flush all
+
 
   # Add a new node, don't add any OSDs to keep Ceph fully remote.
   preseed="$(cat << EOF
@@ -689,7 +695,7 @@ EOF
   check_instance_connectivity "c1" "c3" "0"
   check_instance_connectivity "c1" "c4" "0"
 
-  lxc exec micro01 -- lxc delete -f c1 c2 c3 c4
+  lxc exec micro01 -- lxc delete -f c1 c3 c4
   if ! [ "${SKIP_VM_LAUNCH}" = "1" ]; then
     lxc exec micro01 -- lxc delete -f v1
   fi


### PR DESCRIPTION
This aims at catching the panic the occurs from time to time in the interactive test suite. See https://github.com/canonical/microcloud/actions/runs/12989749320/job/36223575544:

`Error: System "micro02" failed to join the cluster: Failed to update cluster status of services: Put "https://10.24.232.150:9443/1.0/services": EOF`