### PR TITLE
doc: update linkcheck_timeout from 30 to 45 seconds

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -165,6 +165,11 @@ linkcheck_rate_limit_timeout = 600
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-linkcheck_retries
 linkcheck_retries = 3
 
+# Increase the duration, in seconds, that the linkcheck builder will wait for a response after each hyperlink request.
+# Default when unset is 30
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-linkcheck_timeout
+linkcheck_timeout = 45
+
 ############################################################
 ### Additions to default configuration
 ############################################################


### PR DESCRIPTION
To avoid read timeout issues (different from rate limit timeout), set `linkcheck_timeout` to `45` seconds. Default when unset is `30`. 