### PR TITLE
CLI: Use new formatting scheme for OVN underlay selection

### DIFF
--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -1192,10 +1192,13 @@ func (c *initConfig) askOVNNetwork(sh *service.Handler) error {
 	}
 
 	if len(ovnUnderlaySelectedIPs) > 0 {
+		// Add a space between the CLI and the response.
+		fmt.Println("")
+
 		for peer := range askSystems {
 			underlayIP, ok := ovnUnderlaySelectedIPs[peer]
 			if ok {
-				fmt.Printf(" Using %q for OVN underlay traffic on %q\n", underlayIP, peer)
+				fmt.Println(tui.SummarizeResult("Using %s on %s for OVN underlay traffic", underlayIP, peer))
 			}
 		}
 


### PR DESCRIPTION
Fixes https://github.com/canonical/microcloud/issues/613

Fix the output of the OVN underlay selection to also use the new formatting scheme using the yellow and bold highlight color:

![Screenshot from 2025-02-18 10-51-55](https://github.com/user-attachments/assets/8db9404d-d859-4ad1-8db2-d5d2b4229603)