### PR TITLE
Service: Fix panic for invalid types

### DIFF
--- a/service/service_handler.go
+++ b/service/service_handler.go
@@ -59,6 +59,8 @@ func NewHandler(name string, addr string, stateDir string, services ...types.Ser
 			service, err = NewOVNService(name, addr, stateDir)
 		case types.LXD:
 			service, err = NewLXDService(name, addr, stateDir)
+		default:
+			return nil, api.StatusErrorf(http.StatusNotFound, "Invalid service type: %q", serviceType)
 		}
 
 		if err != nil {


### PR DESCRIPTION
When requesting tokens for an invalid service name, MicroCloud panics as the API handler doesn't perform validation of the URL parameter

`POST /1.0/services/foo/tokens` -> panic

To fix this the generation of service handlers now errors out when trying to create a service handler for an invalid service type.