### PR TITLE
golangci-lint: enable perfsprint, prealloc and testifylint linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,6 +3,9 @@ linters:
   enable:
     - godot
     - misspell
+    - perfsprint
+    - prealloc
+    - testifylint
     - whitespace
   exclusions:
     generated: lax
@@ -15,6 +18,11 @@ linters:
       - linters:
           - staticcheck
         text: "ST1005:" # ST1005: error strings should not be capitalized
+  settings:
+    testifylint:
+      disable:
+        - float-compare
+        - require-error
 formatters:
   enable:
     - gci

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ check-system:
 .PHONY: check-static
 check-static:
 ifeq ($(shell command -v golangci-lint 2> /dev/null),)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$HOME/go/bin v2.0.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$HOME/go/bin v2.1.6
 endif
 ifeq ($(shell command -v revive 2> /dev/null),)
 	go install github.com/mgechev/revive@latest

--- a/api/services_auth.go
+++ b/api/services_auth.go
@@ -45,7 +45,7 @@ func authHandlerMTLS(sh *service.Handler, f endpointHandler) endpointHandler {
 			}
 		}
 
-		return response.Forbidden(fmt.Errorf("Failed to authenticate using mTLS"))
+		return response.Forbidden(errors.New("Failed to authenticate using mTLS"))
 	}
 }
 

