### PR TITLE
doc: use PATH_PREFIX in docs Makefile for RTD build

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -9,6 +9,8 @@
 
 current_dir := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 
+# Set the path prefix and MicroCloud component versions corresponding to each MicroCloud docs version
+PATH_PREFIX      = /en/latest/
 LXDVERSION       = origin/main
 MICROCEPHVERSION = origin/main
 MICROOVNVERSION  = origin/main
@@ -84,10 +86,10 @@ html: integrate
 # `html-rtd` builds the integrated docs, with the correct paths for Read the Docs.
 # This target is used by the Read the Docs build.
 html-rtd:
-	cd integration/lxd/doc/ && $(MAKE) html-rtd BUILDDIR=$(READTHEDOCS_OUTPUT)/html/lxd
-	cd integration/microceph/docs/ && $(MAKE) html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microceph
-	cd integration/microovn/docs/ && $(MAKE) html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microovn
-	$(MAKE) -f Makefile.sp sp-html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microcloud
+	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -C integration/lxd/doc/ html-rtd BUILDDIR=$(READTHEDOCS_OUTPUT)/html/lxd
+	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -C integration/microceph/docs/ html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microceph
+	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -C integration/microovn/docs/ html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microovn
+	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -f Makefile.sp sp-html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microcloud
 
 # `spelling` checks only the MicroCloud docs.
 spelling: clean-doc microcloud

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -244,9 +244,9 @@ if ('SINGLE_BUILD' in os.environ and os.environ['SINGLE_BUILD'] == 'True'):
     }
 elif ('READTHEDOCS' in os.environ) and (os.environ['READTHEDOCS'] == 'True'):
     intersphinx_mapping = {
-        'lxd': ('/en/latest/lxd/', os.environ['READTHEDOCS_OUTPUT'] + 'html/lxd/objects.inv'),
-        'microceph': ('/en/latest/microceph/', os.environ['READTHEDOCS_OUTPUT'] + 'html/microceph/objects.inv'),
-        'microovn': ('/en/latest/microovn/', os.environ['READTHEDOCS_OUTPUT'] + 'html/microovn/objects.inv'),
+        'lxd': (os.environ['PATH_PREFIX'] + 'lxd/', os.environ['READTHEDOCS_OUTPUT'] + 'html/lxd/objects.inv'),
+        'microceph': (os.environ['PATH_PREFIX'] + 'microceph/', os.environ['READTHEDOCS_OUTPUT'] + 'html/microceph/objects.inv'),
+        'microovn': (os.environ['PATH_PREFIX'] + 'microovn/', os.environ['READTHEDOCS_OUTPUT'] + 'html/microovn/objects.inv'),
         'ceph': ('https://docs.ceph.com/en/latest/', None)
     }
 else:


### PR DESCRIPTION
Follow-up for https://github.com/canonical/microcloud/pull/665

Sets a variable for the URL path prefix for versioned docs in docs Makefile. This way, both the Makefile and custom_conf.py don't need to be updated for new versions, only the Makefile.