### PR TITLE
doc: fix infinite loop for make run

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -99,6 +99,10 @@ spelling: clean-doc microcloud
 microcloud:
 	$(MAKE) -f Makefile.sp sp-html SINGLE_BUILD=True
 
+.PHONY: run
+run:
+	$(MAKE) -f Makefile.sp sp-run LOCAL_SPHINX_BUILD=True ADDPREREQS='gitpython pyyaml' SPHINXOPTS="--ignore './index.html' -c . -d .sphinx/.doctrees -j auto"
+
 # `serve` rebuilds the integrated docs and serves them.
 serve: html
 	cd $(current_dir)/_build/; python3 -m http.server --bind 127.0.0.1 8000

--- a/doc/index.html
+++ b/doc/index.html
@@ -1,0 +1,1 @@
+<html><head><meta http-equiv="refresh" content="0; url=microcloud/"></head></html>


### PR DESCRIPTION
`index.html` is auto-generated and is [required to be in docs root](https://blog.readthedocs.com/builds-without-index/) yet it wasn't committed. It also re-generates at every build, which was causing `make run` to auto-loop (since it watches for changes), so used `--ignore` for sphinx-autobuild to ignore it. 