### PR TITLE
Untangle deps to MicroCeph and MicroOVN

### DIFF
--- a/api/status.go
+++ b/api/status.go
@@ -18,7 +18,6 @@ import (
 	microTypes "github.com/canonical/microcluster/v2/rest/types"
 	"github.com/canonical/microcluster/v2/state"
 	ovnTypes "github.com/canonical/microovn/microovn/api/types"
-	ovnClient "github.com/canonical/microovn/microovn/client"
 
 	"github.com/canonical/microcloud/microcloud/api/types"
 	"github.com/canonical/microcloud/microcloud/client"
@@ -195,7 +194,9 @@ func cephStatus(ctx context.Context, s service.Service) (clusterMembers []microT
 }
 
 func ovnStatus(ctx context.Context, s service.Service) (clusterMembers []microTypes.ClusterMember, ovnServices []ovnTypes.Service, err error) {
-	microClient, err := s.(*service.OVNService).Client()
+	serviceOVN := s.(*service.OVNService)
+
+	microClient, err := serviceOVN.Client()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -205,7 +206,7 @@ func ovnStatus(ctx context.Context, s service.Service) (clusterMembers []microTy
 		return nil, nil, err
 	}
 
-	services, err := ovnClient.GetServices(ctx, microClient)
+	services, err := serviceOVN.GetServices(ctx)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/api/status.go
+++ b/api/status.go
@@ -13,7 +13,6 @@ import (
 	lxdAPI "github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 	cephTypes "github.com/canonical/microceph/microceph/api/types"
-	cephClient "github.com/canonical/microceph/microceph/client"
 	microClient "github.com/canonical/microcluster/v2/client"
 	"github.com/canonical/microcluster/v2/rest"
 	microTypes "github.com/canonical/microcluster/v2/rest/types"
@@ -150,7 +149,9 @@ func statusGet(sh *service.Handler) endpointHandler {
 }
 
 func cephStatus(ctx context.Context, s service.Service) (clusterMembers []microTypes.ClusterMember, osds []cephTypes.Disk, cephServices []cephTypes.Service, err error) {
-	microClient, err := s.(*service.CephService).Client("")
+	cephService := s.(*service.CephService)
+
+	microClient, err := cephService.Client("")
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -160,7 +161,7 @@ func cephStatus(ctx context.Context, s service.Service) (clusterMembers []microT
 		return nil, nil, nil, err
 	}
 
-	disks, err := cephClient.GetDisks(ctx, microClient)
+	disks, err := cephService.GetDisks(ctx, "")
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -175,7 +176,7 @@ func cephStatus(ctx context.Context, s service.Service) (clusterMembers []microT
 		}
 	}
 
-	services, err := cephClient.GetServices(ctx, microClient)
+	services, err := cephService.GetServices(ctx, "")
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/cmd/microcloud/main_init.go
+++ b/cmd/microcloud/main_init.go
@@ -17,7 +17,6 @@ import (
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/validate"
 	cephTypes "github.com/canonical/microceph/microceph/api/types"
-	ovnClient "github.com/canonical/microovn/microovn/client"
 	"github.com/spf13/cobra"
 
 	"github.com/canonical/microcloud/microcloud/api"
@@ -841,13 +840,9 @@ func (c *initConfig) setupCluster(s *service.Handler) error {
 
 	var ovnConfig string
 	if s.Services[types.MicroOVN] != nil {
-		ovn := s.Services[types.MicroOVN].(*service.OVNService)
-		client, err := ovn.Client()
-		if err != nil {
-			return err
-		}
+		serviceOVN := s.Services[types.MicroOVN].(*service.OVNService)
 
-		services, err := ovnClient.GetServices(context.Background(), client)
+		services, err := serviceOVN.GetServices(context.Background())
 		if err != nil {
 			return err
 		}

--- a/service/microceph.go
+++ b/service/microceph.go
@@ -14,7 +14,6 @@ import (
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 	cephTypes "github.com/canonical/microceph/microceph/api/types"
-	cephClient "github.com/canonical/microceph/microceph/client"
 	"github.com/canonical/microcluster/v2/client"
 	"github.com/canonical/microcluster/v2/microcluster"
 
@@ -130,6 +129,124 @@ func (s CephService) DeleteToken(ctx context.Context, tokenName string, address 
 	return c.DeleteTokenRecord(ctx, tokenName)
 }
 
+// AddDisk requests Ceph sets up a new OSD.
+func (s CephService) AddDisk(ctx context.Context, data cephTypes.DisksPost, target string) (cephTypes.DiskAddResponse, error) {
+	response := cephTypes.DiskAddResponse{}
+
+	c, err := s.Client(target)
+	if err != nil {
+		return response, err
+	}
+
+	err = c.Query(ctx, "POST", types.APIVersion, api.NewURL().Path("disks"), data, &response)
+	if err != nil {
+		return response, fmt.Errorf("Failed to request disk addition: %w", err)
+	}
+
+	return response, nil
+}
+
+// GetServices returns the list of configured ceph services.
+func (s CephService) GetServices(ctx context.Context, target string) (cephTypes.Services, error) {
+	c, err := s.Client(target)
+	if err != nil {
+		return nil, err
+	}
+
+	services := cephTypes.Services{}
+
+	err = c.Query(ctx, "GET", types.APIVersion, api.NewURL().Path("services"), nil, &services)
+	if err != nil {
+		return nil, fmt.Errorf("Failed listing services: %w", err)
+	}
+
+	return services, nil
+}
+
+// GetDisks returns the list of configured disks.
+func (s CephService) GetDisks(ctx context.Context, target string) (cephTypes.Disks, error) {
+	c, err := s.Client(target)
+	if err != nil {
+		return nil, err
+	}
+
+	disks := cephTypes.Disks{}
+
+	err = c.Query(ctx, "GET", types.APIVersion, api.NewURL().Path("disks"), nil, &disks)
+	if err != nil {
+		return nil, fmt.Errorf("Failed listing disks: %w", err)
+	}
+
+	return disks, nil
+}
+
+// GetPools returns a list of pools.
+func (s CephService) GetPools(ctx context.Context, target string) ([]cephTypes.Pool, error) {
+	c, err := s.Client(target)
+	if err != nil {
+		return nil, err
+	}
+
+	var pools []cephTypes.Pool
+
+	err = c.Query(ctx, "GET", types.APIVersion, api.NewURL().Path("pools"), nil, &pools)
+	if err != nil {
+		return nil, fmt.Errorf("Failed listing OSD pools: %w", err)
+	}
+
+	return pools, nil
+}
+
+// PoolSetReplicationFactor sets the replication factor for the given pools.
+func (s CephService) PoolSetReplicationFactor(ctx context.Context, data cephTypes.PoolPut, target string) error {
+	c, err := s.Client(target)
+	if err != nil {
+		return err
+	}
+
+	err = c.Query(ctx, "PUT", types.APIVersion, api.NewURL().Path("pools-op"), data, nil)
+	if err != nil {
+		return fmt.Errorf("Failed setting replication factor: %w", err)
+	}
+
+	return nil
+}
+
+// GetConfig returns the requested config.
+// It allows passing a certificate in case the cluster config is derived directly from the remote
+// before the MicroCloud cluster is being formed.
+// If the cluster is already formed and the trust got established this isn't required anymore.
+func (s CephService) GetConfig(ctx context.Context, data cephTypes.Config, target string, cert *x509.Certificate) (cephTypes.Configs, error) {
+	var c *client.Client
+	var err error
+
+	if target == "" {
+		c, err = s.Client("")
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		c, err = s.remoteClient(cert, target)
+		if err != nil {
+			return nil, err
+		}
+
+		c, err = cloudClient.UseAuthProxy(c, types.MicroCeph, cloudClient.AuthConfig{})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	configs := cephTypes.Configs{}
+
+	err = c.Query(ctx, "GET", types.APIVersion, api.NewURL().Path("configs"), data, &configs)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to fetch cluster config key %q: %w", data.Key, err)
+	}
+
+	return configs, nil
+}
+
 // Join joins a cluster with the given token.
 func (s CephService) Join(ctx context.Context, joinConfig JoinConfig) error {
 	err := s.m.JoinCluster(ctx, s.name, util.CanonicalNetworkAddress(s.address, s.port), joinConfig.Token, nil)
@@ -137,13 +254,8 @@ func (s CephService) Join(ctx context.Context, joinConfig JoinConfig) error {
 		return err
 	}
 
-	c, err := s.Client("")
-	if err != nil {
-		return err
-	}
-
 	for _, disk := range joinConfig.CephConfig {
-		_, err := cephClient.AddDisk(ctx, c, &disk)
+		_, err := s.AddDisk(ctx, disk, "")
 		if err != nil {
 			return err
 		}
@@ -210,27 +322,8 @@ func (s CephService) DeleteClusterMember(ctx context.Context, name string, force
 
 // ClusterConfig returns the Ceph cluster configuration.
 func (s CephService) ClusterConfig(ctx context.Context, targetAddress string, cert *x509.Certificate) (map[string]string, error) {
-	var c *client.Client
-	var err error
-	if targetAddress == "" {
-		c, err = s.Client("")
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		c, err = s.remoteClient(cert, targetAddress)
-		if err != nil {
-			return nil, err
-		}
-
-		c, err = cloudClient.UseAuthProxy(c, types.MicroCeph, cloudClient.AuthConfig{})
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	data := cephTypes.Config{}
-	cs, err := cephClient.GetConfig(ctx, c, &data)
+	cs, err := s.GetConfig(ctx, data, targetAddress, cert)
 	if err != nil {
 		return nil, err
 	}

--- a/service/microovn.go
+++ b/service/microovn.go
@@ -15,6 +15,7 @@ import (
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/microcluster/v2/client"
 	"github.com/canonical/microcluster/v2/microcluster"
+	ovnTypes "github.com/canonical/microovn/microovn/api/types"
 
 	"github.com/canonical/microcloud/microcloud/api/types"
 	cloudClient "github.com/canonical/microcloud/microcloud/client"
@@ -248,4 +249,21 @@ func (s *OVNService) SupportsFeature(ctx context.Context, feature string) (bool,
 	}
 
 	return server.Extensions.HasExtension(feature), nil
+}
+
+// GetServices returns the list of configured OVN services.
+func (s *OVNService) GetServices(ctx context.Context) (ovnTypes.Services, error) {
+	client, err := s.Client()
+	if err != nil {
+		return nil, err
+	}
+
+	services := ovnTypes.Services{}
+
+	err = client.Query(ctx, "GET", types.APIVersion, api.NewURL().Path("services"), nil, &services)
+	if err != nil {
+		return nil, fmt.Errorf("Failed listing services: %w", err)
+	}
+
+	return services, nil
 }


### PR DESCRIPTION
This allows switching the used version of Microcluster without having to also bump the version of Microcluster in both MicroCeph and MicroOVN.