--- a/api/services_proxy.go
+++ b/api/services_proxy.go
@@ -119,7 +119,7 @@ func lxdHandler(s state.State, r *http.Request) response.Response {
 // microHandler forwards a request made to /1.0/services/<microcluster-service>/<rest> to /1.0/<rest> on the service unix socket.
 func microHandler(service string, stateDir string) func(state.State, *http.Request) response.Response {
 	return func(s state.State, r *http.Request) response.Response {
-		_, path, ok := strings.Cut(r.URL.Path, fmt.Sprintf("/1.0/services/%s", service))
+		_, path, ok := strings.Cut(r.URL.Path, "/1.0/services/"+service)
 		if !ok {
 			return response.SmartError(fmt.Errorf("Invalid path %q", r.URL.Path))
 		}

--- a/api/session.go
+++ b/api/session.go
@@ -274,7 +274,7 @@ func handleJoiningSession(state state.State, sh *service.Handler, gw *cloudClien
 
 	// No address selected, try to lookup system.
 	if session.InitiatorAddress == "" {
-		lookupCtx, cancel := context.WithTimeoutCause(gw.Context(), session.LookupTimeout, fmt.Errorf("Lookup timeout exceeded"))
+		lookupCtx, cancel := context.WithTimeoutCause(gw.Context(), session.LookupTimeout, errors.New("Lookup timeout exceeded"))
 		defer cancel()
 
 		discovery := multicast.NewDiscovery(session.Interface, service.CloudMulticastPort)
@@ -371,7 +371,7 @@ func handleJoiningSession(state state.State, sh *service.Handler, gw *cloudClien
 
 	certBlock, _ := pem.Decode([]byte(confirmedIntent.Certificate))
 	if certBlock == nil {
-		return fmt.Errorf("Invalid certificate file")
+		return errors.New("Invalid certificate file")
 	}
 
 	remoteCert, err := x509.ParseCertificate(certBlock.Bytes)

--- a/api/session_join.go
+++ b/api/session_join.go
@@ -81,7 +81,7 @@ func sessionJoinPost(sh *service.Handler) func(state state.State, r *http.Reques
 			case session.IntentCh() <- req:
 				return nil
 			case <-ctx.Done():
-				return fmt.Errorf("Timeout waiting for an active consumer of the join intent")
+				return errors.New("Timeout waiting for an active consumer of the join intent")
 			}
 		})
 

--- a/client/client.go
+++ b/client/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -103,7 +104,7 @@ func JoinIntent(ctx context.Context, c *client.Client, data types.SessionJoinPos
 	}
 
 	if len(resp.TLS.PeerCertificates) == 0 {
-		return nil, fmt.Errorf("Peer's certificate is missing")
+		return nil, errors.New("Peer's certificate is missing")
 	}
 
 	return resp.TLS.PeerCertificates[0], nil

--- a/client/proxy.go
+++ b/client/proxy.go
@@ -62,7 +62,7 @@ func AuthProxy(hmac string, serviceType types.ServiceType) func(r *http.Request)
 
 		// MicroCloud itself doesn't need to use the proxy.
 		if serviceType != types.MicroCloud {
-			path := fmt.Sprintf("/1.0/services/%s", strings.ToLower(string(serviceType)))
+			path := "/1.0/services/" + strings.ToLower(string(serviceType))
 			if !strings.HasPrefix(r.URL.Path, path) {
 				r.URL.Path = path + r.URL.Path
 			}

--- a/client/proxy.go
+++ b/client/proxy.go
@@ -3,7 +3,7 @@ package client
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
+	"errors"
 	"net/http"
 	"net/url"
 	"strings"
@@ -30,7 +30,7 @@ type AuthConfig struct {
 func UseAuthProxy(c *client.Client, serviceType types.ServiceType, conf AuthConfig) (*client.Client, error) {
 	tp, ok := c.Transport.(*http.Transport)
 	if !ok {
-		return nil, fmt.Errorf("Invalid client transport type")
+		return nil, errors.New("Invalid client transport type")
 	}
 
 	// If the client is a unix client, it may not have any TLS config.
@@ -40,7 +40,7 @@ func UseAuthProxy(c *client.Client, serviceType types.ServiceType, conf AuthConf
 
 	// Error out if no HMAC is provided and mTLS verification is disabled.
 	if conf.HMAC == "" && conf.InsecureSkipVerify {
-		return nil, fmt.Errorf("Cannot disable mTLS verification without providing an HMAC")
+		return nil, errors.New("Cannot disable mTLS verification without providing an HMAC")
 	}
 
 	tp.TLSClientConfig.InsecureSkipVerify = conf.InsecureSkipVerify

--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -182,7 +182,7 @@ func (c *initConfig) askMissingServices(services []types.ServiceType, stateDirs 
 			}
 
 			if !confirm {
-				return nil, fmt.Errorf("User aborted")
+				return nil, errors.New("User aborted")
 			}
 
 			return services, nil
@@ -203,7 +203,7 @@ func (c *initConfig) askAddress(filterAddress string) error {
 	listenAddr := c.address
 	if listenAddr == "" {
 		if len(info) == 0 {
-			return fmt.Errorf("Found no valid network interfaces")
+			return errors.New("Found no valid network interfaces")
 		}
 
 		filterIp := net.ParseIP(filterAddress)
@@ -231,7 +231,7 @@ func (c *initConfig) askAddress(filterAddress string) error {
 				}
 
 				if len(answers) != 1 {
-					return fmt.Errorf("You must select exactly one address")
+					return errors.New("You must select exactly one address")
 				}
 
 				listenAddr = answers[0]["ADDRESS"]
@@ -376,7 +376,7 @@ func (c *initConfig) askLocalPool(sh *service.Handler) error {
 		}
 
 		if len(answers) == 0 {
-			return fmt.Errorf("No disks selected")
+			return errors.New("No disks selected")
 		}
 
 		for _, entry := range answers {
@@ -392,7 +392,7 @@ func (c *initConfig) askLocalPool(sh *service.Handler) error {
 		}
 
 		if len(selected) != len(askSystems) {
-			return fmt.Errorf("Failed to add local storage pool: Some peers don't have an available disk")
+			return errors.New("Failed to add local storage pool: Some peers don't have an available disk")
 		}
 
 		if wipeable {
@@ -548,7 +548,7 @@ func (c *initConfig) validateCephInterfacesForSubnet(lxdService *service.LXDServ
 func getTargetCephNetworks(sh *service.Handler, s *InitSystem) (publicCephNetwork *net.IPNet, internalCephNetwork *net.IPNet, err error) {
 	microCephService := sh.Services[types.MicroCeph].(*service.CephService)
 	if microCephService == nil {
-		return nil, nil, fmt.Errorf("Failed to get MicroCeph service")
+		return nil, nil, errors.New("Failed to get MicroCeph service")
 	}
 
 	var cephAddr string
@@ -614,7 +614,7 @@ func (c *initConfig) askRemotePool(sh *service.Handler) error {
 		}
 
 		if !hasPool && hasFSPool {
-			return fmt.Errorf("Unsupported configuration, remote-fs pool already exists")
+			return errors.New("Unsupported configuration, remote-fs pool already exists")
 		}
 
 		if hasPool {
@@ -694,7 +694,7 @@ func (c *initConfig) askRemotePool(sh *service.Handler) error {
 			}
 
 			if len(data) == 0 {
-				return fmt.Errorf("Invalid disk configuration. Found no available disks")
+				return errors.New("Invalid disk configuration. Found no available disks")
 			}
 
 			sort.Sort(cli.SortColumnsNaturally(data))
@@ -745,7 +745,7 @@ func (c *initConfig) askRemotePool(sh *service.Handler) error {
 			selectedDisks = targetDisks
 
 			if len(targetDisks) == 0 {
-				return fmt.Errorf("No disks were selected")
+				return errors.New("No disks were selected")
 			}
 
 			insufficientDisks = !useJoinConfigRemote && len(targetDisks) < RecommendedOSDHosts
@@ -942,7 +942,7 @@ func (c *initConfig) askOVNNetwork(sh *service.Handler) error {
 			return nil
 		}
 
-		return fmt.Errorf("User aborted")
+		return errors.New("User aborted")
 	}
 
 	// Ask the user if they want OVN.
@@ -988,7 +988,7 @@ func (c *initConfig) askOVNNetwork(sh *service.Handler) error {
 		}
 
 		if len(selected) != len(askSystems) {
-			return fmt.Errorf("Failed to add OVN uplink network: Some peers don't have a selected interface")
+			return errors.New("Failed to add OVN uplink network: Some peers don't have a selected interface")
 		}
 
 		selectedIfaces = selected
@@ -1032,11 +1032,11 @@ func (c *initConfig) askOVNNetwork(sh *service.Handler) error {
 				}
 
 				if addr.To4() == nil && ip == "IPv4" {
-					return fmt.Errorf("Not a valid IPv4")
+					return errors.New("Not a valid IPv4")
 				}
 
 				if addr.To4() != nil && ip == "IPv6" {
-					return fmt.Errorf("Not a valid IPv6")
+					return errors.New("Not a valid IPv6")
 				}
 
 				return nil
@@ -1280,7 +1280,7 @@ func (c *initConfig) askNetwork(sh *service.Handler) error {
 			}
 
 			if !proceedWithNoOverlayNetworking {
-				return fmt.Errorf("Cluster bootstrapping aborted due to lack of usable networking")
+				return errors.New("Cluster bootstrapping aborted due to lack of usable networking")
 			}
 		}
 
@@ -1474,7 +1474,7 @@ func (c *initConfig) askClustered(s *service.Handler, expectedServices map[types
 
 func (c *initConfig) shortFingerprint(fingerprint string) (string, error) {
 	if len(fingerprint) < 12 {
-		return "", fmt.Errorf("Fingerprint is not long enough")
+		return "", errors.New("Fingerprint is not long enough")
 	}
 
 	return fingerprint[0:12], nil
@@ -1489,7 +1489,7 @@ func (c *initConfig) askPassphrase(s *service.Handler) (string, error) {
 		})
 
 		if len(passwordClean) != 4 {
-			return "", fmt.Errorf("Passphrase has to contain exactly four elements")
+			return "", errors.New("Passphrase has to contain exactly four elements")
 		}
 
 		return strings.Join(passwordClean, " "), nil
@@ -1497,7 +1497,7 @@ func (c *initConfig) askPassphrase(s *service.Handler) (string, error) {
 
 	validator := func(password string) error {
 		if password == "" {
-			return fmt.Errorf("Passphrase cannot be empty")
+			return errors.New("Passphrase cannot be empty")
 		}
 
 		_, err := format(password)
@@ -1605,7 +1605,7 @@ func (c *initConfig) askJoinIntents(gw *cloudClient.WebsocketGateway, expectedSy
 			}
 
 			if len(answers) == 0 {
-				return fmt.Errorf("No system selected")
+				return errors.New("No system selected")
 			}
 
 			return nil

--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -1671,7 +1671,7 @@ func (c *initConfig) askJoinConfirmation(gw *cloudClient.WebsocketGateway, servi
 
 	fmt.Println(tui.SuccessColor("Successfully joined the MicroCloud cluster and closing the session.", true))
 
-	var servicesStr []string
+	servicesStr := make([]string, 0, len(services))
 	for serviceType := range services {
 		if serviceType == types.MicroCloud {
 			continue

--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -64,14 +64,14 @@ func checkInitialized(stateDir string, expectInitialized bool, preseed bool) err
 		if expectInitialized && !initialized {
 			errMsg := fmt.Sprintf("%s is not initialized", s.Type())
 			if s.Type() == types.MicroCloud && !preseed {
-				errMsg = fmt.Sprintf("%s. Run 'microcloud init' first", errMsg)
+				errMsg = errMsg + ". Run 'microcloud init' first"
 			}
 
 			return fmt.Errorf("%s", errMsg)
 		} else if !expectInitialized && initialized {
 			errMsg := fmt.Sprintf("%s is already initialized", s.Type())
 			if s.Type() == types.MicroCloud && !preseed {
-				errMsg = fmt.Sprintf("%s. Use 'microcloud add' instead", errMsg)
+				errMsg = errMsg + ". Use 'microcloud add' instead"
 			}
 
 			return fmt.Errorf("%s", errMsg)
@@ -174,7 +174,7 @@ func (c *initConfig) askMissingServices(services []types.ServiceType, stateDirs 
 
 		// Ignore missing services in case of preseed.
 		if !c.autoSetup {
-			warning := fmt.Sprintf("%s not found", serviceStr)
+			warning := serviceStr + " not found"
 			question := "Continue anyway?"
 			confirm, err := c.asker.AskBoolWarn(warning, question, true)
 			if err != nil {
@@ -283,11 +283,11 @@ func (c *initConfig) askDisks(sh *service.Handler) error {
 }
 
 func parseDiskPath(disk api.ResourcesStorageDisk) string {
-	devicePath := fmt.Sprintf("/dev/%s", disk.ID)
+	devicePath := "/dev/" + disk.ID
 	if disk.DeviceID != "" {
-		devicePath = fmt.Sprintf("/dev/disk/by-id/%s", disk.DeviceID)
+		devicePath = "/dev/disk/by-id/" + disk.DeviceID
 	} else if disk.DevicePath != "" {
-		devicePath = fmt.Sprintf("/dev/disk/by-path/%s", disk.DevicePath)
+		devicePath = "/dev/disk/by-path/" + disk.DevicePath
 	}
 
 	return devicePath

--- a/cmd/microcloud/main_init.go
+++ b/cmd/microcloud/main_init.go
@@ -860,7 +860,7 @@ func (c *initConfig) setupCluster(s *service.Handler) error {
 					addr = clusterMap[service.Location]
 				}
 
-				conns = append(conns, fmt.Sprintf("ssl:%s", util.CanonicalNetworkAddress(addr, 6641)))
+				conns = append(conns, "ssl:"+util.CanonicalNetworkAddress(addr, 6641))
 			}
 		}
 

--- a/cmd/microcloud/preseed.go
+++ b/cmd/microcloud/preseed.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -241,11 +242,11 @@ func (c *initConfig) RunPreseed(cmd *cobra.Command) error {
 	}
 
 	if !status.Ready && !c.bootstrap && initiator {
-		return fmt.Errorf("MicroCloud isn't yet initialized and cannot be the initiator")
+		return errors.New("MicroCloud isn't yet initialized and cannot be the initiator")
 	}
 
 	if status.Ready && !initiator {
-		return fmt.Errorf("MicroCloud is already initialized and can only be the initiator")
+		return errors.New("MicroCloud is already initialized and can only be the initiator")
 	}
 
 	systems, err := config.Parse(s, c, services)
@@ -321,29 +322,29 @@ func (p *Preseed) validate(name string, bootstrap bool) error {
 	localInit := false
 
 	if len(p.Systems) < 1 {
-		return fmt.Errorf("No systems given")
+		return errors.New("No systems given")
 	}
 
 	if p.Initiator == "" && p.InitiatorAddress == "" {
-		return fmt.Errorf("Missing initiator's name or address")
+		return errors.New("Missing initiator's name or address")
 	}
 
 	if p.Initiator != "" && p.InitiatorAddress != "" {
-		return fmt.Errorf("Cannot provide both the initiator's name and address")
+		return errors.New("Cannot provide both the initiator's name and address")
 	}
 
 	if p.InitiatorAddress != "" && p.LookupSubnet != "" {
-		return fmt.Errorf("Cannot provide both the initiator's address and lookup subnet")
+		return errors.New("Cannot provide both the initiator's address and lookup subnet")
 	}
 
 	if len(p.Systems) > 1 && p.SessionPassphrase == "" {
-		return fmt.Errorf("Missing session passphrase")
+		return errors.New("Missing session passphrase")
 	}
 
 	systemNames := make([]string, 0, len(p.Systems))
 	for _, system := range p.Systems {
 		if system.Name == "" {
-			return fmt.Errorf("Missing system name")
+			return errors.New("Missing system name")
 		}
 
 		if system.Address != "" && p.LookupSubnet != "" {
@@ -391,7 +392,7 @@ func (p *Preseed) validate(name string, bootstrap bool) error {
 	}
 
 	if bootstrap && !localInit {
-		return fmt.Errorf("Local MicroCloud must be included in the list of systems when initializing")
+		return errors.New("Local MicroCloud must be included in the list of systems when initializing")
 	}
 
 	containsUplinks := false
@@ -399,23 +400,23 @@ func (p *Preseed) validate(name string, bootstrap bool) error {
 	containsCephStorage := false
 	containsUplinks = uplinkCount > 0
 	if containsUplinks && uplinkCount < len(p.Systems) {
-		return fmt.Errorf("Some systems are missing an uplink interface")
+		return errors.New("Some systems are missing an uplink interface")
 	}
 
 	containsUnderlay := underlayCount > 0
 	if containsUnderlay && underlayCount < len(p.Systems) {
-		return fmt.Errorf("Some systems are missing an underlay interface")
+		return errors.New("Some systems are missing an underlay interface")
 	}
 
 	containsLocalStorage = directLocalCount > 0
 	if containsLocalStorage && directLocalCount < len(p.Systems) && len(p.Storage.Local) == 0 {
-		return fmt.Errorf("Some systems are missing local storage disks")
+		return errors.New("Some systems are missing local storage disks")
 	}
 
 	containsCephStorage = directCephCount > 0 || len(p.Storage.Ceph) > 0
 	usingCephPublicNetwork := p.Ceph.PublicNetwork != ""
 	if !containsCephStorage && usingCephPublicNetwork {
-		return fmt.Errorf("Cannot specify a Ceph public network without Ceph storage disks")
+		return errors.New("Cannot specify a Ceph public network without Ceph storage disks")
 	}
 
 	if usingCephPublicNetwork {
@@ -427,7 +428,7 @@ func (p *Preseed) validate(name string, bootstrap bool) error {
 
 	usingCephInternalNetwork := p.Ceph.InternalNetwork != ""
 	if !containsCephStorage && usingCephInternalNetwork {
-		return fmt.Errorf("Cannot specify a Ceph internal network without Ceph storage disks")
+		return errors.New("Cannot specify a Ceph internal network without Ceph storage disks")
 	}
 
 	if usingCephInternalNetwork {
@@ -438,7 +439,7 @@ func (p *Preseed) validate(name string, bootstrap bool) error {
 	}
 
 	if p.OVN.IPv4Gateway == "" && p.OVN.IPv4Range != "" {
-		return fmt.Errorf("Cannot specify IPv4 range without IPv4 gateway")
+		return errors.New("Cannot specify IPv4 range without IPv4 gateway")
 	}
 
 	if p.OVN.IPv4Gateway != "" {
@@ -448,14 +449,14 @@ func (p *Preseed) validate(name string, bootstrap bool) error {
 		}
 
 		if p.OVN.IPv4Range == "" {
-			return fmt.Errorf("Cannot specify IPv4 range without IPv4 gateway")
+			return errors.New("Cannot specify IPv4 range without IPv4 gateway")
 		}
 
 		start, end, ok := strings.Cut(p.OVN.IPv4Range, "-")
 		startIP := net.ParseIP(start)
 		endIP := net.ParseIP(end)
 		if !ok || startIP == nil || endIP == nil {
-			return fmt.Errorf("Invalid IPv4 range (must be of the form <ip>-<ip>)")
+			return errors.New("Invalid IPv4 range (must be of the form <ip>-<ip>)")
 		}
 	}
 
@@ -468,7 +469,7 @@ func (p *Preseed) validate(name string, bootstrap bool) error {
 
 	for _, filter := range p.Storage.Ceph {
 		if filter.Find == "" {
-			return fmt.Errorf("Received empty remote disk filter")
+			return errors.New("Received empty remote disk filter")
 		}
 
 		if filter.FindMax > 0 {
@@ -479,13 +480,13 @@ func (p *Preseed) validate(name string, bootstrap bool) error {
 
 		// For distributed storage, the minimum match count must be defined so that we don't have a default configuration that can be non-HA.
 		if filter.FindMin < 1 {
-			return fmt.Errorf("Remote storage filter cannot be defined with find_min less than 1")
+			return errors.New("Remote storage filter cannot be defined with find_min less than 1")
 		}
 	}
 
 	for i, filter := range p.Storage.Local {
 		if filter.Find == "" {
-			return fmt.Errorf("Received empty local disk filter")
+			return errors.New("Received empty local disk filter")
 		}
 
 		if filter.FindMax > 0 {
@@ -572,7 +573,7 @@ func (p *Preseed) address(name string) (string, error) {
 // Match matches the devices to the given filter, and returns the result.
 func (d *DiskFilter) Match(disks []lxdAPI.ResourcesStorageDisk) ([]lxdAPI.ResourcesStorageDisk, error) {
 	if d.Find == "" {
-		return nil, fmt.Errorf("Received empty filter")
+		return nil, errors.New("Received empty filter")
 	}
 
 	clauses, err := filter.Parse(d.Find, DiskOperatorSet())
@@ -908,11 +909,11 @@ func (p *Preseed) Parse(s *service.Handler, c *initConfig, installedServices map
 	}
 
 	if len(checkFilterCeph) == 0 && len(p.Storage.Ceph) > 0 {
-		return nil, fmt.Errorf("Ceph disk filter cannot be used. All systems have explicitly specified disks")
+		return nil, errors.New("Ceph disk filter cannot be used. All systems have explicitly specified disks")
 	}
 
 	if len(checkFilterZFS) == 0 && len(p.Storage.Local) > 0 {
-		return nil, fmt.Errorf("Local disk filter cannot be used. All systems have explicitly specified a disk")
+		return nil, errors.New("Local disk filter cannot be used. All systems have explicitly specified a disk")
 	}
 
 	allResourcesZFS := map[string]*lxdAPI.Resources{}
@@ -1168,7 +1169,7 @@ func (p *Preseed) Parse(s *service.Handler, c *initConfig, installedServices map
 	}
 
 	if c.bootstrap && len(zfsMachines)+len(directZFSMatches) > 0 && len(zfsMachines)+len(directZFSMatches) < len(c.systems) {
-		return nil, fmt.Errorf("Failed to find at least 1 disk on each machine for local storage pool configuration")
+		return nil, errors.New("Failed to find at least 1 disk on each machine for local storage pool configuration")
 	}
 
 	// If disks where selected for Ceph make sure to create the respective Ceph storage pool on all cluster members.

--- a/cmd/microcloud/preseed_test.go
+++ b/cmd/microcloud/preseed_test.go
@@ -333,7 +333,7 @@ func (s *preseedSuite) Test_preseedMatchDisksMemory() {
 	results, err := filter.Match(disks)
 	s.NoError(err)
 
-	s.Equal(len(results), 1)
+	s.Len(results, 1)
 	s.Equal(results[0], disks[0])
 }
 

--- a/cmd/microcloud/services.go
+++ b/cmd/microcloud/services.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"sort"
@@ -82,7 +83,7 @@ func (c *cmdServiceList) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if !status.Ready {
-		return fmt.Errorf("MicroCloud is uninitialized, run 'microcloud init' first")
+		return errors.New("MicroCloud is uninitialized, run 'microcloud init' first")
 	}
 
 	services := []types.ServiceType{types.MicroCloud, types.LXD}
@@ -317,7 +318,7 @@ func (c *cmdServiceAdd) Run(cmd *cobra.Command, args []string) error {
 	for _, state := range cfg.state {
 		localState := cfg.state[s.Name]
 		if len(state.ExistingServices[types.LXD]) != len(localState.ExistingServices[types.LXD]) || len(state.ExistingServices[types.LXD]) <= 0 {
-			return fmt.Errorf("Unable to add services. Some systems are not part of the LXD cluster")
+			return errors.New("Unable to add services. Some systems are not part of the LXD cluster")
 		}
 
 		if len(state.ExistingServices[types.MicroCeph]) <= 0 && !serviceMap[types.MicroCeph] {
@@ -332,7 +333,7 @@ func (c *cmdServiceAdd) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(askClusteredServices) == 0 {
-		return fmt.Errorf("All services have already been set up")
+		return errors.New("All services have already been set up")
 	}
 
 	err = cfg.askClustered(s, askClusteredServices)

--- a/cmd/microcloud/session.go
+++ b/cmd/microcloud/session.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"time"
 
@@ -122,13 +123,13 @@ Verify the fingerprint %s is displayed on joining systems.
 	}
 
 	if !session.Accepted {
-		return fmt.Errorf("Join confirmations didn't get accepted on all systems")
+		return errors.New("Join confirmations didn't get accepted on all systems")
 	}
 
 	for _, joinIntent := range confirmedIntents {
 		certBlock, _ := pem.Decode([]byte(joinIntent.Certificate))
 		if certBlock == nil {
-			return fmt.Errorf("Invalid certificate file")
+			return errors.New("Invalid certificate file")
 		}
 
 		remoteCert, err := x509.ParseCertificate(certBlock.Bytes)

--- a/cmd/microcloud/status.go
+++ b/cmd/microcloud/status.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -124,7 +125,7 @@ func (c *cmdStatus) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if !status.Ready {
-		return fmt.Errorf("MicroCloud is uninitialized, run 'microcloud init' first")
+		return errors.New("MicroCloud is uninitialized, run 'microcloud init' first")
 	}
 
 	cfg := initConfig{

--- a/cmd/microcloud/status_test.go
+++ b/cmd/microcloud/status_test.go
@@ -473,7 +473,7 @@ func (s *statusSuite) Test_statusWarnings() {
 		s.T().Log(i, c.desc)
 		warnings := compileWarnings("micro01", c.statuses)
 
-		s.Equal(len(c.expectedWarnings), len(warnings))
+		s.Len(warnings, len(c.expectedWarnings))
 		for _, w := range warnings {
 			s.Contains(c.expectedWarnings, w)
 		}

--- a/cmd/tui/console.go
+++ b/cmd/tui/console.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -139,7 +140,7 @@ func (c *testConsole) parseInput(handler *InputHandler) error {
 
 			// If expecting 0, error out as the table will be invalid with 0 rows.
 			if count == 0 {
-				return fmt.Errorf("Cannot expect 0 rows")
+				return errors.New("Cannot expect 0 rows")
 			}
 
 			// Sanity check that the table didn't start with more rows than we are going to expect.

--- a/cmd/tui/console_test.go
+++ b/cmd/tui/console_test.go
@@ -139,7 +139,7 @@ func (s *inputSuite) Test_parseInput() {
 		defer cancel()
 		b := bytes.Buffer{}
 		for _, line := range t.in {
-			_, _ = b.WriteString(fmt.Sprintf("%s\n", line))
+			_, _ = b.WriteString(line + "\n")
 		}
 
 		out, err := os.CreateTemp("", "test-output")
@@ -177,7 +177,7 @@ func (s *inputSuite) Test_waitInput() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		b := bytes.Buffer{}
-		_, _ = b.WriteString(fmt.Sprintf("%s\n", t.txt))
+		_, _ = b.WriteString(t.txt + "\n")
 		_, _ = b.WriteString("table:select\n")
 		_, _ = b.WriteString("table:done\n")
 
@@ -242,7 +242,7 @@ func (s *inputSuite) Test_waitExpectStatic() {
 		defer cancel()
 
 		b := bytes.Buffer{}
-		_, _ = b.WriteString(fmt.Sprintf("%s\n", t.txt))
+		_, _ = b.WriteString(t.txt + "\n")
 		_, _ = b.WriteString("table:done\n")
 
 		r := bufio.NewReader(bytes.NewReader(b.Bytes()))
@@ -313,7 +313,7 @@ func (s *inputSuite) Test_waitExpectDynamic() {
 		defer cancel()
 
 		b := bytes.Buffer{}
-		_, _ = b.WriteString(fmt.Sprintf("%s\n", t.txt))
+		_, _ = b.WriteString(t.txt + "\n")
 		_, _ = b.WriteString("table:done\n")
 
 		r := bufio.NewReader(bytes.NewReader(b.Bytes()))

--- a/cmd/tui/console_test.go
+++ b/cmd/tui/console_test.go
@@ -61,7 +61,7 @@ func (s *inputSuite) Test_consoleComments() {
 	s.Equal("a line with a comment and more delimiters", string(line))
 	line, _, err = c.queue.ReadLine()
 	s.NoError(err)
-	s.Equal("", string(line))
+	s.Empty(string(line))
 	line, _, err = c.queue.ReadLine()
 	s.NoError(err)
 	s.Equal("a line with a comment with more spaces", string(line))

--- a/cmd/tui/handler.go
+++ b/cmd/tui/handler.go
@@ -81,7 +81,7 @@ func (i *InputHandler) formatQuestion(question string, defaultAnswer string, acc
 
 	var defaultAnswerBlock string
 	if defaultAnswer != "" {
-		defaultAnswerBlock = Printf(Fmt{Arg: " [%s]"}, Fmt{Arg: fmt.Sprintf("default=%s", defaultAnswer), Bold: true})
+		defaultAnswerBlock = Printf(Fmt{Arg: " [%s]"}, Fmt{Arg: "default=" + defaultAnswer, Bold: true})
 	}
 
 	return fmt.Sprintf("%s%s%s: ", question, acceptedAnswersBlock, defaultAnswerBlock)

--- a/cmd/tui/selectable_table.go
+++ b/cmd/tui/selectable_table.go
@@ -91,7 +91,7 @@ func SummarizeResult(tmpl string, args ...any) string {
 		fmtArgs = append(fmtArgs, Fmt{Arg: arg, Color: Yellow, Bold: true})
 	}
 
-	return Printf(Fmt{Arg: fmt.Sprintf(" %s", tmpl), Color: White}, fmtArgs...)
+	return Printf(Fmt{Arg: " " + tmpl, Color: White}, fmtArgs...)
 }
 
 // NewSelectableTable takes a slice of structs and adds table rows for them.

--- a/cmd/tui/selectable_table.go
+++ b/cmd/tui/selectable_table.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -108,7 +109,7 @@ func NewSelectableTable(header []string, rows [][]string) *selectableTable {
 // Optionally takes a set of rows to replace the initial set.
 func (s *selectableTable) Render(ctx context.Context, handler *InputHandler, title string, newRows ...[]string) ([]map[string]string, error) {
 	if s.active || handler.table.active {
-		return nil, fmt.Errorf("Cannot render table while another is already active")
+		return nil, errors.New("Cannot render table while another is already active")
 	}
 
 	handler.tableMu.Lock()
@@ -145,7 +146,7 @@ func (s *selectableTable) Render(ctx context.Context, handler *InputHandler, tit
 
 	table, ok := result.(*selectableTable)
 	if !ok {
-		return nil, fmt.Errorf("Unexpected result type")
+		return nil, errors.New("Unexpected result type")
 	}
 
 	resultMap := make([]map[string]string, 0, len(table.rawRows))
@@ -460,7 +461,7 @@ func (s *selectableTable) handleKeyEvent(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		s.activeRows = map[int]bool{}
 		s.active = false
 		if s.err != nil {
-			s.err = fmt.Errorf("Input cancelled")
+			s.err = errors.New("Input cancelled")
 		}
 
 		return s, tea.Quit

--- a/multicast/discovery_test.go
+++ b/multicast/discovery_test.go
@@ -2,7 +2,7 @@ package multicast
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -54,7 +54,7 @@ func (m *multicastSuite) Test_Lookup() {
 		{
 			desc:        "Cannot lookup system if invalid interface is given",
 			lookupIface: "invalid-interface",
-			lookupErr:   fmt.Errorf(`Failed to resolve lookup interface "invalid-interface": route ip+net: no such network interface`),
+			lookupErr:   errors.New(`Failed to resolve lookup interface "invalid-interface": route ip+net: no such network interface`),
 		},
 		{
 			desc:          "Cannot lookup system if the responder is offline",
@@ -70,7 +70,7 @@ func (m *multicastSuite) Test_Lookup() {
 			modifier: func(server *Discovery) {
 				_ = server.StopResponder()
 			},
-			lookupErr: fmt.Errorf("Failed to read from multicast network endpoint: Timeout exceeded"),
+			lookupErr: errors.New("Failed to read from multicast network endpoint: Timeout exceeded"),
 		},
 		{
 			desc:          "Cannot lookup system if the responder uses a different version",
@@ -83,7 +83,7 @@ func (m *multicastSuite) Test_Lookup() {
 				Address: "1.2.3.4",
 			},
 			lookupTimeout: 500 * time.Microsecond,
-			lookupErr:     fmt.Errorf("Failed to read from multicast network endpoint: Timeout exceeded"),
+			lookupErr:     errors.New("Failed to read from multicast network endpoint: Timeout exceeded"),
 		},
 	}
 
@@ -105,7 +105,7 @@ func (m *multicastSuite) Test_Lookup() {
 		ctx := context.Background()
 		var cancel context.CancelFunc
 		if c.lookupTimeout > 0 {
-			ctx, cancel = context.WithTimeoutCause(ctx, c.lookupTimeout, fmt.Errorf("Timeout exceeded"))
+			ctx, cancel = context.WithTimeoutCause(ctx, c.lookupTimeout, errors.New("Timeout exceeded"))
 		}
 
 		receivedInfo, err := testDiscovery.Lookup(ctx, c.lookupVersion)

--- a/service/lxd.go
+++ b/service/lxd.go
@@ -141,7 +141,7 @@ func (s LXDService) Bootstrap(ctx context.Context) error {
 	}
 
 	if currentCluster.Enabled {
-		return fmt.Errorf("This LXD server is already clustered")
+		return errors.New("This LXD server is already clustered")
 	}
 
 	cluster := api.ClusterPut{
@@ -166,7 +166,7 @@ func (s LXDService) Bootstrap(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("Timed out waiting for LXD cluster to initialize")
+			return errors.New("Timed out waiting for LXD cluster to initialize")
 		default:
 			names, err := client.GetClusterMemberNames()
 			if err != nil {
@@ -614,7 +614,7 @@ func (s *LXDService) ValidateCephInterfaces(cephNetworkSubnetStr string, peerInt
 
 	ones, bits := subnet.Mask.Size()
 	if bits-ones == 0 {
-		return nil, fmt.Errorf("Invalid Ceph network subnet (must have more than one address)")
+		return nil, errors.New("Invalid Ceph network subnet (must have more than one address)")
 	}
 
 	data := make(map[string][][]string)
@@ -771,7 +771,7 @@ func (s LXDService) defaultGatewaySubnetV4() (*net.IPNet, string, error) {
 	}
 
 	if !available {
-		return nil, "", fmt.Errorf("No default IPv4 gateway available")
+		return nil, "", errors.New("No default IPv4 gateway available")
 	}
 
 	iface, err := net.InterfaceByName(ifaceName)
@@ -797,14 +797,14 @@ func (s LXDService) defaultGatewaySubnetV4() (*net.IPNet, string, error) {
 		}
 
 		if subnet != nil {
-			return nil, "", fmt.Errorf("More than one IPv4 subnet on default interface")
+			return nil, "", errors.New("More than one IPv4 subnet on default interface")
 		}
 
 		subnet = addrNet
 	}
 
 	if subnet == nil {
-		return nil, "", fmt.Errorf("No IPv4 subnet on default interface")
+		return nil, "", errors.New("No IPv4 subnet on default interface")
 	}
 
 	return subnet, ifaceName, nil
@@ -823,7 +823,7 @@ func (s LXDService) SupportsFeature(ctx context.Context, feature string) (bool, 
 	}
 
 	if server.APIExtensions == nil {
-		return false, fmt.Errorf("API extensions not available when checking for a LXD feature")
+		return false, errors.New("API extensions not available when checking for a LXD feature")
 	}
 
 	return shared.ValueInSlice(feature, server.APIExtensions), nil

--- a/service/lxd_join.go
+++ b/service/lxd_join.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/pem"
+	"errors"
 	"fmt"
 
 	"github.com/canonical/lxd/lxd/util"
@@ -58,7 +59,7 @@ func (s *LXDService) configFromToken(token string) (*api.ClusterPut, error) {
 	}
 
 	if config.ClusterCertificate == "" {
-		return nil, fmt.Errorf("Unable to connect to any of the cluster members specified in join token")
+		return nil, errors.New("Unable to connect to any of the cluster members specified in join token")
 	}
 
 	return config, nil

--- a/service/lxd_join.go
+++ b/service/lxd_join.go
@@ -42,7 +42,7 @@ func (s *LXDService) configFromToken(token string) (*api.ClusterPut, error) {
 		config.ClusterAddress = util.CanonicalNetworkAddress(clusterAddress, s.port)
 
 		// Cluster certificate
-		cert, err := shared.GetRemoteCertificate(fmt.Sprintf("https://%s", config.ClusterAddress), version.UserAgent)
+		cert, err := shared.GetRemoteCertificate("https://"+config.ClusterAddress, version.UserAgent)
 		if err != nil {
 			logger.Warnf("Error connecting to existing cluster member %q: %v\n", clusterAddress, err)
 			continue

--- a/service/microceph.go
+++ b/service/microceph.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -86,7 +87,7 @@ func (s CephService) Bootstrap(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("Timed out waiting for MicroCeph cluster to initialize")
+			return errors.New("Timed out waiting for MicroCeph cluster to initialize")
 		default:
 			names, err := s.ClusterMembers(ctx)
 			if err != nil {

--- a/service/microcloud.go
+++ b/service/microcloud.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -82,7 +83,7 @@ func (s CloudService) Bootstrap(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("Timed out waiting for MicroCloud cluster to initialize")
+			return errors.New("Timed out waiting for MicroCloud cluster to initialize")
 		default:
 			names, err := s.ClusterMembers(ctx)
 			if err != nil {

--- a/service/microovn.go
+++ b/service/microovn.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -72,7 +73,7 @@ func (s OVNService) Bootstrap(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("Timed out waiting for MicroOVN cluster to initialize")
+			return errors.New("Timed out waiting for MicroOVN cluster to initialize")
 		default:
 			names, err := s.ClusterMembers(ctx)
 			if err != nil {

--- a/service/system_information.go
+++ b/service/system_information.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -66,7 +67,7 @@ type SystemInformation struct {
 // CollectSystemInformation fetches the current cluster information of the system specified by the connection info.
 func (sh *Handler) CollectSystemInformation(ctx context.Context, connectInfo multicast.ServerInfo) (*SystemInformation, error) {
 	if connectInfo.Name == "" || connectInfo.Address == "" {
-		return nil, fmt.Errorf("Connection information is incomplete")
+		return nil, errors.New("Connection information is incomplete")
 	}
 
 	localSystem := sh.Name == connectInfo.Name

--- a/service/version.go
+++ b/service/version.go
@@ -24,8 +24,8 @@ const (
 func validateVersion(serviceType types.ServiceType, daemonVersion string) error {
 	switch serviceType {
 	case types.LXD:
-		lxdVersion := semver.Canonical(fmt.Sprintf("v%s", daemonVersion))
-		expectedVersion := semver.Canonical(fmt.Sprintf("v%s", lxdMinVersion))
+		lxdVersion := semver.Canonical("v" + daemonVersion)
+		expectedVersion := semver.Canonical("v" + lxdMinVersion)
 		if semver.Compare(semver.MajorMinor(lxdVersion), semver.MajorMinor(expectedVersion)) != 0 {
 			return fmt.Errorf("%s version %q is not supported", serviceType, daemonVersion)
 		}
@@ -42,8 +42,8 @@ func validateVersion(serviceType types.ServiceType, daemonVersion string) error 
 			return fmt.Errorf("%s version format not supported (%s)", serviceType, daemonVersion)
 		}
 
-		daemonVersion = semver.Canonical(fmt.Sprintf("v%s", match))
-		expectedVersion := semver.Canonical(fmt.Sprintf("v%s", microCephMinVersion))
+		daemonVersion = semver.Canonical("v" + match)
+		expectedVersion := semver.Canonical("v" + microCephMinVersion)
 		if semver.Compare(semver.MajorMinor(daemonVersion), semver.MajorMinor(expectedVersion)) != 0 {
 			return fmt.Errorf("%s version %q is not supported", serviceType, daemonVersion)
 		}

--- a/service/version_test.go
+++ b/service/version_test.go
@@ -58,7 +58,7 @@ func (s *versionSuite) Test_validateVersions() {
 		},
 		{
 			desc:      "Valid LXD with different patch version",
-			version:   fmt.Sprintf("%s.999", lxdMinVersion),
+			version:   lxdMinVersion + ".999",
 			service:   types.LXD,
 			expectErr: false,
 		},
@@ -76,7 +76,7 @@ func (s *versionSuite) Test_validateVersions() {
 		},
 		{
 			desc:      "Unsupported LXD with different minor version",
-			version:   fmt.Sprintf("%s.999", strings.Split(lxdMinVersion, ".")[0]),
+			version:   strings.Split(lxdMinVersion, ".")[0] + ".999",
 			service:   types.LXD,
 			expectErr: true,
 		},

--- a/version/version.go
+++ b/version/version.go
@@ -1,10 +1,6 @@
 // Package version provides shared version information.
 package version
 
-import (
-	"fmt"
-)
-
 // RawVersion is the current daemon version of MicroCloud.
 // LTS versions also include the patch number.
 const RawVersion = "2.1.0"
@@ -15,7 +11,7 @@ const LTS = true
 // Version appends "LTS" to the raw version string if MicroCloud is an LTS version.
 func Version() string {
 	if LTS {
-		return fmt.Sprintf("%s LTS", RawVersion)
+		return RawVersion + " LTS"
 	}
 
 	return RawVersion


### PR DESCRIPTION
Only `revive` is missing from the linters list use by LXD. I kept it for another day ;)