### PR TITLE
doc: update how related links extension is used

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -82,8 +82,8 @@ html_context = {
 
     # ru-fu: we're using different Discourses
     'discourse_prefix': {
+        'ubuntu': 'https://discourse.ubuntu.com/t/',
         'lxc': 'https://discuss.linuxcontainers.org/t/',
-        'ubuntu': 'https://discourse.ubuntu.com/t/'
     },
 
     # Change to the Mattermost channel you want to link to

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,6 +1,6 @@
 ---
-discourse: lxc:15871
-relatedlinks: https://snapcraft.io/microcloud
+discourse: lxc:[Introducing&#32;MicroCloud](15871)
+relatedlinks: "[Install&#32;MicroCloud&#32;on&#32;Linux&#32;|&#32;Snap&#32;Store](https://snapcraft.io/microcloud)"
 ---
 
 (home)=


### PR DESCRIPTION
1) Make the Ubuntu Discourse the default Discourse instance instead of the LinuxContainers instance
2) Explicitly set all titles for links created using the [relatedlinks Sphinx extension](https://github.com/canonical/canonical-sphinx-extensions?tab=readme-ov-file#related-links) (both Discourse links and general related links) rather than fetching at build, so that external sites' outages do not affect LXD builds. (Same as https://github.com/canonical/lxd/pull/15131)