### PR TITLE
test/e2e: add script/Terraform recipe to test MicroCloud deployments

### DIFF
--- a/test/e2e/.gitignore
+++ b/test/e2e/.gitignore
@@ -1,0 +1,3 @@
+terraform.tfstate
+terraform.tfstate.backup
+terraform.tfvars

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,49 @@
+# End to end testing of MicroCloud
+
+Once MicroCloud is deployed, end to end testing can verify that everything works as it should.
+
+## Testing
+
+The [`run`](run) script will setup a dedicated project using the [Terraform provider for LXD](https://github.com/terraform-lxd/terraform-provider-lxd) and deploy a number of instances on the MicroCloud. Those instances will be a mix of containers and virtual machines.
+
+It is possible to override the variables defined in [`variables.tf`](variables.tf) by creating a file named `terraform.tfvars`:
+
+```sh
+# terraform.tfvars
+containers_per_host = 25
+vms_per_host = 5
+```
+
+Then execute the script and provide it the name of the LXD remote corresponding to the MicroCloud deployment to test (`mc` here):
+
+```sh
+./run mc
+```
+
+If the LXD remote to test is not configured yet, it's possible to add it with an identity token issued from a MicroCloud cluster member (`micro1` here):
+
+```sh
+# Create the needed group
+root@micro1:~# lxc auth group create e2e-testing
+Group e2e-testing created
+
+# Grant admin permission on server
+root@micro1:~# lxc auth group permission add e2e-testing server admin
+
+# Issue the identity token
+root@micro1:~# lxc auth identity create tls/e2e-testing
+TLS identity "tls/e2e-testing" (d16614b8-f39e-4ef5-8e9b-90764b61b660) pending identity token:
+eyJjbGllbnRfbmFtZSI6ImUyZS10ZXN0aW5nIiwiZmluZ2VycHJpbnQiOiIyNzY1OGNjYmRlNmRkZDcwNDliMzliNmY5NzA1MWIzMWVkMWQ0NDM2OTFjZGFjMWIxNmI1ODBjNmI4NzFiNmM2IiwiYWRkcmVzc2VzIjpbIjE3Mi4yNC4yNi4xODo4NDQzIiwiWzIwMDE6NDcwOmIxYzM6Nzk0Njo4NWYzOmQzYTg6ZDcxZTo3YjA1XTo4NDQzIl0sInNlY3JldCI6ImJjNjlmOTM4YzM5NjRhNTI1ZDI3OTlmMTEyM2Q2NWE5ZGExZDE1ZGFmNjVjZjlmNTViYjQ1ZDdmZjBiMjg1YmYiLCJleHBpcmVzX2F0IjoiMDAwMS0wMS0wMVQwMDowMDowMFoiLCJ0eXBlIjoiQ2xpZW50IGNlcnRpZmljYXRlIn0=
+
+# Add the freshly created identity to the freshly created group
+root@micro1:~# lxc auth identity group add tls/e2e-testing e2e-testing
+```
+
+This token can be used on the machine where the `run` script will be used:
+
+```sh
+lxc remote add mc https://microcloud.lxd:8443 --token eyJjbGllbnRfbmFtZSI6ImUyZS10ZXN0aW5nIiwiZmluZ2VycHJpbnQiOiIyNzY1OGNjYmRlNmRkZDcwNDliMzliNmY5NzA1MWIzMWVkMWQ0NDM2OTFjZGFjMWIxNmI1ODBjNmI4NzFiNmM2IiwiYWRkcmVzc2VzIjpbIjE3Mi4yNC4yNi4xODo4NDQzIiwiWzIwMDE6NDcwOmIxYzM6Nzk0Njo4NWYzOmQzYTg6ZDcxZTo3YjA1XTo4NDQzIl0sInNlY3JldCI6ImJjNjlmOTM4YzM5NjRhNTI1ZDI3OTlmMTEyM2Q2NWE5ZGExZDE1ZGFmNjVjZjlmNTViYjQ1ZDdmZjBiMjg1YmYiLCJleHBpcmVzX2F0IjoiMDAwMS0wMS0wMVQwMDowMDowMFoiLCJ0eXBlIjoiQ2xpZW50IGNlcnRpZmljYXRlIn0=
+
+
+./run mc
+```

--- a/test/e2e/main.tf
+++ b/test/e2e/main.tf
@@ -1,0 +1,123 @@
+# Data sources
+data "lxd_info" "cluster" {
+  remote = var.remote
+}
+
+# Project
+resource "lxd_project" "e2e" {
+  name   = "e2e-testing"
+  remote = var.remote
+}
+
+# Profile
+resource "lxd_profile" "e2e" {
+  name    = "e2e-testing"
+  project = lxd_project.e2e.name
+  remote  = lxd_project.e2e.remote
+
+  # Configuration
+  config = {
+    "limits.cpu"    = 1
+    "limits.memory" = "1GiB"
+  }
+
+  # Devices
+  device {
+    name = "root"
+    type = "disk"
+    properties = {
+      pool = "remote"
+      path = "/"
+      size = "4GiB"
+    }
+  }
+
+  device {
+    name = "eth0"
+    type = "nic"
+    properties = {
+      network = "default"
+    }
+  }
+}
+
+# Images
+resource "lxd_cached_image" "ctn" {
+  count         = var.containers_per_host > 0 ? 1 : 0
+  project       = lxd_project.e2e.name
+  remote        = lxd_project.e2e.remote
+  source_remote = "ubuntu-minimal-daily"
+  source_image  = "24.04"
+  type          = "container"
+}
+
+resource "lxd_cached_image" "vm" {
+  count         = var.vms_per_host > 0 ? 1 : 0
+  project       = lxd_project.e2e.name
+  remote        = lxd_project.e2e.remote
+  source_remote = "ubuntu-minimal-daily"
+  source_image  = "24.04"
+  type          = "virtual-machine"
+}
+
+# Containers
+resource "lxd_instance" "e2e-ctn" {
+  for_each = {
+    for _, v in local.containers : v.instance => v.target
+  }
+
+  name             = each.key
+  target           = each.value
+  type             = "container"
+  remote           = lxd_project.e2e.remote
+  project          = lxd_project.e2e.name
+  profiles         = [lxd_profile.e2e.name]
+  image            = lxd_cached_image.ctn[0].fingerprint
+  wait_for_network = true
+}
+
+# VMs
+resource "lxd_instance" "e2e-vm" {
+  for_each = {
+    for _, v in local.vms : v.instance => v.target
+  }
+
+  name             = each.key
+  target           = each.value
+  type             = "virtual-machine"
+  remote           = lxd_project.e2e.remote
+  project          = lxd_project.e2e.name
+  profiles         = [lxd_profile.e2e.name]
+  image            = lxd_cached_image.vm[0].fingerprint
+  wait_for_network = true
+}
+
+# Locals
+locals {
+  cluster_member_names = [for k, _ in data.lxd_info.cluster.cluster_members : k]
+
+  containers = flatten([
+    for index, cluster_member_name in local.cluster_member_names : [
+      for i in range(var.containers_per_host) : {
+        instance = "c${format("%02d", var.containers_per_host * index + i + 1)}"
+        target   = cluster_member_name
+      }
+    ]
+  ])
+  vms = flatten([
+    for index, cluster_member_name in local.cluster_member_names : [
+      for i in range(var.vms_per_host) : {
+        instance = "vm${format("%02d", var.vms_per_host * index + i + 1)}"
+        target   = cluster_member_name
+      }
+    ]
+  ])
+}
+
+# Outputs
+output "instances" {
+  value = {
+    "ctns" = local.containers
+    "vms"  = local.vms
+  }
+}

--- a/test/e2e/run
+++ b/test/e2e/run
@@ -1,0 +1,89 @@
+#!/bin/bash
+set -eu
+set -o pipefail
+
+REMOTE="${REMOTE:-${1:-""}}"
+
+remoteAccessible() {
+    lxc info "${REMOTE}:" >/dev/null 2>&1
+}
+
+init() {
+    if ! command -v lxc >/dev/null; then
+        echo "Missing command: lxc" >&2
+        echo "Please install the LXD snap: snap install lxd" >&2
+        exit 1
+    fi
+
+    if [ -z "${REMOTE}" ]; then
+        echo "Please set the REMOTE environment variable to the name of the remote LXD server" >&2
+        exit 1
+    fi
+
+    if ! remoteAccessible; then
+        echo "The ${REMOTE}: remote is not usable." >&2
+        echo "Please see https://documentation.ubuntu.com/lxd/en/latest/howto/server_expose/#authenticate-with-the-lxd-server" >&2
+        exit 1
+    fi
+
+    if ! command -v terraform >/dev/null; then
+        echo "Missing command: terraform" >&2
+        exit 1
+    fi
+}
+
+retry() {
+    local cmd="$*"
+    local i
+    for i in 1 2 3; do
+        ${cmd} && return 0
+        retry="$((i*5))"
+        echo "Retrying in ${retry} seconds... (${i}/3)"
+        sleep "${retry}"
+    done
+    return 1
+}
+
+apply() {
+    echo "terraform apply"
+
+    # retry to work around the following issues with cluster image downloads:
+    # a) multiple cluster members trying to figure which image fingerprint to download:
+    # Failed creating instance from image: Error inserting volume "876fac034595ac77ccfd4dc023bd2667fe5d4b4226dfc38cd8109aa215783998" for project "default" in pool "remote" of type "images" into database "UNIQUE constraint failed: index
+    # 'storage_volumes_unique_storage_pool_id_node_id_project_id_name_type'"
+
+    # b) missing parent image (failed turning the tarball/squashfs into an image volume+snapshot):
+    # Failed creating instance from image: Failed to run: rbd --id admin --cluster ceph --image-feature layering --image-feature striping --image-feature exclusive-lock --image-feature object-map --image-feature fast-diff --image-feature deep-flatten clone
+    # lxd_remote/image_876fac034595ac77ccfd4dc023bd2667fe5d4b4226dfc38cd8109aa215783998_ext4@readonly lxd_remote/container_e2e-testing_c01: exit status 2 (2025-04-01T14:38:07.671+0000 7f8284b55640 -1 librbd::image::RefreshRequest: failed to locate snapshot:
+    # readonly
+    # 2025-04-01T14:38:07.671+0000 7f8284b55640 -1 librbd::image::OpenRequest: failed to find snapshot readonly
+    # 2025-04-01T14:38:07.671+0000 7f826bfff640 -1 librbd::image::CloneRequest: 0x55b8434ed7c0 handle_open_parent: failed to open parent image: (2) No such file or directory
+    # rbd: clone error: (2) No such file or directory)
+    retry terraform apply -auto-approve -var "remote=${REMOTE}"
+}
+
+destroy() {
+    local confirm
+    read -rp "Are you sure you want to destroy the environment? [y/N] " confirm
+    if [ "${confirm:-N}" != "y" ]; then
+        echo "Not destroying the environment"
+        return
+    fi
+
+    terraform destroy -auto-approve -var "remote=${REMOTE}"
+}
+
+setup() {
+    echo "Setting up e2e environment on ${REMOTE}"
+    apply
+
+    echo "Setup done"
+}
+
+init
+setup
+
+# TODO: Add tests here
+
+destroy
+echo "Done"

--- a/test/e2e/variables.tf
+++ b/test/e2e/variables.tf
@@ -1,0 +1,28 @@
+variable "remote" {
+  description = "LXD remote to use"
+  type        = string
+  validation {
+    condition     = !strcontains(var.remote, ":")
+    error_message = "Remote name must not contain `:` character"
+  }
+}
+
+variable "containers_per_host" {
+  description = "Number of containers per host"
+  type        = number
+  default     = 9
+  validation {
+    condition     = var.containers_per_host >= 0
+    error_message = "Number of containers per host must be greater or equal to 0"
+  }
+}
+
+variable "vms_per_host" {
+  description = "Number of VMs per host"
+  type        = number
+  default     = 3
+  validation {
+    condition     = var.vms_per_host >= 0
+    error_message = "Number of VMs per host must be greater or equal to 0"
+  }
+}

--- a/test/e2e/versions.tf
+++ b/test/e2e/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    lxd = {
+      source  = "terraform-lxd/lxd"
+      version = ">= 2.5.0"
+    }
+  }
+}


### PR DESCRIPTION
This PR lays the foundation to deploy instances on a MicroCloud, run tests with those and finally tear them down.

The tests themselves will be added in subsequent PRs. The initial plan is to add connectivity and live migration tests.