### PR TITLE
doc: replace include from README to improve versioning support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,11 @@ microcloud join
 
 Following the CLI prompts, a working MicroCloud will be ready within minutes.
 
-<!-- include start about -->
-
 The MicroCloud snap drives three other snaps ([LXD](https://canonical-microcloud.readthedocs-hosted.com/en/latest/lxd/), [MicroCeph](https://canonical-microcloud.readthedocs-hosted.com/en/latest/microceph/), and [MicroOVN](https://canonical-microcloud.readthedocs-hosted.com/en/latest/microovn/)), enabling automated deployment of a highly available LXD cluster for compute, with Ceph as the storage driver and OVN as the managed network.
 
 During initialization, MicroCloud scrapes the other servers for details and then prompts you to add disks to Ceph and configure the networking setup.
 
 At the end of this, you’ll have an OVN cluster, a Ceph cluster, and a LXD cluster. LXD itself will have been configured with both networking and storage suitable for use in a cluster.
-
-<!-- include end about -->
 
 For more information, see the MicroCloud documentation for [installation](https://canonical-microcloud.readthedocs-hosted.com/en/latest/microcloud/how-to/install/) and [initialization](https://canonical-microcloud.readthedocs-hosted.com/en/latest/microcloud/how-to/initialize/). You can also [follow a tutorial](https://canonical-microcloud.readthedocs-hosted.com/en/latest/microcloud/tutorial/get_started/) that demonstrates the basics of MicroCloud.
 

--- a/doc/explanation/microcloud.md
+++ b/doc/explanation/microcloud.md
@@ -5,10 +5,11 @@ relatedlinks: https://documentation.ubuntu.com/lxd/
 (explanation-microcloud)=
 # About MicroCloud
 
-```{include} ../../README.md
-:start-after: <!-- include start about -->
-:end-before: <!-- include end about -->
-```
+The MicroCloud snap drives three other snaps ({doc}`lxd:index`, {doc}`microceph:index`, and {doc}`microovn:index`), enabling automated deployment of a highly available LXD cluster for compute, with Ceph as the storage driver and OVN as the managed network.
+
+During initialization, MicroCloud scrapes the other servers for details and then prompts you to add disks to Ceph and configure the networking setup.
+
+At the end of this, you’ll have an OVN cluster, a Ceph cluster, and a LXD cluster. LXD itself will have been configured with both networking and storage suitable for use in a cluster.
 
 ## LXD cluster
 


### PR DESCRIPTION
Replaces a programmatic include of text from README.md with the direct content of the same text, with links fixed to support versioning (so they point to the selected version of the docs instead of always the latest version). Related to https://github.com/canonical/microcloud/pull/655 (for v2-edge)