### PR TITLE
doc: use PATH_PREFIX in docs Makefile for RTD build (v2-edge)

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -9,6 +9,8 @@
 
 current_dir := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 
+# Set the path prefix and MicroCloud component versions corresponding to each MicroCloud docs version
+PATH_PREFIX      = /en/v2-edge/
 LXDVERSION       = origin/stable-5.21
 MICROCEPHVERSION = 1200ba77f2320be2acec45939f4b96a8ac4f0722 # origin/main right after squid LTS.
 MICROOVNVERSION  = origin/branch-24.03
@@ -84,10 +86,10 @@ html: integrate
 # `html-rtd` builds the integrated docs, with the correct paths for Read the Docs.
 # This target is used by the Read the Docs build.
 html-rtd:
-	cd integration/lxd/doc/ && $(MAKE) html-rtd BUILDDIR=$(READTHEDOCS_OUTPUT)/html/lxd
-	cd integration/microceph/docs/ && $(MAKE) html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microceph
-	cd integration/microovn/docs/ && $(MAKE) html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microovn
-	$(MAKE) -f Makefile.sp sp-html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microcloud
+	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -C integration/lxd/doc/ html-rtd BUILDDIR=$(READTHEDOCS_OUTPUT)/html/lxd
+	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -C integration/microceph/docs/ html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microceph
+	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -C integration/microovn/docs/ html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microovn
+	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -f Makefile.sp sp-html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microcloud
 
 # `spelling` checks only the MicroCloud docs.
 spelling: clean-doc microcloud

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -233,9 +233,9 @@ if ('SINGLE_BUILD' in os.environ and os.environ['SINGLE_BUILD'] == 'True'):
     }
 elif ('READTHEDOCS' in os.environ) and (os.environ['READTHEDOCS'] == 'True'):
     intersphinx_mapping = {
-        'lxd': ('/en/v2-edge/lxd/', os.environ['READTHEDOCS_OUTPUT'] + 'html/lxd/objects.inv'),
-        'microceph': ('/en/v2-edge/microceph/', os.environ['READTHEDOCS_OUTPUT'] + 'html/microceph/objects.inv'),
-        'microovn': ('/en/v2-edge/microovn/', os.environ['READTHEDOCS_OUTPUT'] + 'html/microovn/objects.inv'),
+        'lxd': (os.environ['PATH_PREFIX'] + 'lxd/', os.environ['READTHEDOCS_OUTPUT'] + 'html/lxd/objects.inv'),
+        'microceph': (os.environ['PATH_PREFIX'] + 'microceph/', os.environ['READTHEDOCS_OUTPUT'] + 'html/microceph/objects.inv'),
+        'microovn': (os.environ['PATH_PREFIX'] + 'microovn/', os.environ['READTHEDOCS_OUTPUT'] + 'html/microovn/objects.inv'),
         'ceph': ('https://docs.ceph.com/en/latest/', None)
     }
 else:


### PR DESCRIPTION
Per @roosterfish suggestion at https://github.com/canonical/microcloud/pull/655#discussion_r1967186572, updated so that a PATH_PREFIX variable is set in the docs Makefile then used when building for RTD only.

This should make it easier to remember to update the PATH_PREFIX for new versions (at the same time as setting the correponding versions for LXD/MicroCeph/MicroOVN). Plus, we'll only need to change the Makefile instead of both the Makefile and custom_conf.py. Will add change to main also once if this is approved/merged.