### PR TITLE
Revert path valid for both GitHub and Canonical runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,7 @@ env:
   CGO_LDFLAGS: -L/home/runner/go/deps/dqlite/.libs/
   LD_LIBRARY_PATH: /home/runner/go/deps/dqlite/.libs/
   CGO_LDFLAGS_ALLOW: (-Wl,-wrap,pthread_create)|(-Wl,-z,now)
-  # Use a directory path for the cover files present on every system regardless of the used runner.
-  GOCOVERDIR: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ) && '/tmp/cover' || '' }}
+  GOCOVERDIR: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ) && '/home/runner/work/microcloud/microcloud/cover' || '' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
This reverts commit 954597a9be759bf31116ae6456641f2925e2c26b.

This commit broke the TICS job, see https://github.com/canonical/microcloud/actions/runs/13220529278/job/36907299961
We don't run the TICS job on the Canonical runners and don't require any exception.