### PR TITLE
Service: Allow MicroCloud to be used with LXD 5.21 or newer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -166,6 +166,9 @@ jobs:
           - "5.21/edge"
           - "6/edge"
         microcloud: ["latest/edge"]
+        exclude:
+          # Exclude LXD 6 for regular development pipelines to speed up the result cycle.
+          - lxd: ${{ github.event_name != 'schedule' && '6/edge' }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -161,7 +161,10 @@ jobs:
         os: ["24.04"]
         microceph: ["latest/edge"]
         microovn: ["latest/edge"]
-        lxd: ["5.21/edge"]
+        lxd:
+          # Both LXD 5.21 and 6 are supported.
+          - "5.21/edge"
+          - "6/edge"
         microcloud: ["latest/edge"]
     steps:
       - name: Checkout

--- a/service/version.go
+++ b/service/version.go
@@ -26,7 +26,11 @@ func validateVersion(serviceType types.ServiceType, daemonVersion string) error 
 	case types.LXD:
 		lxdVersion := semver.Canonical("v" + daemonVersion)
 		expectedVersion := semver.Canonical("v" + lxdMinVersion)
-		if semver.Compare(semver.MajorMinor(lxdVersion), semver.MajorMinor(expectedVersion)) != 0 {
+		// semver.Compare returns
+		// * 0 in case lxdVersion == expectedVersion
+		// * 1 in case lxdVersion > expectedVersion
+		// Only if the lxdVersion is lower than the expected version MicroCloud should error out.
+		if semver.Compare(semver.MajorMinor(lxdVersion), semver.MajorMinor(expectedVersion)) == -1 {
 			return fmt.Errorf("%s version %q is not supported", serviceType, daemonVersion)
 		}
 

--- a/service/version.go
+++ b/service/version.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/mod/semver"
 
 	"github.com/canonical/microcloud/microcloud/api/types"
+	"github.com/canonical/microcloud/microcloud/cmd/tui"
 )
 
 const (
@@ -32,6 +33,11 @@ func validateVersion(serviceType types.ServiceType, daemonVersion string) error 
 		// Only if the lxdVersion is lower than the expected version MicroCloud should error out.
 		if semver.Compare(semver.MajorMinor(lxdVersion), semver.MajorMinor(expectedVersion)) == -1 {
 			return fmt.Errorf("%s version %q is not supported", serviceType, daemonVersion)
+		}
+
+		// Print a warning in case a non-LTS version of LXD is used.
+		if semver.Compare(semver.MajorMinor(lxdVersion), semver.MajorMinor(expectedVersion)) == 1 {
+			fmt.Printf("%s Discovered non-LTS version %q of LXD\n", tui.WarningSymbol(), daemonVersion)
 		}
 
 	case types.MicroOVN:

--- a/service/version_test.go
+++ b/service/version_test.go
@@ -75,10 +75,10 @@ func (s *versionSuite) Test_validateVersions() {
 			expectErr: false,
 		},
 		{
-			desc:      "Unsupported LXD with different minor version",
+			desc:      "Supported LXD with higher minor version",
 			version:   strings.Split(lxdMinVersion, ".")[0] + ".999",
 			service:   types.LXD,
-			expectErr: true,
+			expectErr: false,
 		},
 		{
 			desc:      "Unsupported MicroCeph with larger minor version",
@@ -93,14 +93,20 @@ func (s *versionSuite) Test_validateVersions() {
 			expectErr: true,
 		},
 		{
-			desc:      "Unsupported LXD with larger major version",
+			desc:      "Supported LXD with larger major version",
 			version:   "999.0",
 			service:   types.LXD,
-			expectErr: true,
+			expectErr: false,
 		},
 		{
 			desc:      "Unsupported LXD with smaller major version",
 			version:   "1.0",
+			service:   types.LXD,
+			expectErr: true,
+		},
+		{
+			desc:      "Unsupported LXD with smaller minor version",
+			version:   "5.20",
 			service:   types.LXD,
 			expectErr: true,
 		},


### PR DESCRIPTION
Fixes https://github.com/canonical/microcloud/issues/670

Furthermore this extends the test matrix to also include LXD version 6.