### PR TITLE
doc: add how-to on safely shutting down a cluster member

### DIFF
--- a/doc/how-to/commands.md
+++ b/doc/how-to/commands.md
@@ -285,4 +285,6 @@ See {ref}`lxd:cluster-manage-instance` and {ref}`lxd:cluster-evacuate`.
    - {command}`lxc cluster evacuate <member>`
  * - Restore a cluster member
    - {command}`lxc cluster restore <member>`
+ * - Shut down a cluster member
+   - See: {ref}`howto-shutdown`.
 ```

--- a/doc/how-to/index.md
+++ b/doc/how-to/index.md
@@ -14,6 +14,7 @@ Configure Ceph networking </how-to/ceph_networking>
 Configure OVN underlay </how-to/ovn_underlay>
 Add a machine </how-to/add_machine>
 Remove a machine </how-to/remove_machine>
+Shut down a machine </how-to/shutdown_machine>
 Add a service </how-to/add_service>
 Get support </how-to/support>
 Contribute to MicroCloud </how-to/contribute>

--- a/doc/how-to/shutdown_machine.md
+++ b/doc/how-to/shutdown_machine.md
@@ -1,0 +1,38 @@
+(howto-shutdown)=
+# How to shut down a machine
+
+## Stop all instances on the cluster member
+
+Before you can shut down a machine that is a MicroCloud cluster member, first stop all LXD instances hosted on it:
+
+```
+lxc stop --all
+```
+
+## Enforce services shutdown and restart order
+
+During the shutdown process of a MicroCloud cluster member, the LXD service must stop _before_ the MicroCeph and MicroOVN services. At restart, the LXD service must start _after_ MicroCeph and MicroOVN. This order ensures that LXD does not run into issues due to unavailable storage or networking services.
+
+To enforce this shutdown and restart order, create a configuration file in each cluster member's `/etc/systemd/system/snap.lxd.daemon.service.d` directory to override the behaviour of `snap.lxd.daemon.service`. To simplify creating the directory and configuration file, you can copy and paste the following commands into each cluster member:
+
+```
+# Create the directory if it doesn't exist
+sudo mkdir -p /etc/systemd/system/snap.lxd.daemon.service.d
+
+# Create the configuration file
+cat << EOF | sudo tee /etc/systemd/system/snap.lxd.daemon.service.d/lxd-shutdown.conf
+# Makes sure the LXD daemon stops before Ceph/OVN and restarts after Ceph/OVN
+[Unit]
+After=snap.microceph.daemon.service
+After=snap.microovn.daemon.service
+EOF
+
+# Reload systemd daemon
+sudo systemctl daemon-reload
+```
+
+You only need to perform this step once for each cluster member. Afterwards, the `snap.lxd.daemon.service` respects this configuration at every shutdown and restart.
+
+### Shut down
+
+Once you have completed the steps above, you can safely shut down and restart the machine as normal. 

--- a/doc/how-to/shutdown_machine.md
+++ b/doc/how-to/shutdown_machine.md
@@ -1,13 +1,19 @@
 (howto-shutdown)=
 # How to shut down a machine
 
-## Stop all instances on the cluster member
+## Stop or live-migrate all instances on the cluster member
 
-Before you can shut down a machine that is a MicroCloud cluster member, first stop all LXD instances hosted on it:
+To shut down a machine that is a MicroCloud cluster member, first ensure that it is not hosting any running LXD instances.
+
+You can stop all instances on a cluster member using the command:
 
 ```
 lxc stop --all
 ```
+
+Alternatively, for instances that can be {ref}`live-migrated <lxd:live-migration>`, you can move them to another cluster member without stopping them. See: {ref}`lxd:move-instances` for more information.
+
+You can also temporarily move all instances on a machine to another cluster member by using cluster evacuation, then restore them after you restart. This method can live-migrate eligible instances; instances that cannot be live-migrated are automatically stopped and restarted. See: {ref}`lxd:cluster-evacuate` for more information.
 
 ## Enforce services shutdown and restart order
 


### PR DESCRIPTION
- Add how-to on shutting down cluster members
- Add to nav sidebar
- Add link to "Work with MicroCloud" page

Thanks to @simondeziel for testing and the commands to override services start/stop sequence.