### PR TITLE
doc: update config for move to documentation.ubuntu.com

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -50,7 +50,7 @@ copyright = '%s, %s' % (datetime.date.today().year, author)
 # don't know yet)
 # NOTE: If no ogp_* variable is defined (e.g. if you remove this section) the
 # sphinxext.opengraph extension will be disabled.
-ogp_site_url = 'https://canonical-microcloud.readthedocs-hosted.com/en/latest/'
+ogp_site_url = 'https://documentation.ubuntu.com/microcloud/latest'
 # The documentation website name (usually the same as the product name)
 ogp_site_name = project
 # The URL of an image or logo that is used in the preview
@@ -122,7 +122,7 @@ html_context = {
 
 # If your project is on documentation.ubuntu.com, specify the project
 # slug (for example, "lxd") here.
-slug = ""
+slug = "microcloud"
 
 ############################################################
 ### Redirects


### PR DESCRIPTION
The move to documentation.ubuntu.com/microcloud is approved and is done through the ReadTheDocs dashboard (by adding it as a subproject of the Ubuntu documentation library project). This PR updates the Sphinx custom_conf.py to reflect the change in URL and needs to be done along with the move. Otherwise, static resources won't fetch correctly.