### PR TITLE
Test: Hold all snaps to prevent unplanned refresh

### DIFF
--- a/test/includes/microcloud.sh
+++ b/test/includes/microcloud.sh
@@ -1277,6 +1277,12 @@ setup_system() {
       lxc exec "${name}" -- snap install microcloud --channel="${MICROCLOUD_SNAP_CHANNEL}" --cohort="+"
     fi
 
+    # Hold the snaps to not perform any refreshes during test execution.
+    # This can cause various side effects in case of restoring an old test deployment
+    # as the snaps will identify upstream changes and initiate a refresh.
+    # It was also observed in the test pipeline jobs from time to time.
+    lxc exec "${name}" -- snap refresh --hold microceph microovn lxd microcloud
+
     set_debug_binaries "${name}"
   )
 


### PR DESCRIPTION
The test suite should hold the lxd, microceph, microovn and microcloud snaps to not cause unplanned refreshes during test execution.

This was observed in the pipeline every now and then and caused some of the daemons to be stopped out of nowhere which resulted in API endpoints returning EOF.
In the daemon logs this is clearly indicated by systemd stopping the respective service and starting it afterwards:

```
Feb 20 09:53:13 micro03 systemd[1]: Stopping snap.microcloud.daemon.service - Service for snap application microcloud.daemon...
Feb 20 09:53:13 micro03 systemd[1]: snap.microcloud.daemon.service: Deactivated successfully.
Feb 20 09:53:13 micro03 systemd[1]: Stopped snap.microcloud.daemon.service - Service for snap application microcloud.daemon.
Feb 20 09:53:16 micro03 systemd[1]: Started snap.microcloud.daemon.service - Service for snap application microcloud.daemon.
```

An example error visible from the users (MicroCloud) point of view is this. It happened at the same time as `snapd` started to refresh the MicroCloud snap:

`Error: System "micro03" failed to join the cluster: Failed to update cluster status of services: Put "https://10.87.144.161:9443/1.0/services": EOF`