### PR TITLE
test: Collect the logs from all services on failure

### DIFF
--- a/test/main.sh
+++ b/test/main.sh
@@ -95,8 +95,12 @@ cleanup() {
     fi
     echo
 
-    echo -n "${name} MicroCloud daemon log:"
-    lxc exec "${name}" -- snap logs microcloud -n 200
+    for service in microcloud microceph microovn lxd; do
+      echo "${name} ${service} daemon log:"
+      lxc exec "${name}" -- snap logs "${service}" -n 200
+      # Print a newline to separate the log from the next one.
+      echo ""
+    done
   done
 
   if [ ${enable_xtrace} = 1 ]; then


### PR DESCRIPTION
Whilst trying to reason about the recent test failures in the e2e suite, there was [this error](https://github.com/canonical/microcloud/actions/runs/14612411462/job/41100534644?pr=752) which made me wonder if LXD/MicroOVN isn't yet fully ready which might be indicated by a log entry in the LXD/MicroOVN log. 

This PR ensures that on failure the logs from all services (not only MicroCloud) are collected for all the `micro*` nodes.