### PR TITLE
doc: add 'integrated' project tag to integrated docs sets

### DIFF
--- a/doc/.sphinx/_integration/add_config.py
+++ b/doc/.sphinx/_integration/add_config.py
@@ -18,3 +18,6 @@ elif project == "MicroCeph":
     html_baseurl = "https://canonical-microceph.readthedocs-hosted.com/en/latest/"
 elif project == "MicroOVN":
     html_baseurl = "https://canonical-microovn.readthedocs-hosted.com/en/latest/"
+
+# Include integrated tag
+custom_tags.append('integrated')


### PR DESCRIPTION
This enables the ability for the integrated docs sets (LXD, etc) to use the `only` directive to show certain content only when a part of the MicroCloud integration. This is intended for use in showing `Note`-style annotations that indicate when a page in the integrated docs set is not relevant for MicroCloud users, such as [LXD's how-to guide on installation](https://github.com/canonical/lxd/pull/15266/files#diff-1d71fbf6452c615eacc9abfd4951cbf726383a79ac5796fb8c21be4b79d49ca2). Also see: https://github.com/canonical/lxd/pull/15266