### PR TITLE
doc: update EOL notice for track 1

### DIFF
--- a/doc/how-to/snaps.md
+++ b/doc/how-to/snaps.md
@@ -13,7 +13,7 @@ The installed snap versions must be compatible with one another, and for each of
 Snaps come with different channels that define which release of a snap is installed and tracked for updates.
 See [Channels and tracks](https://snapcraft.io/docs/channels) in the snap documentation for detailed information.
 
-MicroCloud currently provides the `2` LTS and `3` development track. The `1` track reaches {abbr}`EOL (End of Life)` at the end of April 2025.
+MicroCloud currently provides the `2` LTS and `3` development track. The `1` track reached {abbr}`EOL (End of Life)` at the end of April 2025.
 
 ```{tip}
 In general, you should use the default channels for all snaps required to run MicroCloud.

--- a/doc/how-to/support.md
+++ b/doc/how-to/support.md
@@ -8,15 +8,13 @@ We recommend using the following channels for the snaps required to run MicroClo
 * For MicroCeph: `squid/(stable|candidate|edge)`
 * For MicroOVN: `24.03/(stable|candidate|edge)`
 
-```{note}
 The LTS version of MicroCloud is available in the `2` track.
 It's recommended to use the `<track>/stable` channels for production deployments.
-```
 
-```{important}
-MicroCloud `1/(stable|candidate|edge)` reaches {abbr}`EOL (End of Life)` at the end of April 2025.
-Make sure to upgrade to the `2` LTS track before this date.
-See the {ref}`howto-update-upgrade-upgrade` guide for more information.
+```{admonition} Users of the 1 track
+:class: important
+MicroCloud `1/(stable|candidate|edge)` reached {abbr}`EOL (End of Life)` at the end of April 2025.
+If you use this track, make sure to upgrade to the `2` LTS track. See the {ref}`howto-update-upgrade-upgrade` guide for more information.
 ```
 
 ## Support and community

--- a/doc/how-to/update_upgrade.md
+++ b/doc/how-to/update_upgrade.md
@@ -39,9 +39,10 @@ Performing an update requires going through the list of snaps one after another 
 Depending on which snap gets updated, some services of this snap (such as API endpoints) might not be available while performing the update. Check the respective services' documentation on updates for more information.
 ```
 
-```{important}
-MicroCloud `1/(stable|candidate|edge)` reaches {abbr}`EOL (End of Life)` at the end of April 2025.
-Make sure to upgrade to the `2` LTS track before this date.
+```{admonition} Users of the 1 track
+:class: important
+MicroCloud `1/(stable|candidate|edge)` reached {abbr}`EOL (End of Life)` at the end of April 2025.
+If you use this track, make sure to upgrade to the `2` LTS track.
 See the {ref}`howto-update-upgrade-upgrade` guide below for more information.
 ```
 


### PR DESCRIPTION
Update EOL for track 1 notice to past tense since it is now past the end of April 2025.