### PR TITLE
doc: use v2-edge paths for integrated docs (v2-edge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,11 @@ microcloud join
 
 Following the simple CLI prompts, a working MicroCloud will be ready within minutes.
 
-<!-- include start about -->
-
 The MicroCloud snap drives three other snaps ([LXD](https://canonical-microcloud.readthedocs-hosted.com/en/latest/lxd/), [MicroCeph](https://canonical-microcloud.readthedocs-hosted.com/en/latest/microceph/), and [MicroOVN](https://canonical-microcloud.readthedocs-hosted.com/en/latest/microovn/)), enabling automated deployment of a highly available LXD cluster for compute, with Ceph as the storage driver and OVN as the managed network.
 
 During initialisation, MicroCloud scrapes the other servers for details and then prompts you to add disks to Ceph and configure the networking setup.
 
 At the end of this, you’ll have an OVN cluster, a Ceph cluster, and a LXD cluster. LXD itself will have been configured with both networking and storage suitable for use in a cluster.
-
-<!-- include end about -->
 
 ## **What about networking?**
 

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -233,9 +233,9 @@ if ('SINGLE_BUILD' in os.environ and os.environ['SINGLE_BUILD'] == 'True'):
     }
 elif ('READTHEDOCS' in os.environ) and (os.environ['READTHEDOCS'] == 'True'):
     intersphinx_mapping = {
-        'lxd': ('/en/latest/lxd/', os.environ['READTHEDOCS_OUTPUT'] + 'html/lxd/objects.inv'),
-        'microceph': ('/en/latest/microceph/', os.environ['READTHEDOCS_OUTPUT'] + 'html/microceph/objects.inv'),
-        'microovn': ('/en/latest/microovn/', os.environ['READTHEDOCS_OUTPUT'] + 'html/microovn/objects.inv'),
+        'lxd': ('/en/v2-edge/lxd/', os.environ['READTHEDOCS_OUTPUT'] + 'html/lxd/objects.inv'),
+        'microceph': ('/en/v2-edge/microceph/', os.environ['READTHEDOCS_OUTPUT'] + 'html/microceph/objects.inv'),
+        'microovn': ('/en/v2-edge/microovn/', os.environ['READTHEDOCS_OUTPUT'] + 'html/microovn/objects.inv'),
         'ceph': ('https://docs.ceph.com/en/latest/', None)
     }
 else:

--- a/doc/explanation/microcloud.md
+++ b/doc/explanation/microcloud.md
@@ -5,10 +5,12 @@ relatedlinks: https://documentation.ubuntu.com/lxd/
 (explanation-microcloud)=
 # About MicroCloud
 
-```{include} ../../README.md
-:start-after: <!-- include start about -->
-:end-before: <!-- include end about -->
-```
+The MicroCloud snap drives three other snaps ({doc}`lxd:index`, {doc}`microceph:index`, and {doc}`microovn:index`), enabling automated deployment of a highly available LXD cluster for compute, with Ceph as the storage driver and OVN as the managed network.
+
+During initialisation, MicroCloud scrapes the other servers for details and then prompts you to add disks to Ceph and configure the networking setup.
+
+At the end of this, you’ll have an OVN cluster, a Ceph cluster, and a LXD cluster. LXD itself will have been configured with both networking and storage suitable for use in a cluster.
+
 
 ## LXD cluster
 


### PR DESCRIPTION
The v2-edge branch's docs Makefile already [points to the correct docs versions](https://github.com/canonical/microcloud/blob/v2-edge/doc/Makefile#L12) for each integrated repository, so I only needed to change the path in custom_config.py. I tested to make sure that it doesn't just change the URL from latest to v2-edge; it also changes the docs version shown. 

To test this in the [RTD preview](https://canonical-microcloud--655.com.readthedocs.build/en/655/):
- ~~Switch to the `v2-edge` version from the flyout at the bottom right.~~
- From the docs landing page, scroll down to **How to use this documentation** , where there are links to LXD, MicroCeph, and MicroOVN.
- Hover over those links and confirm that they now direct to `v2-edge` instead of `latest`. Unfortunately, due to the way the RTD preview works, you can't actually click them - they'll 404. However, you can see this working in my test MicroCloud site [here](https://canonical-microcloud-test.readthedocs-hosted.com/en/v2-edge/microcloud/) (test site access requires login to RTD).
- You can also test the links in issue #610.

Fixes #610