### PR TITLE
Network: Populate the `NetworkInfo` with the right subnet address

### DIFF
--- a/multicast/info.go
+++ b/multicast/info.go
@@ -31,16 +31,16 @@ func GetNetworkInfo() ([]NetworkInfo, error) {
 		}
 
 		for _, addr := range addrs {
-			ipNet, ok := addr.(*net.IPNet)
-			if !ok {
+			ip, ipNet, err := net.ParseCIDR(addr.String())
+			if err != nil {
 				continue
 			}
 
-			if !ipNet.IP.IsGlobalUnicast() {
+			if !ip.IsGlobalUnicast() {
 				continue
 			}
 
-			networks = append(networks, NetworkInfo{Interface: iface, Address: ipNet.IP.String(), Subnet: ipNet})
+			networks = append(networks, NetworkInfo{Interface: iface, Address: ip.String(), Subnet: ipNet})
 		}
 	}
 


### PR DESCRIPTION
Don't falsely populate the subnet by using the regular address. Use the actual network address.

Before this was setting `10.1.2.3/24` as the `Subnet` but it should actually set `10.1.2.0/24`.