### PR TITLE
Avoid HTTP redirects for a few doc links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 The MicroCloud team welcomes contributions through pull requests, issue reports, and discussions.
 
 - Contribute to the code or documentation, report bugs, or request features in the [GitHub repository](https://github.com/canonical/microcloud).
-- Ask questions or join discussions in the [MicroCloud forum](https://discourse.ubuntu.com/c/lxd/microcloud).
+- Ask questions or join discussions in the [MicroCloud forum](https://discourse.ubuntu.com/c/lxd/microcloud/145).
 
 Review the following guidelines before contributing to the project.
 

--- a/doc/how-to/contribute.md
+++ b/doc/how-to/contribute.md
@@ -30,7 +30,7 @@ Clarify concepts or common questions based on your own experience.
 Report documentation issues by opening an issue in [GitHub](https://github.com/canonical/microcloud/issues).
 : - We will evaluate and update the documentation as needed.
 
-Ask questions or suggest improvements in the [MicroCloud forum](https://discourse.ubuntu.com/c/lxd/microcloud).
+Ask questions or suggest improvements in the [MicroCloud forum](https://discourse.ubuntu.com/c/lxd/microcloud/145).
 : - We monitor discussions and update the documentation when necessary.
 
 If you contribute images to `doc/images`:

--- a/doc/how-to/snaps.md
+++ b/doc/how-to/snaps.md
@@ -67,19 +67,19 @@ To avoid this problem, use the `--cohort="+"` flag when refreshing your snaps:
 
 This flag ensures that all machines in a cluster see the same snap revision and are therefore not affected by a progressive rollout.
 
-## Use a Snap Store Proxy
+## Use an Enterprise Store Proxy
 
-If you manage a large MicroCloud deployment and you need absolute control over when updates are applied, consider installing a Snap Store Proxy.
+If you manage a large MicroCloud deployment and you need absolute control over when updates are applied, consider installing an Enterprise Store Proxy.
 
-The Snap Store Proxy is a separate application that sits between the snap client command on your machines and the snap store.
-You can configure the Snap Store Proxy to make only specific snap revisions available for installation.
+The Enterprise Store Proxy is a separate application that sits between the snap client command on your machines and the snap store.
+You can configure the Enterprise Store Proxy to make only specific snap revisions available for installation.
 
-See the [Snap Store Proxy documentation](https://docs.ubuntu.com/snap-store-proxy/) for information about how to install and register the Snap Store Proxy.
+See the [Enterprise Store Proxy documentation](https://documentation.ubuntu.com/enterprise-store/) for information about how to install and register the Enterprise Store Proxy.
 
 After setting it up, configure the snap clients on all cluster members to use the proxy.
-See [Configuring snap devices](https://docs.ubuntu.com/snap-store-proxy/en/devices) for instructions.
+See [Configuring devices](https://documentation.ubuntu.com/enterprise-store/en/devices/) for instructions.
 
-You can then configure the Snap Store Proxy to override the revisions for the snaps that are needed for MicroCloud:
+You can then configure the Enterprise Store Proxy to override the revisions for the snaps that are needed for MicroCloud:
 
     sudo snap-proxy override lxd <channel>=<revision>
     sudo snap-proxy override microceph <channel>=<revision>

--- a/doc/how-to/support.md
+++ b/doc/how-to/support.md
@@ -24,7 +24,7 @@ See the {ref}`howto-update-upgrade-upgrade` guide for more information.
 The following channels are available for you to interact with the MicroCloud community:
 
 - You can file bug reports and feature requests as [GitHub issues](https://github.com/canonical/microcloud/issues/new).
-- To ask questions, go to the MicroCloud section of our [discussion forum](https://discourse.ubuntu.com/c/lxd/microcloud/).
+- To ask questions, go to the MicroCloud section of our [discussion forum](https://discourse.ubuntu.com/c/lxd/microcloud/145).
 
 ## Commercial support
 
@@ -37,4 +37,4 @@ See the full [Ubuntu Pro service description](https://ubuntu.com/legal/ubuntu-pr
 
 See the [MicroCloud documentation](https://canonical-microcloud.readthedocs-hosted.com/) for official product documentation.
 
-You can find additional resources on the [website](https://canonical.com/microcloud) and in the [discussion forum](https://discourse.ubuntu.com/c/lxd/microcloud/).
+You can find additional resources on the [website](https://canonical.com/microcloud) and in the [discussion forum](https://discourse.ubuntu.com/c/lxd/microcloud/145).

--- a/doc/index.md
+++ b/doc/index.md
@@ -75,7 +75,7 @@ MicroCloud is a member of the Ubuntu family. It’s an open source project that 
 
 - [MicroCloud snap](https://snapcraft.io/microcloud)
 - [Contribute](https://github.com/canonical/microcloud)
-- [Get support](https://discourse.ubuntu.com/c/lxd/microcloud/)
+- [Get support](https://discourse.ubuntu.com/c/lxd/microcloud/145)
 - [Thinking about using MicroCloud for your next project? Get in touch!](https://canonical.com/microcloud)
 
 


### PR DESCRIPTION
Also, the Snap Store Proxy was renamed to Enterprise Store Proxy.