### PR TITLE
doc: Fix link to Ceph disk encryption setup

### DIFF
--- a/doc/how-to/initialize.md
+++ b/doc/how-to/initialize.md
@@ -7,7 +7,7 @@ You run the initialization on one of the machines, and it configures the require
 ## Pre-initialization requirements
 
 - Complete the steps in {ref}`howto-install` before initialization.
-- If you intend to use full disk encryption (FDE) on any cluster member, that member must meet the prerequisites listed on this page: {doc}`microceph:explanation/full-disk-encryption`.
+- If you intend to use full disk encryption (FDE) on any cluster member, that member must meet the prerequisites listed on this page: {doc}`microceph:explanation/security/full-disk-encryption`.
   - Follow only the instructions in the Prerequisites section on that page. Skip its Usage section; the MicroCloud initialization process handles the disk encryption.
 
 (howto-initialize-interactive)=
@@ -91,7 +91,7 @@ Complete the following steps to initialize MicroCloud:
       Encrypting a disk will store the encryption keys in the Ceph key ring inside the Ceph configuration folder.
 
       ```{warning}
-      Cluster members with disks to be encrypted require a kernel with `dm-crypt` enabled. The snap `dm-crypt` plug must also be connected. See the Prerequisites section of this page for more information: {doc}`microceph:explanation/full-disk-encryption`.
+      Cluster members with disks to be encrypted require a kernel with `dm-crypt` enabled. The snap `dm-crypt` plug must also be connected. See the Prerequisites section of this page for more information: {doc}`microceph:explanation/security/full-disk-encryption`.
 
       If you have not enabled and connected `dm-crypt` on any cluster member that you want to encrypt, do so now before you continue.
 

--- a/doc/reference/requirements.md
+++ b/doc/reference/requirements.md
@@ -67,7 +67,7 @@ For production environments, we recommend at least 3 NVMe disks per cluster memb
 
 If you intend to use full disk encryption on any cluster member, the `dm-crypt` kernel module must be available, and the snap `dm-crypt` plug must be connected to MicroCeph. The `dm-crypt` module is available by default in Ubuntu 24.04 and higher.
 
-For further information, see the Prerequisites section of this page: {doc}`microceph:explanation/full-disk-encryption`. Note that the command shown on that page to connect the snap `dm-crypt` plug can only be performed once MicroCeph is installed. The MicroCloud installation steps include installing MicroCeph; thus, {ref}`install MicroCloud first<howto-install>`, then connect the plug.
+For further information, see the Prerequisites section of this page: {doc}`microceph:explanation/security/full-disk-encryption`. Note that the command shown on that page to connect the snap `dm-crypt` plug can only be performed once MicroCeph is installed. The MicroCloud installation steps include installing MicroCeph; thus, {ref}`install MicroCloud first<howto-install>`, then connect the plug.
 
 (reference-requirements-network)=
 ## Networking requirements


### PR DESCRIPTION
The page was moved upstream in https://github.com/canonical/microceph/pull/542.