### PR TITLE
github: Use `github.workspace` variable for GOCOVERDIR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,8 @@ env:
   CGO_LDFLAGS: -L/home/runner/go/deps/dqlite/.libs/
   LD_LIBRARY_PATH: /home/runner/go/deps/dqlite/.libs/
   CGO_LDFLAGS_ALLOW: (-Wl,-wrap,pthread_create)|(-Wl,-z,now)
-  GOCOVERDIR: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ) && '/home/runner/work/microcloud/microcloud/cover' || '' }}
+  # Use the github.workspace variable to adapt the cover directory path based on the used runner.
+  GOCOVERDIR: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ) && format('{0}/cover', github.workspace) || '' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
Merging https://github.com/canonical/microcloud/pull/631 introduced another regression because in order to pick up the cover files from the Canonical runners (during weekly test execution) the path still has to be aligned with the different directory structure.
The `/home/runner` path does not exist on the Canonical runners, see https://github.com/canonical/microcloud/actions/runs/13349891499/job/37285054247

The TICS job is looking at `${{ github.workspace }}/cover` to find the respective files.