### PR TITLE
doc: update move wording to migrate

### DIFF
--- a/doc/explanation/networking.md
+++ b/doc/explanation/networking.md
@@ -78,7 +78,7 @@ A dedicated underlay network serves as the physical infrastructure over which th
 
 If you decide to not use MicroOVN, MicroCloud falls back on the [Ubuntu fan](https://wiki.ubuntu.com/FanNetworking) for basic networking. MicroCloud will still be usable, but you will see some limitations, including:
 
-- When you move an instance from one cluster member to another, its IP address changes.
+- When you migrate an instance from one cluster member to another, its IP address changes.
 - Egress traffic leaves from the local cluster member (while OVN provides shared egress).
   As a result of this, network forwarding works at a basic level only, and external addresses must be forwarded to a specific cluster member and don't fail over.
 - There is no support for hardware acceleration, load balancers, or ACL functionality within the local network.

--- a/doc/how-to/commands.md
+++ b/doc/how-to/commands.md
@@ -271,15 +271,15 @@ See {ref}`lxd:cluster-manage-instance` and {ref}`lxd:cluster-evacuate`.
      {command}`microceph cluster list`
 
      {command}`microovn cluster list`
- * - Move an instance to a different cluster member
+ * - Migrate an instance to a different cluster member
    - {command}`lxc move <instance> --target <member>`
  * - Copy an instance from a different LXD server
-   - Add one of the MicroCloud cluster members as a remote on the different LXD server and copy or move the instance from that server.
+   - Add one of the MicroCloud cluster members as a remote on the different LXD server and copy or migrate the instance from that server.
 
      {command}`lxc copy <instance> <remote>`
 
      ```{tip}
-     See {ref}`lxd:move-instances` for details.
+     See {ref}`lxd:howto-instances-migrate` for details.
      ```
  * - Evacuate a cluster member
    - {command}`lxc cluster evacuate <member>`

--- a/doc/how-to/shutdown_machine.md
+++ b/doc/how-to/shutdown_machine.md
@@ -11,9 +11,9 @@ You can stop all instances on a cluster member using the command:
 lxc stop --all
 ```
 
-Alternatively, for instances that can be {ref}`live-migrated <lxd:live-migration>`, you can move them to another cluster member without stopping them. See: {ref}`lxd:move-instances` for more information.
+Alternatively, for instances that can be {ref}`live-migrated <lxd:live-migration>`, you can migrate them to another cluster member without stopping them. See: {ref}`lxd:howto-instances-migrate` for more information.
 
-You can also temporarily move all instances on a machine to another cluster member by using cluster evacuation, then restore them after you restart. This method can live-migrate eligible instances; instances that cannot be live-migrated are automatically stopped and restarted. See: {ref}`lxd:cluster-evacuate` for more information.
+You can also temporarily migrate all instances on a machine to another cluster member by using cluster evacuation, then restore them after you restart. This method can live-migrate eligible instances; instances that cannot be live-migrated are automatically stopped and restarted. See: {ref}`lxd:cluster-evacuate` for more information.
 
 ## Enforce services shutdown and restart order
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -5,8 +5,8 @@ Once MicroCloud is deployed, end to end testing can verify that everything works
 ```{caution}
 By running end to end tests against a MicroCloud, you acknowledge that:
 
-1. All instances will be impacted as the cluster member evacuations require them to be moved, restarted or live-migrated
-1. Resources will be consumed (instances, memory, CPU, disk space, IP addresses, etc)
+1. All instances will be impacted as the cluster member evacuations require them to be migrated (and restarted if not live-migrated).
+1. Resources will be consumed (instances, memory, CPU, disk space, IP addresses, etc).
 
 As such, those end to end tests are best used to ascertain the working condition of a MicroCloud deployment before  deploying production workload to it.
 ```


### PR DESCRIPTION
Per recent discussions, we recently updated wording in the LXD docs referring to moving instances between LXD servers to consistently use the term 'migrate' (see: https://github.com/canonical/lxd/pull/15575). This PR does the same for MicroCloud, including updating a reference target (`move-instances` to `howto-instances-migrate`) that was changed in LXD and is referenced in MicroCloud.