### PR TITLE
doc: add information about using a single network interface

### DIFF
--- a/doc/how-to/install.md
+++ b/doc/how-to/install.md
@@ -46,6 +46,8 @@ These requirements are in addition to those listed in the General tab.
   - 1 member
 - Memory:
   - Minimum 8 GiB RAM per cluster member
+- Networking:
+  - It is possible to use a single network interface per cluster member. However, such a configuration is neither supported nor recommended. For details, see: {ref}`reference-requirements-network-interface-single`.
 - Storage:
   - If high availability is required, use distributed storage with:
     - a minimum of 3 cluster members

--- a/doc/reference/requirements.md
+++ b/doc/reference/requirements.md
@@ -77,7 +77,7 @@ For further information, see the Prerequisites section of this page: {doc}`micro
 (reference-requirements-network-interfaces)=
 ### Required network interfaces
 
-For networking, each machine in the MicroCloud cluster requires at least two dedicated network interfaces: one for intra-cluster communication and one for external connectivity. These can be connected to the same network, or different networks.
+For networking, use at least two dedicated network interfaces for each machine in a MicroCloud cluster: one for intra-cluster communication and one for external connectivity. These can be connected to the same network, or different networks.
 
 In production environments, we recommend dual-port network cards with a minimum 10 GiB capacity, or higher if low latency is essential.
 
@@ -97,6 +97,13 @@ Network interface to connect to the uplink network
 
    You can specify a different interface to be used as the uplink interface for each cluster member.
    MicroCloud requires that all uplink interfaces are connected to the uplink network, using the gateway and IP address range information that you provide during the MicroCloud initialization process.
+
+(reference-requirements-network-interface-single)=
+### Single network interface configuration
+
+For testing or development environments, it is possible to use a single network interface per cluster member, with a bridge in front of each for external connectivity to the uplink network. An OVS bridge is preferable to a native bridge to avoid an extra hop for OVN uplink traffic.
+
+However, this configuration is neither supported nor recommended, because it prevents traffic segregation of intra-cluster and uplink traffic.
 
 (reference-requirements-network-nics-optional)=
 ### Optional network interfaces


### PR DESCRIPTION
Replaces https://github.com/canonical/microcloud/pull/596 to clarify that a configuration with a single network interface per cluster member can be used in testing/development environments.