### PR TITLE
doc: Add documentation note for when LXD 5.0 is already installed

### DIFF
--- a/doc/how-to/install.md
+++ b/doc/how-to/install.md
@@ -101,5 +101,10 @@ If you don't want to use MicroCloud's full functionality, you can install only s
 However, this is not recommended.
 ```
 
+```{note}
+It's possible that a required snap is already installed on your machine. For example, it might be a version of Ubuntu that comes with LXD pre-installed.
+In this case, run `sudo snap refresh <snap> --channel=<track>/stable --cohort="+"` to refresh (update) the installed snap.
+```
+
 After installing the snaps make sure to hold any automatic updates to keep the used snap versions across MicroCloud in sync.
 See {ref}`howto-snap-hold-updates` for more information.


### PR DESCRIPTION
Fixes the outstanding doc error in https://github.com/canonical/microcloud/pull/437 and closes the PR.

Fixes https://github.com/canonical/microcloud/issues/410
Closes https://github.com/canonical/microcloud/pull/437