### PR TITLE
GitHub: Fix TICS deps

### DIFF
--- a/.github/actions/install-builddeps/action.yml
+++ b/.github/actions/install-builddeps/action.yml
@@ -1,0 +1,23 @@
+name: Install MicroCloud build dependencies
+runs:
+  using: composite
+  steps:
+    - name: Installs MicroCloud build dependencies
+      shell: bash
+      run: |
+        set -eux
+        sudo apt-get update
+
+        # Install deps.
+        sudo apt-get install --no-install-recommends -y \
+          pkg-config \
+          autoconf \
+          automake \
+          libtool \
+          make \
+          libuv1-dev \
+          libsqlite3-dev \
+          liblz4-dev
+
+        # Reclaim some space.
+        sudo apt-get clean

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,10 +91,8 @@ jobs:
           path: ${{ steps.ShellCheck.outputs.sarif }}
         if: github.event_name == 'pull_request'
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends -y pkg-config autoconf automake libtool make libuv1-dev libsqlite3-dev liblz4-dev
+      - name: Install MicroCloud build dependencies
+        uses: ./.github/actions/install-builddeps
 
       - name: Build
         run: |
@@ -265,6 +263,9 @@ jobs:
           name: system-test-deps
           merge-multiple: true
           path: /home/runner/go/bin
+
+      - name: Install MicroCloud build dependencies
+        uses: ./.github/actions/install-builddeps
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,6 +99,11 @@ jobs:
           make deps
           make build-test
 
+          # Include dqlite libs in dependencies for system tests.
+          mkdir /home/runner/go/bin/dqlite
+          mv ~/go/deps/dqlite/include /home/runner/go/bin/dqlite/include
+          mv ~/go/deps/dqlite/.libs /home/runner/go/bin/dqlite/libs
+
       - name: Run static analysis
         run: make check-static
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -231,6 +231,11 @@ jobs:
     name: Tiobe TICS
     runs-on: ubuntu-22.04
     needs: [system-tests-core, system-tests-upgrade]
+    env:
+      CGO_CFLAGS: "-I/home/runner/go/bin/dqlite/include/"
+      CGO_LDFLAGS: "-L/home/runner/go/bin/dqlite/libs/"
+      LD_LIBRARY_PATH: "/home/runner/go/bin/dqlite/libs/"
+      CGO_LDFLAGS_ALLOW: "(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
     if: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ) && github.ref_name == 'main' && github.repository == 'canonical/microcloud' }}
     steps:
       - name: Checkout


### PR DESCRIPTION
When switching from dqlite PPA to manual build in https://github.com/canonical/microcloud/pull/513, the `dqlite` dep was already added in the list of build artifacts.
However in the TICS job the global `CGO_*` and `LD_*` flags have to be modified to point to the downloaded location instead as it's different from the build job.

The PR also adds a common `install-builddeps` action as in LXD to wrap the dep installation.