### PR TITLE
Update absolute docs links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,4 +104,4 @@ In addition to the sign-off requirement, contributors must also cryptographicall
 
 ## More information
 
-For more information, see [How to contribute to MicroCloud](https://canonical-microcloud.readthedocs-hosted.com/en/latest/microcloud/how-to/contribute/) in the documentation.
+For more information, see [How to contribute to MicroCloud](https://documentation.ubuntu.com/microcloud/latest/microcloud/how-to/contribute/) in the documentation.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ MicroCloud is designed for small-scale private clouds and hybrid cloud extension
 
 MicroCloud can be deployed on machines running Ubuntu 22.04 or newer. A MicroCloud cluster can consist of a single cluster member for a testing deployment, and requires a minimum of 3 cluster members for a production deployment. 
 
-See: [Pre-deployment requirements](https://canonical-microcloud.readthedocs-hosted.com/en/latest/microcloud/how-to/install/#pre-deployment-requirements) in the MicroCloud documentation for a full list of requirements.
+See: [Pre-deployment requirements](https://documentation.ubuntu.com/microcloud/latest/microcloud/how-to/install/#pre-deployment-requirements) in the MicroCloud documentation for a full list of requirements.
 
 
 ## **How to get started**
@@ -46,13 +46,13 @@ microcloud join
 
 Following the CLI prompts, a working MicroCloud will be ready within minutes.
 
-The MicroCloud snap drives three other snaps ([LXD](https://canonical-microcloud.readthedocs-hosted.com/en/latest/lxd/), [MicroCeph](https://canonical-microcloud.readthedocs-hosted.com/en/latest/microceph/), and [MicroOVN](https://canonical-microcloud.readthedocs-hosted.com/en/latest/microovn/)), enabling automated deployment of a highly available LXD cluster for compute, with Ceph as the storage driver and OVN as the managed network.
+The MicroCloud snap drives three other snaps ([LXD](https://documentation.ubuntu.com/microcloud/latest/lxd/), [MicroCeph](https://documentation.ubuntu.com/microcloud/latest/microceph/), and [MicroOVN](https://documentation.ubuntu.com/microcloud/latest/microovn/)), enabling automated deployment of a highly available LXD cluster for compute, with Ceph as the storage driver and OVN as the managed network.
 
 During initialization, MicroCloud scrapes the other servers for details and then prompts you to add disks to Ceph and configure the networking setup.
 
 At the end of this, you’ll have an OVN cluster, a Ceph cluster, and a LXD cluster. LXD itself will have been configured with both networking and storage suitable for use in a cluster.
 
-For more information, see the MicroCloud documentation for [installation](https://canonical-microcloud.readthedocs-hosted.com/en/latest/microcloud/how-to/install/) and [initialization](https://canonical-microcloud.readthedocs-hosted.com/en/latest/microcloud/how-to/initialize/). You can also [follow a tutorial](https://canonical-microcloud.readthedocs-hosted.com/en/latest/microcloud/tutorial/get_started/) that demonstrates the basics of MicroCloud.
+For more information, see the MicroCloud documentation for [installation](https://documentation.ubuntu.com/microcloud/latest/microcloud/how-to/install/) and [initialization](https://documentation.ubuntu.com/microcloud/latest/microcloud/how-to/initialize/). You can also [follow a tutorial](https://documentation.ubuntu.com/microcloud/latest/microcloud/tutorial/get_started/) that demonstrates the basics of MicroCloud.
 
 ## **What about networking?**
 
@@ -66,7 +66,7 @@ You can optionally add the following dedicated networks:
 
 ### **RESOURCES:**
 
-- Documentation: https://canonical-microcloud.readthedocs-hosted.com/
+- Documentation: https://documentation.ubuntu.com/microcloud/latest/microcloud/
 - Find the package at the Snap Store:
 
  [![Snapcraft logo](https://dashboard.snapcraft.io/site_media/appmedia/2018/04/Snapcraft-logo-bird.png)](https://snapcraft.io/microcloud)

--- a/doc/.sphinx/_integration/add_config.py
+++ b/doc/.sphinx/_integration/add_config.py
@@ -13,7 +13,7 @@ html_context['microovn_tag'] = "../microovn/_static/microovn.png"
 custom_html_js_files.append('rtd-search.js')
 
 if project == "LXD":
-    html_baseurl = "https://documentation.ubuntu.com/lxd/en/latest/"
+    html_baseurl = "https://documentation.ubuntu.com/lxd/latest/"
 elif project == "MicroCeph":
     html_baseurl = "https://canonical-microceph.readthedocs-hosted.com/en/latest/"
 elif project == "MicroOVN":

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,5 +1,5 @@
 # MicroCloud documentation
 
-We advise you to read the [published documentation](https://canonical-microcloud.readthedocs-hosted.com/en/latest) rather than reading the documentation through GitHub. The GitHub web interface provides a basic rendering of the documentation. However, important features are missing, such as includes and cross-references.
+We advise you to read the [published documentation](https://documentation.ubuntu.com/microcloud/latest/microcloud/) rather than reading the documentation through GitHub. The GitHub web interface provides a basic rendering of the documentation. However, important features are missing, such as includes and cross-references.
 
-Compelled to contribute to the documentation? Visit the [documentation contributor guidelines](https://canonical-microcloud.readthedocs-hosted.com/en/latest/microcloud/how-to/contribute/#contribute-to-the-documentation).
+Compelled to contribute to the documentation? Visit the [documentation contributor guidelines](https://documentation.ubuntu.com/microcloud/latest/microcloud/how-to/contribute//#contribute-to-the-documentation).

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -243,7 +243,7 @@ custom_tags = []
 
 if ('SINGLE_BUILD' in os.environ and os.environ['SINGLE_BUILD'] == 'True'):
     intersphinx_mapping = {
-        'lxd': ('https://documentation.ubuntu.com/lxd/en/latest/', None),
+        'lxd': ('https://documentation.ubuntu.com/lxd/latest/', None),
         'microceph': ('https://canonical-microceph.readthedocs-hosted.com/en/latest/', None),
         'microovn': ('https://canonical-microovn.readthedocs-hosted.com/en/latest/', None),
         'ceph': ('https://docs.ceph.com/en/latest/', None),

--- a/doc/how-to/recover.md
+++ b/doc/how-to/recover.md
@@ -8,7 +8,7 @@ similar for each service, this document only covers cluster recovery for the
 `microcloudd` daemon. For cluster recovery procedures for LXD, MicroCeph and
 MicroOVN, see:
 
-- [LXD Cluster Recovery](https://documentation.ubuntu.com/lxd/en/latest/howto/cluster_recover/)
+- {ref}`How to recover a LXD cluster <lxd:cluster-recover>`
 - [MicroOVN Launchpad Bug](https://bugs.launchpad.net/microovn/+bug/2072377)
 - [MicroCeph Issue](https://github.com/canonical/microceph/issues/380)
 ```

--- a/doc/how-to/support.md
+++ b/doc/how-to/support.md
@@ -35,6 +35,6 @@ See the full [Ubuntu Pro service description](https://ubuntu.com/legal/ubuntu-pr
 
 ## Documentation
 
-See the [MicroCloud documentation](https://canonical-microcloud.readthedocs-hosted.com/) for official product documentation.
+See the [MicroCloud documentation](https://documentation.ubuntu.com/microcloud/latest/microcloud/) for official product documentation.
 
 You can find additional resources on the [website](https://canonical.com/microcloud) and in the [discussion forum](https://discourse.ubuntu.com/c/lxd/microcloud/145).

--- a/test/e2e/run
+++ b/test/e2e/run
@@ -29,7 +29,7 @@ init() {
 
     if ! remoteAccessible; then
         echo "The ${REMOTE}: remote is not usable." >&2
-        echo "Please see https://documentation.ubuntu.com/lxd/en/latest/howto/server_expose/#authenticate-with-the-lxd-server" >&2
+        echo "Please see https://documentation.ubuntu.com/lxd/latest/howto/server_expose/#authenticate-with-the-lxd-server" >&2
         exit 1
     fi
 


### PR DESCRIPTION
This PR updates absolute links to both the MicroCloud and LXD documentation due to both recently changing URLs to remove /en/ from the path and, in MicroCloud's case, moving to a subdirectory of documentation.ubuntu.com. 