### PR TITLE
Lint: Fix revive

### DIFF
--- a/cmd/microcloud/add.go
+++ b/cmd/microcloud/add.go
@@ -24,6 +24,7 @@ type cmdAdd struct {
 	flagSessionTimeout int64
 }
 
+// Command returns the subcommand to add new systems to MicroCloud.
 func (c *cmdAdd) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add",
@@ -36,6 +37,7 @@ func (c *cmdAdd) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the subcommand to add new systems to MicroCloud.
 func (c *cmdAdd) Run(cmd *cobra.Command, args []string) error {
 	if len(args) != 0 {
 		return cmd.Help()

--- a/cmd/microcloud/cluster_members.go
+++ b/cmd/microcloud/cluster_members.go
@@ -48,6 +48,7 @@ type cmdClusterMembers struct {
 	common *CmdControl
 }
 
+// Command returns the subcommand to manage cluster members.
 func (c *cmdClusterMembers) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cluster",
@@ -67,6 +68,7 @@ func (c *cmdClusterMembers) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the subcommand to manage cluster members.
 func (c *cmdClusterMembers) Run(cmd *cobra.Command, args []string) error {
 	return cmd.Help()
 }
@@ -78,6 +80,7 @@ type cmdClusterMembersList struct {
 	flagLocal  bool
 }
 
+// Command returns the subcommand to list cluster members.
 func (c *cmdClusterMembersList) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list <address>",
@@ -91,6 +94,7 @@ func (c *cmdClusterMembersList) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the subcommand to list cluster members.
 func (c *cmdClusterMembersList) Run(cmd *cobra.Command, args []string) error {
 	if len(args) > 1 {
 		return cmd.Help()
@@ -183,6 +187,7 @@ type cmdClusterMemberRemove struct {
 	flagForce bool
 }
 
+// Command returns the subcommand to remove a cluster member.
 func (c *cmdClusterMemberRemove) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "remove <name>",
@@ -195,6 +200,7 @@ func (c *cmdClusterMemberRemove) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the subcommand to remove a cluster member.
 func (c *cmdClusterMemberRemove) Run(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return cmd.Help()

--- a/cmd/microcloud/join.go
+++ b/cmd/microcloud/join.go
@@ -22,6 +22,7 @@ type cmdJoin struct {
 	flagInitiatorAddress string
 }
 
+// Command returns the subcommand for joining a MicroCloud.
 func (c *cmdJoin) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "join",
@@ -36,6 +37,7 @@ func (c *cmdJoin) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the subcommand for joining a MicroCloud.
 func (c *cmdJoin) Run(cmd *cobra.Command, args []string) error {
 	if len(args) != 0 {
 		return cmd.Help()

--- a/cmd/microcloud/main_init.go
+++ b/cmd/microcloud/main_init.go
@@ -123,6 +123,7 @@ type cmdInit struct {
 	flagSessionTimeout int64
 }
 
+// Command returns the subcommand for initializing a MicroCloud.
 func (c *cmdInit) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "init",
@@ -136,6 +137,7 @@ func (c *cmdInit) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the subcommand for initializing a MicroCloud.
 func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 	if len(args) != 0 {
 		return cmd.Help()
@@ -158,6 +160,7 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 	return cfg.RunInteractive(cmd, args)
 }
 
+// RunInteractive runs the interactive subcommand for initializing a MicroCloud.
 func (c *initConfig) RunInteractive(cmd *cobra.Command, args []string) error {
 	fmt.Println("Waiting for services to start ...")
 	err := checkInitialized(c.common.FlagMicroCloudDir, false, false)

--- a/cmd/microcloud/preseed.go
+++ b/cmd/microcloud/preseed.go
@@ -114,6 +114,7 @@ type cmdPreseed struct {
 	common *CmdControl
 }
 
+// Command returns the subcommand for unattended cluster initialization.
 func (c *cmdPreseed) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "preseed",
@@ -124,6 +125,7 @@ func (c *cmdPreseed) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the subcommand for unattended cluster initialization.
 func (c *cmdPreseed) Run(cmd *cobra.Command, args []string) error {
 	if len(args) != 0 {
 		return cmd.Help()

--- a/cmd/microcloud/remove.go
+++ b/cmd/microcloud/remove.go
@@ -16,6 +16,7 @@ type cmdRemove struct {
 	flagForce bool
 }
 
+// Command returns the subcommand to remove a member from all MicroCloud services.
 func (c *cmdRemove) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "remove <name>",
@@ -29,6 +30,7 @@ func (c *cmdRemove) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the subcommand to remove a member from all MicroCloud services.
 func (c *cmdRemove) Run(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return cmd.Help()

--- a/cmd/microcloud/services.go
+++ b/cmd/microcloud/services.go
@@ -26,6 +26,7 @@ type cmdServices struct {
 	common *CmdControl
 }
 
+// Command returns the subcommand to manage MicroCloud services.
 func (c *cmdServices) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "service",
@@ -46,6 +47,7 @@ type cmdServiceList struct {
 	common *CmdControl
 }
 
+// Command returns the subcommand to list MicroCloud services.
 func (c *cmdServiceList) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -56,6 +58,7 @@ func (c *cmdServiceList) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the subcommand to list MicroCloud services.
 func (c *cmdServiceList) Run(cmd *cobra.Command, args []string) error {
 	if len(args) != 0 {
 		return cmd.Help()
@@ -195,6 +198,7 @@ type cmdServiceAdd struct {
 	common *CmdControl
 }
 
+// Command returns the subcommand to add services to MicroCloud.
 func (c *cmdServiceAdd) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add",
@@ -205,6 +209,7 @@ func (c *cmdServiceAdd) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the subcommand to add services to MicroCloud.
 func (c *cmdServiceAdd) Run(cmd *cobra.Command, args []string) error {
 	if len(args) != 0 {
 		return cmd.Help()

--- a/cmd/microcloud/session.go
+++ b/cmd/microcloud/session.go
@@ -16,6 +16,7 @@ import (
 	"github.com/canonical/microcloud/microcloud/service"
 )
 
+// SessionFunc represents a function executed throughout the lifetime of a session.
 type SessionFunc func(gw *cloudClient.WebsocketGateway) error
 
 func (c *initConfig) runSession(ctx context.Context, s *service.Handler, role types.SessionRole, timeout time.Duration, f SessionFunc) error {

--- a/cmd/microcloud/shutdown.go
+++ b/cmd/microcloud/shutdown.go
@@ -12,6 +12,7 @@ type cmdShutdown struct {
 	common *CmdControl
 }
 
+// Command returns the subcommand for shutting down the MicroCloud daemon.
 func (c *cmdShutdown) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "shutdown",
@@ -22,6 +23,7 @@ func (c *cmdShutdown) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the subcommand for shutting down the MicroCloud daemon.
 func (c *cmdShutdown) Run(cmd *cobra.Command, args []string) error {
 	if len(args) != 0 {
 		return cmd.Help()

--- a/cmd/microcloud/sql.go
+++ b/cmd/microcloud/sql.go
@@ -14,6 +14,7 @@ type cmdSQL struct {
 	common *CmdControl
 }
 
+// Command returns the subcommand for sql queries.
 func (c *cmdSQL) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sql <query>",
@@ -24,6 +25,7 @@ func (c *cmdSQL) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the subcommand for sql queries.
 func (c *cmdSQL) Run(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		err := cmd.Help()

--- a/cmd/microcloud/status.go
+++ b/cmd/microcloud/status.go
@@ -91,6 +91,7 @@ type cmdStatus struct {
 	common *CmdControl
 }
 
+// Command returns the subcommand for the deployment status.
 func (c *cmdStatus) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "status",
@@ -101,6 +102,7 @@ func (c *cmdStatus) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the subcommand for the deployment status.
 func (c *cmdStatus) Run(cmd *cobra.Command, args []string) error {
 	if len(args) != 0 {
 		return cmd.Help()

--- a/cmd/microcloud/tokens.go
+++ b/cmd/microcloud/tokens.go
@@ -16,6 +16,7 @@ type cmdSecrets struct {
 	common *CmdControl
 }
 
+// Command returns the tokens subcommand.
 func (c *cmdSecrets) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tokens",
@@ -32,6 +33,7 @@ func (c *cmdSecrets) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the tokens subcommand.
 func (c *cmdSecrets) Run(cmd *cobra.Command, args []string) error {
 	return cmd.Help()
 }
@@ -41,6 +43,7 @@ type cmdTokensList struct {
 	flagFormat string
 }
 
+// Command returns the subcommand for listing tokens.
 func (c *cmdTokensList) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -53,6 +56,7 @@ func (c *cmdTokensList) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the subcommand for listing tokens.
 func (c *cmdTokensList) Run(cmd *cobra.Command, args []string) error {
 	if len(args) != 0 {
 		return cmd.Help()
@@ -96,6 +100,7 @@ type cmdTokensRevoke struct {
 	common *CmdControl
 }
 
+// Command returns the subcommand for revoking tokens by name.
 func (c *cmdTokensRevoke) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "revoke <name>",
@@ -106,6 +111,7 @@ func (c *cmdTokensRevoke) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the subcommand for revoking tokens by name.
 func (c *cmdTokensRevoke) Run(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return cmd.Help()

--- a/cmd/microcloud/waitready.go
+++ b/cmd/microcloud/waitready.go
@@ -14,6 +14,7 @@ type cmdWaitready struct {
 	flagTimeout int
 }
 
+// Command returns the subcommand for waiting on the daemon to be ready.
 func (c *cmdWaitready) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "waitready",
@@ -26,6 +27,7 @@ func (c *cmdWaitready) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the subcommand for waiting on the daemon to be ready.
 func (c *cmdWaitready) Run(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		return cmd.Help()

--- a/cmd/microcloudd/main.go
+++ b/cmd/microcloudd/main.go
@@ -51,6 +51,7 @@ type cmdDaemon struct {
 	flagHeartbeatInterval time.Duration
 }
 
+// Command returns the main microcloudd command.
 func (c *cmdDaemon) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "microcloudd",
@@ -63,6 +64,7 @@ func (c *cmdDaemon) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the main microcloudd command.
 func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 	if len(args) != 0 {
 		return cmd.Help()

--- a/cmd/tui/selectable_table.go
+++ b/cmd/tui/selectable_table.go
@@ -15,8 +15,8 @@ import (
 // RemoveMsg is a table notification that returns a row index of the table to remove.
 type RemoveMsg int
 
-// TODO: Use DisableMsg to inform the initiator when a joiner's websocket has closed.
 // DisableMsg is a table notification that returns a row index of the table to disable.
+// TODO: Use DisableMsg to inform the initiator when a joiner's websocket has closed.
 type DisableMsg int
 
 // EnableMsg is a table notification that returns a row index of the table to enable, if it was disabled.


### PR DESCRIPTION
Presumably with the new version of [revive](https://github.com/mgechev/revive/releases/tag/v1.6.1) new rules got added which make sense.

This PR fixes the new warnings.