### PR TITLE
doc: increase linkcheck max rate limit timeout and retries

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -158,6 +158,10 @@ custom_linkcheck_anchors_ignore_for_url = [
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-linkcheck_timeout
 linkcheck_rate_limit_timeout = 600
 
+# Increase linkcheck retries, default when unset is 1
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-linkcheck_retries
+linkcheck_retries = 3
+
 ############################################################
 ### Additions to default configuration
 ############################################################

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -138,7 +138,7 @@ redirects = {
     'tutorial/index': 'get_started/'}
 
 ############################################################
-### Link checker exceptions
+### Link checker
 ############################################################
 
 # Links to ignore when checking links
@@ -153,6 +153,10 @@ linkcheck_ignore = [
 custom_linkcheck_anchors_ignore_for_url = [
     r'https://snapcraft\.io/docs/.*'
     ]
+
+# Increase linkcheck rate limit timeout max, default when unset is 300
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-linkcheck_timeout
+linkcheck_rate_limit_timeout = 600
 
 ############################################################
 ### Additions to default configuration


### PR DESCRIPTION
Increasing the max rate limit timeout should help with linkcheck issues due to rate limits.
Increasing the number of retries for read timeouts.

(Same updates as in LXD repo: https://github.com/canonical/lxd/pull/14892)