### PR TITLE
doc: remove partitioned filter in preseed example

### DIFF
--- a/doc/how-to/preseed.yaml
+++ b/doc/how-to/preseed.yaml
@@ -101,7 +101,7 @@ storage:
       find_min: 1
       find_max: 2
       wipe: true
-    - find: size > 10GiB && size < 50GiB && type == hdd && partitioned == false && block_size == 512 && model == 'Samsung %'
+    - find: size > 10GiB && size < 50GiB && type == hdd && block_size == 512 && model == 'Samsung %'
       find_min: 3
       find_max: 8
       wipe: false


### PR DESCRIPTION
Per https://github.com/canonical/microcloud/issues/781, removes ceph filter example of `partitioned==false`. MicroCloud already ignores partitioned disks, so there's no need to filter them as this example suggests.