### PR TITLE
doc: fix intersphinx links

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -10,7 +10,7 @@
 current_dir := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 
 # Set the path prefix and MicroCloud component versions corresponding to each MicroCloud docs version
-PATH_PREFIX      = /en/latest/
+PATH_PREFIX      = /microcloud/latest/
 LXDVERSION       = origin/main
 MICROCEPHVERSION = origin/main
 MICROOVNVERSION  = origin/main


### PR DESCRIPTION
With `PATH_PREFIX` in `docs/Makefile` set to `/en/latest`, since the site move/redirect to `documentation.ubuntu.com/microcloud`, the intersphinx links are replacing `/microcloud` in the URL with `/en/latest`. Example: the link to the LXD integrated docs from [this page](https://documentation.ubuntu.com/microcloud/latest/microcloud/#about-the-integrated-documentation-sets) is trying to go to `https://documentation.ubuntu.com/en/latest/lxd` where it should go to `https://documentation.ubuntu.com/microcloud/latest/lxd`. 

Changed `PATH_PREFIX` in docs/Makefile to `/microcloud/latest` should fix this. Note: RTD preview build does not work for intersphinx links so cannot test through it. Also will need to update `PATH_PREFIX` in `stable` & `v2-edge` once confirmed this works for `latest`.