### PR TITLE
doc: fix intersphinx links (v2-edge)

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -10,7 +10,7 @@
 current_dir := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 
 # Set the path prefix and MicroCloud component versions corresponding to each MicroCloud docs version
-PATH_PREFIX      = /en/v2-edge/
+PATH_PREFIX      = /microcloud/v2-edge/
 LXDVERSION       = origin/stable-5.21
 MICROCEPHVERSION = 1200ba77f2320be2acec45939f4b96a8ac4f0722 # origin/main right after squid LTS.
 MICROOVNVERSION  = origin/branch-24.03

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -243,8 +243,8 @@ custom_tags = []
 
 if ('SINGLE_BUILD' in os.environ and os.environ['SINGLE_BUILD'] == 'True'):
     intersphinx_mapping = {
-        'lxd': ('https://documentation.ubuntu.com/lxd/en/latest/', None),
-        'microceph': ('https://canonical-microceph.readthedocs-hosted.com/en/latest/', None),
+        'lxd': ('https://documentation.ubuntu.com/lxd/stable-5.21/', None),
+        'microceph': ('https://canonical-microceph.readthedocs-hosted.com/en/squid-stable/', None),
         'microovn': ('https://canonical-microovn.readthedocs-hosted.com/en/latest/', None),
         'ceph': ('https://docs.ceph.com/en/latest/', None),
     }


### PR DESCRIPTION
Fix intersphinx links to point to /microcloud/v2-edge instead of /en/v2-edge per recent changes to site.
Backport of https://github.com/canonical/microcloud/pull/764
