### PR TITLE
doc: update snaps and releases documentation

### DIFF
--- a/doc/.custom_wordlist.txt
+++ b/doc/.custom_wordlist.txt
@@ -5,6 +5,8 @@ AGPLv
 backend
 backporting
 balancers
+bugfix
+bugfixes
 CCLA
 Ceph
 Ceph's
@@ -29,6 +31,7 @@ intra
 IOV
 IPs
 IPv
+lifecycle
 LTS
 LXD
 LXD's
@@ -61,6 +64,7 @@ subnets
 SVG
 TinyPNG
 uplink
+upstream's
 VLAN
 vlatest
 VM

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -112,5 +112,8 @@ serve: html
 serve-microcloud: microcloud
 	cd $(current_dir)/_build/; python3 -m http.server --bind 127.0.0.1 8000
 
+install:
+	$(MAKE) -f Makefile.sp sp-install
+	
 %:
 	$(MAKE) -f Makefile.sp sp-$@

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -82,7 +82,7 @@ html: integrate
 	cd integration/lxd/doc/ && $(MAKE) html BUILDDIR=$(current_dir)/_build/lxd
 	cd integration/microceph/docs/ && $(MAKE) html BUILDDIR=$(current_dir)/_build/microceph
 	cd integration/microovn/docs/ && $(MAKE) html BUILDDIR=$(current_dir)/_build/microovn
-	$(MAKE) -f Makefile.sp sp-html BUILDDIR=$(current_dir)/_build/microcloud
+	$(MAKE) -f Makefile.sp sp-html BUILDDIR=$(current_dir)/_build/microcloud ADDPREREQS='pyyaml'
 
 # `html-rtd` builds the integrated docs, with the correct paths for Read the Docs.
 # This target is used by the Read the Docs build.
@@ -90,7 +90,7 @@ html-rtd:
 	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -C integration/lxd/doc/ html-rtd BUILDDIR=$(READTHEDOCS_OUTPUT)/html/lxd
 	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -C integration/microceph/docs/ html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microceph
 	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -C integration/microovn/docs/ html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microovn
-	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -f Makefile.sp sp-html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microcloud
+	ADDPREREQS='pyyaml' PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -f Makefile.sp sp-html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microcloud
 
 # `spelling` checks only the MicroCloud docs.
 spelling: clean-doc microcloud
@@ -113,7 +113,7 @@ serve-microcloud: microcloud
 	cd $(current_dir)/_build/; python3 -m http.server --bind 127.0.0.1 8000
 
 install:
-	$(MAKE) -f Makefile.sp sp-install
+	$(MAKE) -f Makefile.sp sp-install ADDPREREQS='pyyaml'
 	
 %:
 	$(MAKE) -f Makefile.sp sp-$@

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import yaml
 
 # Custom configuration for the Sphinx documentation builder.
 # All configuration specific to your project should be done in this file.
@@ -221,6 +222,7 @@ custom_extensions = [
 # sphinxext-opengraph
 custom_required_modules = [
     'sphinx-sitemap',
+    'pyyaml',
 ]
 
 # Add files or directories that should be excluded from processing.
@@ -294,3 +296,8 @@ if not ('SINGLE_BUILD' in os.environ and os.environ['SINGLE_BUILD'] == 'True'):
     custom_templates_path = ['integration/microcloud/_templates']
     redirects['../index'] = 'microcloud/'
     custom_tags.append('integrated')
+
+# Load substitutions from YAML file
+if os.path.exists('./substitutions.yaml'):
+    with open('./substitutions.yaml', 'r') as fd:
+        myst_substitutions = yaml.safe_load(fd.read())

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -164,7 +164,9 @@ redirects = {
 # Links to ignore when checking links
 linkcheck_ignore = [
     'http://127.0.0.1:8000',
-    'http://localhost:8000'
+    'http://localhost:8000',
+    # These links may fail from time to time
+    'https://ceph.io',
     ]
 
 # Pages on which to ignore anchors

--- a/doc/how-to/install.md
+++ b/doc/how-to/install.md
@@ -86,27 +86,73 @@ For detailed information, see: {ref}`reference-requirements`.
 ```{youtube} https://www.youtube.com/watch?v=M0y0hQ16YuE
 ```
 
-To install MicroCloud, install all required {ref}`snaps <reference-requirements-software-snaps>` on all machines that you want to include in your cluster.
+To install MicroCloud, install all required {ref}`snaps <reference-requirements-software-snaps>` on all machines that you want to include in your cluster. You can {ref}`optionally specify a channel <howto-install-specify-channel>` for each snap, but generally, you can leave out the channel to use the current recommended default. 
 
 To do so, enter the following commands on all machines:
 
-    sudo snap install lxd --channel=5.21/stable --cohort="+"
-    sudo snap install microceph --channel=squid/stable --cohort="+"
-    sudo snap install microovn --channel=24.03/stable --cohort="+"
-    sudo snap install microcloud --channel=2/stable --cohort="+"
-
-```{note}
-Make sure to install the same version of the snaps on all machines.
-See {ref}`howto-snap` for more information.
-
-If you don't want to use MicroCloud's full functionality, you can install only some of the snaps.
-However, this is not recommended.
+```bash
+sudo snap install lxd --cohort="+"
+sudo snap install microceph --cohort="+"
+sudo snap install microovn --cohort="+"
+sudo snap install microcloud --cohort="+"
 ```
 
-```{note}
-It's possible that a required snap is already installed on your machine. For example, it might be a version of Ubuntu that comes with LXD pre-installed.
-In this case, run `sudo snap refresh <snap> --channel=<track>/stable --cohort="+"` to refresh (update) the installed snap.
+The `--cohort` flag ensures that versions remain {ref}`synchronized during later updates <howto-update-sync>`.
+
+Following installation, make sure to {ref}`hold updates <howto-update-hold>`.
+
+### Previously installed snaps
+
+If a required snap is already installed on your machine, you will receive a message to that effect. In this case, check the version for the installed snap:
+
+```bash
+snap list <snap>
 ```
 
-After installing the snaps make sure to hold any automatic updates to keep the used snap versions across MicroCloud in sync.
-See {ref}`howto-snap-hold-updates` for more information.
+View the {ref}`matrix of compatible versions <ref-releases-matrix>` to determine whether you need to upgrade the snap to a different channel. Follow either the update or upgrade instructions below.
+
+#### Update
+
+If the installed snap is using a channel corresponding to a release that is compatible with the other snaps, update to the most recent stable version of the snap without changing the channel:
+
+```bash
+sudo snap refresh <snap> --cohort="+"
+```
+
+#### Upgrade
+
+If you need to upgrade the channel, run:
+
+```bash
+sudo snap refresh <snap> --cohort="+" --channel=<target channel>
+```
+
+Example:
+
+```bash
+sudo snap refresh microcloud --cohort="+" --channel=2/stable
+```
+
+(howto-install-specify-channel)=
+### Optionally specify a channel
+
+Channels correspond to different {ref}`releases <ref-releases-snaps>`. When unspecified, MicroCloud and its components' snaps use their respective recommended default channels.
+
+To specify a different channel, add the `--channel` flag at installation:
+
+```bash
+sudo snap install <snap> --cohort="+" --channel=<target channel>
+```
+
+For example, to use the `3/edge` channel for the MicroCloud snap, run:
+
+```bash
+sudo snap install microcloud --cohort="+" --channel=3/edge
+```
+
+For details about the MicroCloud snap channels, see: {ref}`ref-snaps-microcloud-channels`.
+
+(howto-install-hold-updates)=
+## Hold updates
+
+When a new release is published to a snap channel, installed snaps following that channel update automatically by default. This is undesired behavior for MicroCloud and its components, and you should override this default behavior by holding updates. See: {ref}`howto-update-hold`.

--- a/doc/how-to/snaps.md
+++ b/doc/how-to/snaps.md
@@ -1,87 +1,78 @@
 (howto-snap)=
 # How to manage the snaps
 
-MicroCloud is distributed as a [snap](https://snapcraft.io/docs).
-The benefit of packaging MicroCloud as a snap is that it makes it possible to include the required dependencies, and that it allows MicroCloud to be installed on many different Linux distributions.
-The snap ensures that MicroCloud runs in a consistent environment.
+Manage MicroCloud and its components (LXD, MicroCeph, and MicroOVN) through their snap packages.
 
-Because MicroCloud uses a set of {ref}`other snaps <reference-requirements-software-snaps>`, you must make sure to have suitable versions of these snaps installed on all machines of your MicroCloud cluster.
-The installed snap versions must be compatible with one another, and for each of the snaps, the same version must be installed on all machines.
+For the installation guide, see: {ref}`howto-install`. For details about the snaps, including {ref}`supported and compatible releases <ref-releases-matrix>`, {ref}`tracks <ref-snaps-microcloud-tracks>`, and {ref}`release processes <ref-releases-microcloud>`, see: {ref}`ref-releases-snap`.
 
-## Choose the right channel and track
+(howto-snap-info)=
+## View snap information
 
-Snaps come with different channels that define which release of a snap is installed and tracked for updates.
-See [Channels and tracks](https://snapcraft.io/docs/channels) in the snap documentation for detailed information.
+To view information about a snap, including the available channels and installed version, run:
 
-MicroCloud currently provides the `2` LTS and `3` development track. The `1` track reached {abbr}`EOL (End of Life)` at the end of April 2025.
-
-```{tip}
-In general, you should use the default channels for all snaps required to run MicroCloud.
-
-See {ref}`howto-support` for a list of supported channels that are orchestrated to work together.
+```bash
+snap info <microcloud|lxd|microceph|microovn>
 ```
 
-When installing a snap, specify the channel as follows:
+To view information about the installed version only, run:
 
-    sudo snap install <snap_name> --channel=<channel>
+```bash
+snap list <microcloud|lxd|microceph|microovn>
+```
 
-For example:
+Sample output:
 
-    sudo snap install microcloud --channel=2/stable
+```{terminal}
+:input: snap list microcloud
+:user: root
+:host: instance
 
-To see all available channels of a snap, run the following command:
+Name        Version        Rev   Tracking  Publisher   Notes
+microcloud  2.1.0-3e8b183  1144  2/stable  canonical✓  in-cohort,held
+```
 
-    snap info <snap_name>
+The first part of the version string corresponds to the release (in this sample, `2.1.0`).
 
-(howto-snap-control-updates)=
-## Control updates
+(howto-snap-daemon)=
+## Manage the MicroCloud daemon
 
-By default, snaps are updated automatically.
-In the case of MicroCloud, this can be problematic because the related snaps must always use compatible versions, and because all machines of a cluster must use the same version of each snap.
+Installing the MicroCloud snap creates the MicroCloud daemon as a [snap service](https://snapcraft.io/docs/service-management). Use the following `snap` commands to manage this daemon.
 
-Therefore, you should manually apply your updates and make sure that all cluster members are in sync regarding the snap versions that they use.
+To view the status of the daemon, run:
 
-(howto-snap-hold-updates)=
-### Hold updates
+```bash
+snap services microcloud
+```
 
-You can hold snap updates for a specific time or forever, for all snaps or for specific snaps.
+To stop the daemon, run:
 
-Which strategy to choose depends on your use case.
-If you want to fully control updates to your MicroCloud setup, you should put a hold on all related snaps until you decide to update them.
+```bash
+sudo snap stop microcloud
+```
 
-Enter the following command to indefinitely hold all updates to the snaps needed for MicroCloud:
+To start the daemon, run:
 
-    sudo snap refresh --hold lxd microceph microovn microcloud
+```bash
+sudo snap start microcloud
+```
 
-See [Hold refreshes](https://snapcraft.io/docs/managing-updates#heading--hold) in the snap documentation for detailed information about holding snap updates.
+To restart the daemon, run:
 
-(howto-snap-cluster)=
-### Keep cluster members in sync
+```bash
+sudo snap restart microcloud
+```
 
-Snap updates are delivered as [progressive releases](https://snapcraft.io/docs/progressive-releases), which means that updated snap versions are made available to different machines at different times.
-This method can cause a problem for cluster updates if some cluster members are refreshed to a version that is not available to other cluster members yet.
+For more information about managing snap services, visit [Service management](https://snapcraft.io/docs/service-management) in the Snap documentation.
 
-To avoid this problem, use the `--cohort="+"` flag when refreshing your snaps:
+## Related topics
 
-    sudo snap refresh <snap> --cohort="+"
+How-to guides:
+- {ref}`howto-update-upgrade`
+- {ref}`howto-install`
 
-This flag ensures that all machines in a cluster see the same snap revision and are therefore not affected by a progressive rollout.
+Reference:
+- {ref}`ref-releases-snaps`
 
-## Use an Enterprise Store Proxy
+In the LXD documentation:
 
-If you manage a large MicroCloud deployment and you need absolute control over when updates are applied, consider installing an Enterprise Store Proxy.
-
-The Enterprise Store Proxy is a separate application that sits between the snap client command on your machines and the snap store.
-You can configure the Enterprise Store Proxy to make only specific snap revisions available for installation.
-
-See the [Enterprise Store Proxy documentation](https://documentation.ubuntu.com/enterprise-store/) for information about how to install and register the Enterprise Store Proxy.
-
-After setting it up, configure the snap clients on all cluster members to use the proxy.
-See [Configuring devices](https://documentation.ubuntu.com/enterprise-store/main/how-to/devices/) for instructions.
-
-You can then configure the Enterprise Store Proxy to override the revisions for the snaps that are needed for MicroCloud:
-
-    sudo snap-proxy override lxd <channel>=<revision>
-    sudo snap-proxy override microceph <channel>=<revision>
-    sudo snap-proxy override microovn <channel>=<revision>
-    sudo snap-proxy override microcloud <channel>=<revision>
+- {ref}`lxd:howto-snap`

--- a/doc/how-to/support.md
+++ b/doc/how-to/support.md
@@ -1,38 +1,31 @@
 (howto-support)=
 # How to get support
 
-We recommend using the following channels for the snaps required to run MicroCloud:
+For information about supported and compatible releases of MicroCloud and its components, see: {ref}`ref-releases-matrix`.
 
-* For MicroCloud: `2/(stable|candidate|edge)`
-* For LXD: `5.21/(stable|candidate|edge)`
-* For MicroCeph: `squid/(stable|candidate|edge)`
-* For MicroOVN: `24.03/(stable|candidate|edge)`
+## Community support
 
-The LTS version of MicroCloud is available in the `2` track.
-It's recommended to use the `<track>/stable` channels for production deployments.
+You can seek support from the LXD developers as well as the wider community through the following channels.
 
-```{admonition} Users of the 1 track
-:class: important
-MicroCloud `1/(stable|candidate|edge)` reached {abbr}`EOL (End of Life)` at the end of April 2025.
-If you use this track, make sure to upgrade to the `2` LTS track. See the {ref}`howto-update-upgrade-upgrade` guide for more information.
-```
+### Forum
 
-## Support and community
+Ask questions or engage in discussions in our [Discourse forum](https://discourse.ubuntu.com/c/lxd/microcloud/145).
 
-The following channels are available for you to interact with the MicroCloud community:
+### Documentation
 
-- You can file bug reports and feature requests as [GitHub issues](https://github.com/canonical/microcloud/issues/new).
-- To ask questions, go to the MicroCloud section of our [discussion forum](https://discourse.ubuntu.com/c/lxd/microcloud/145).
+Access the [official documentation](https://documentation.ubuntu.com/microcloud/latest/).
+
+### Bug reports and feature requests
+
+To file a new bug or feature request, [submit an issue on GitHub](https://github.com/canonical/microcloud/issues/new).
+
+### Other community resources
+
+You can find additional resources on the [MicroCloud website](https://canonical.com/microcloud) and on [the LXD channel on YouTube](https://www.youtube.com/channel/UCuP6xPt0WTeZu32CkQPpbvA).
 
 ## Commercial support
 
-Commercial support for MicroCloud is available through [Ubuntu Pro](https://ubuntu.com/support) (Ubuntu Pro (Infra-only) or full Ubuntu Pro).
-The support will cover all LTS versions for five years starting from the day of the release.
+LTS releases of MicroCloud receive standard support for five years, which means they receive continuous updates. Commercial support for MicroCloud is provided as part of [Ubuntu Pro](https://ubuntu.com/pro) (both Infra-only and full Ubuntu Pro). See the [full service description](https://ubuntu.com/legal/ubuntu-pro-description) for details.
 
-See the full [Ubuntu Pro service description](https://ubuntu.com/legal/ubuntu-pro-description) for detailed information about what support Ubuntu Pro provides.
+Managed solutions and firefighting support are also available for MicroCloud deployments. See: [Managed services](https://ubuntu.com/managed).
 
-## Documentation
-
-See the [MicroCloud documentation](https://documentation.ubuntu.com/microcloud/latest/microcloud/) for official product documentation.
-
-You can find additional resources on the [website](https://canonical.com/microcloud) and in the [discussion forum](https://discourse.ubuntu.com/c/lxd/microcloud/145).

--- a/doc/how-to/update_upgrade.md
+++ b/doc/how-to/update_upgrade.md
@@ -1,12 +1,15 @@
 (howto-update-upgrade)=
 # How to update and upgrade
 
-MicroCloud is made of several snaps that are closely coupled with each other.
-The cluster members that are part of a MicroCloud deployment must always run the same version of the snaps. Thus, when the snaps on one of the cluster members are refreshed, they must also be refreshed on all other cluster members. Until this happens, MicroCloud will continue to function as normal in regards to its data plane. However, its control plane will be inoperable, meaning that its configuration cannot be updated. For example, you will not be able to add or remove cluster members or instances.
+The snaps for MicroCloud, LXD, MicroCeph, and MicroOVN installed on MicroCloud cluster members must always run the same version of each snap. Thus, when the snaps on any cluster member are refreshed, they must also be refreshed on all other cluster members. See {ref}`howto-update-upgrade-order` for the recommended order.
 
-See {ref}`howto-update-upgrade-deps` for the recommended order.
+If the cluster members' snaps are not synchronized, MicroCloud continues to function as normal in regards to its data plane. However, the configuration of its control plane cannot be altered. For example, you cannot add or remove cluster members or instances. To prevent automatic updates from causing snaps to run different versions, make sure to always {ref}`hold updates <howto-update-hold>` as well as {ref}`synchronize updates using the cohort flag <howto-update-sync>`.
 
-Before performing an update or upgrade, make sure to backup your data to prevent any data loss in case of failure.
+Performing an update or upgrade requires going through the list of snaps one after another and updating or upgrading each of the individual cluster members. Some services of a snap (such as API endpoints) might become unavailable during this process. Check the respective services' documentation for more information.
+
+(howto-update-upgrade-backup)=
+## Back up data
+Before performing an update or upgrade, make sure to back up your data to prevent any data loss in case of failure.
 See the following backup guides for each of the snaps:
 
 * {doc}`How to backup MicroCeph <microceph:explanation/taking-snapshots>`
@@ -31,48 +34,118 @@ To avoid such possible effects entirely, use the live migration approach describ
 
 For more information on the cluster evacuate and restore operations, see: {ref}`lxd:cluster-evacuate-restore`.
 
-(howto-update-upgrade-update)=
-## Update MicroCloud
+(howto-update-upgrade-order)=
+## Update and upgrade order
 
-Updating MicroCloud allows access to the latest set of features and fixes in the tracked channels for the various snaps.
-Performing an update requires going through the list of snaps one after another and updating each of the individual cluster members.
+As MicroCloud consumes the services offered by its components, when updating or upgrading, follow this recommended order:
 
-```{note}
-Depending on which snap gets updated, some services of this snap (such as API endpoints) might not be available while performing the update. Check the respective services' documentation on updates for more information.
+1. MicroCeph
+1. MicroOVN
+1. LXD
+1. MicroCloud
+
+Update the same component's snap on all cluster members before moving to the next component. For example, update MicroCeph on all cluster members, then update MicroOVN on all cluster members, and so on.
+
+(howto-update-sync)=
+## Synchronize updates using the cohort flag
+
+Even with manual snap updates, versions can fall out of sync; see {ref}`ref-snap-updates` for details.
+
+To ensure synchronized updates, the `--cohort="+"` flag must be set on all cluster members. You only need to set this flag once per snap on each cluster member, either during {ref}`installation <howto-install>`, or the first time you {ref}`perform a manual update <howto-update>`.
+
+To set this flag during installation:
+
+```bash
+sudo snap install <snap> --cohort="+"
 ```
+
+To set this flag later, during a manual update:
+
+```bash
+sudo snap refresh <snap>> --cohort="+"
+```
+
+After you set this flag, `snap list <snap>` shows `in-cohort` in the `Notes` column. Example:
+
+```{terminal}
+:input: snap list lxd
+:user: root
+:host: instance
+
+Name  Version         Rev    Tracking     Publisher   Notes
+lxd   5.21.3-c5ae129  33110  5.21/stable  canonical✓  in-cohort
+```
+
+Subsequent updates to this snap automatically use the `--cohort="+"` flag. Thus, once the snap is `in-cohort`, you can omit that flag for future updates.
+
+````{admonition} Workaround if the cohort flag malfunctions
+:class: tip
+
+If for some reason, the `--cohort="+"` flag does not work as expected, you can update using a matching revision on all cluster members manually:
+
+```bash
+sudo snap refresh <snap> --revision=<revision_number>
+```
+
+Example:
+
+```bash
+sudo snap refresh lxd --revision=33110
+```
+
+````
+
+(howto-update-hold)=
+## Hold updates
+
+Once you install a snap, it begins tracking the specified snap channel, or the default if not specified. Whenever a new version is published to the tracked channel, the snap version on your system automatically updates.
+
+With MicroCloud and its components, it's important to control the updates. Thus, we direct you to hold updates for these snaps during the {ref}`installation process <howto-install-hold-updates>`.
+
+You can hold snap updates either indefinitely or for a specific duration. For full control of snap updates, set an indefinite hold.
+
+To indefinitely hold all updates to the snaps needed for MicroCloud, run:
+
+```bash
+sudo snap refresh --hold lxd microceph microovn microcloud
+```
+
+Then you can perform {ref}`manual updates <howto-update>` on a schedule that you control.
+
+For detailed information about holds, see: [Pause or stop automatic updates](https://snapcraft.io/docs/managing-updates#p-32248-pause-or-stop-automatic-updates) in the Snap documentation.
+
+(howto-update)=
+## Update MicroCloud
 
 ```{admonition} Users of the 1 track
 :class: important
-MicroCloud `1/(stable|candidate|edge)` reached {abbr}`EOL (End of Life)` at the end of April 2025.
-If you use this track, make sure to upgrade to the `2` LTS track.
-See the {ref}`howto-update-upgrade-upgrade` guide below for more information.
+The `1` MicroCloud track reached {abbr}`EOL (End of Life)` at the end of April 2025.
+If you use this track, make sure to upgrade to the `2` LTS track, as no further updates will be released to the `1` track. See the {ref}`howto-upgrade` guide below for more information. Specific command syntax is provided in {ref}`howto-upgrade-microcloud-full-example`.
 ```
 
-During an update, the snaps channel won't be modified, so the snaps are updated to the last available version inside the current channel.
-This does not introduce breaking changes and can be used on a regular basis to update a MicroCloud deployment.
+Updating MicroCloud allows access to the latest set of features and fixes in the tracked channels for the various snaps. During an update, snaps are refreshed to the most up-to-date version for their tracked channel. This does not introduce breaking changes.
 
-As MicroCloud consumes the services offered by the dependent snaps (MicroCeph, MicroOVN, and LXD), the update procedure starts by updating the list of dependencies first.
+Before you update, ensure that all snaps are {ref}`synchronized using the cohort flag <howto-update-sync>`. You only need to set the `--cohort` flag during updates if the snap is not `in-cohort`.
 
-(howto-update-upgrade-deps)=
-### Update the dependency snaps
+(howto-update-components)=
+### Update snaps for MicroCloud components
 
-Updating the dependencies can be done by running `snap refresh` against the respective snap.
-For MicroCloud, automatic snap refreshes are put on hold. See {ref}`howto-snap-control-updates` for more information.
+As MicroCloud consumes the services offered by its component snaps, the update procedure starts by updating the list of components first.
 
 To start the update procedure, enter the following command on the first machine:
 
-    sudo snap refresh microceph --cohort="+"
-
-If the command succeeds, run the same command on the next machine, and so on.
-
-```{note}
-Make sure to validate the health of the recently updated dependency before continuing with the next one.
+```bash
+sudo snap refresh microceph [--cohort="+"]
 ```
+
+If the command succeeds, run the same command on the next machine, and so on. Make sure to validate the health of the recently updated component before continuing with the next one.
 
 After successfully updating MicroCeph, continue with MicroOVN.
 Again enter the following command on the first machine:
 
-    sudo snap refresh microovn --cohort="+"
+```bash
+sudo snap refresh microovn [--cohort="+"]
+```
 
 Run the same command on the remaining machines, one after another, unless an error is encountered.
 
@@ -82,47 +155,49 @@ Furthermore, LXD might automatically update its snaps on cluster members if they
 
 On all cluster members, run _in parallel_:
 
-    sudo snap refresh lxd --cohort="+"
+```bash
+sudo snap refresh lxd [--cohort="+"]
+```
 
+(howto-update-microcloud)=
 ### Update the MicroCloud snap
 
-Last but not least, we can update MicroCloud.
-As before, enter the following command on the first machine:
+Last but not least, we can update MicroCloud. As before, enter the following command on the first machine:
 
-    sudo snap refresh microcloud --cohort="+"
+```bash
+sudo snap refresh microcloud [--cohort="+"]
+```
 
 Continue running the command on the rest of the machines to finish the update.
 
-Confirm that the MicroCloud deployment is in a healthy state after the update by running the following command:
+Once finished, confirm that the MicroCloud deployment is in a healthy state by running the following command:
 
-    sudo microcloud status
+```bash
+sudo microcloud status
+```
 
 ```{note}
 The status command was introduced in MicroCloud version 2.
-See {ref}`howto-update-upgrade-upgrade` on how to upgrade to another track.
+See {ref}`howto-upgrade` on how to upgrade to another track.
 ```
 
-(howto-update-upgrade-upgrade)=
+(howto-upgrade)=
 ## Upgrade MicroCloud
 
-Upgrading MicroCloud allows switching to another track with major improvements and enhanced functionality.
-Performing an upgrade requires going through the list of snaps one after another and upgrading each of the individual cluster members.
-
-```{note}
-Depending on which snap gets upgraded, some services of this snap (such as API endpoints) might not be available while performing the upgrade. Check the respective services' documentation on upgrades for more information.
-```
+Upgrading MicroCloud means to switch to a newer track with major improvements and enhanced functionality. An upgrade can potentially introduce breaking changes.
 
 During an upgrade, the snaps channel will be switched to another track.
-This might introduce breaking changes for MicroCloud and its dependencies and should be done with care.
-See {ref}`howto-update-upgrade-update` for regular non-breaking updates.
+This might introduce breaking changes for MicroCloud and its components and should be done with care.
+See {ref}`howto-update` for regular non-breaking updates.
 
-As MicroCloud consumes the services offered by the dependent snaps (MicroCeph, MicroOVN and LXD), the update procedure starts by updating the list of dependencies first.
+Before you update, ensure that all snaps are {ref}`synchronized using the cohort flag <howto-update-sync>`. The `--cohort` flag is only necessary if the snap is not `in-cohort`.
 
-### Upgrade the dependency snaps
+(howto-upgrade-components)=
+### Upgrade the component snaps
 
-Upgrading the dependencies can be done by running `snap refresh --channel <new track/stable>` against the respective snap.
+As MicroCloud consumes the services offered by its component snaps, the upgrade procedure starts by upgrading the list of components first.
 
-Make sure to consult the dedicated upgrade guides of each dependency before you perform the actual upgrade:
+Make sure to consult the dedicated upgrade guides of each component before you perform the actual upgrade:
 
 * {doc}`How to upgrade MicroCeph <microceph:how-to/major-upgrade>`
 * {doc}`How to upgrade MicroOVN <microovn:how-to/major-upgrades>`
@@ -130,18 +205,17 @@ Make sure to consult the dedicated upgrade guides of each dependency before you 
 
 To start the upgrade procedure, enter the following command on the first machine:
 
-    sudo snap refresh microceph --channel "squid/stable" --cohort="+"
-
-If the command succeeds, run the same command on the next machine, and so on.
-
-```{note}
-Make sure to validate the health of the recently upgraded dependency before continuing with the next one.
+```bash
+sudo snap refresh microceph --channel=<new channel> [--cohort="+"]
 ```
 
-After successfully upgrading MicroCeph, continue with MicroOVN.
-Again, enter the following command on the first machine:
+If the command succeeds, run the same command on the next machine, and so on. Make sure to validate the health of the recently upgraded component before continuing with the next one.
 
-    sudo snap refresh microovn --channel "24.03/stable" --cohort="+"
+After successfully upgrading MicroCeph, continue with MicroOVN. Again, enter the following command on the first machine:
+
+```bash
+sudo snap refresh microovn --channel=<new channel> [--cohort="+"]
+```
 
 Run the same command on the remaining machines, one after another, unless an error is encountered.
 
@@ -149,16 +223,93 @@ Next, for LXD, we recommend running upgrades in parallel. When any cluster membe
 
 On all cluster members, run _in parallel_:
 
-    sudo snap refresh lxd --channel "5.21/stable" --cohort="+"
+```bash
+sudo snap refresh lxd --channel=<new channel> [--cohort="+"]
+```
 
+(howto-upgrade-microcloud)=
 ### Upgrade MicroCloud snap
 
 Last but not least, we can upgrade MicroCloud.
 As before, enter the following command on the first machine:
 
-    sudo snap refresh microcloud --channel "2/stable" --cohort="+"
+```bash
+sudo snap refresh microcloud --channel=<new channel> [--cohort="+"]
+```
 
 Continue running the command on the rest of the machines to finish the upgrade.
 Confirm that the MicroCloud deployment is in a healthy state after the update by running the following command:
 
-    sudo microcloud status
+```bash
+sudo microcloud status
+```
+
+(howto-upgrade-microcloud-full-example)=
+### Example: Upgrade from MicroCloud 1 to 2
+
+Use the commands below to upgrade all components from MicroCloud 1 to MicroCloud 2.
+
+Omit the `--cohort="+"` flag if the MicroCeph snap is already `in-cohort`. If unsure, see: {ref}`howto-update-sync`.
+
+First, upgrade MicroCeph on all cluster members, one by one:
+
+```bash
+sudo snap refresh microceph --channel=squid/stable --cohort="+"
+```
+
+Next, upgrade MicroOVN on all cluster members, one by one:
+
+```bash
+sudo snap refresh microovn --channel=24.03/stable --cohort="+"
+```
+
+Next, upgrade LXD on all cluster members, _in parallel_:
+
+```bash
+sudo snap refresh lxd --channel=5.21/stable --cohort="+"
+```
+
+Finally, upgrade MicroCloud on all cluster members, one by one:
+
+```bash
+sudo snap refresh microcloud --channel=2/stable
+```
+
+Confirm the cluster's health:
+
+```bash
+sudo microcloud status
+```
+
+(howto-update-upgrade-proxy)=
+## Use an Enterprise Store Proxy
+
+If you manage a large MicroCloud deployment and you need absolute control over when updates are applied, consider installing an Enterprise Store Proxy.
+
+The Enterprise Store Proxy is a separate application that sits between the snap client command on your machines and the snap store. You can configure the Enterprise Store Proxy to make only specific snap revisions available for installation.
+
+See the [Enterprise Store Proxy documentation](https://documentation.ubuntu.com/enterprise-store/) for information about how to install and register the Enterprise Store Proxy.
+
+After setting it up, configure the snap clients on all cluster members to use the proxy.
+See [Configuring devices](https://documentation.ubuntu.com/enterprise-store/main/how-to/devices/) for instructions.
+
+You can then configure the Enterprise Store Proxy to override the revisions for the snaps that are needed for MicroCloud:
+
+```bash
+sudo snap-proxy override lxd <channel>=<revision>
+sudo snap-proxy override microceph <channel>=<revision>
+sudo snap-proxy override microovn <channel>=<revision>
+sudo snap-proxy override microcloud <channel>=<revision>
+```
+
+## Related topics
+
+How-to guides:
+
+- {ref}`howto-support`
+- {ref}`howto-install`
+- {ref}`howto-snap`
+
+Reference:
+
+- {ref}`ref-releases-snaps`

--- a/doc/reference/index.md
+++ b/doc/reference/index.md
@@ -7,3 +7,4 @@ The reference material in this section provides technical information about Micr
 :maxdepth: 1
 
 MicroCloud requirements </reference/requirements>
+/reference/releases-snaps

--- a/doc/reference/releases-snaps.md
+++ b/doc/reference/releases-snaps.md
@@ -1,0 +1,158 @@
+(ref-releases-snaps)=
+# Releases and snaps
+
+(ref-releases-matrix)=
+## Supported and compatible releases
+
+```{table}
+:align: center
+
+| Ubuntu LTS | MicroCloud  | LXD        | MicroCeph       | MicroOVN |
+| ---------- | ----------- | ---------- | --------------- | -------- |
+| 22.04      | 2.1*        | 5.21*      | Squid           | 24.03    |
+| 24.04      | 2.1*        | 5.21*      | Squid           | 24.03    |
+```
+
+`*` For MicroCloud and LXD, the most recent {ref}`feature releases <ref-releases-microcloud-feature>` (after the last LTS) are also supported.
+
+The releases above are currently under standard support, meaning they receive bugfixes and security updates. An [Ubuntu Pro](https://ubuntu.com/pro) subscription can provide additional support.
+
+The snaps for MicroCloud, LXD, MicroCeph, and MicroOVN must be installed on all members of the same MicroCloud cluster along. The versions installed by each snap must be compatible with one another, and the same version of each snap must be installed on all cluster members.
+
+Also see: {ref}`howto-update-upgrade` and {ref}`howto-snap`.
+
+(ref-releases-microcloud)=
+## MicroCloud releases
+
+The MicroCloud team maintains both Long Term Support (LTS) and feature releases in parallel. Release notes are published on [Discourse](https://discourse.ubuntu.com/c/lxd/microcloud/145/).
+
+(ref-releases-microcloud-lts)=
+### LTS releases
+
+LTS releases are **intended for production use**.
+
+MicroCloud follows the [Ubuntu release cycle](https://ubuntu.com/about/release-cycle) cadence, meaning that an LTS release of MicroCloud is created every two years. The release names follow the format _x.y.z_, always including the point number _z_. Updates are provided through point releases, incrementing _z_.
+
+(ref-releases-microcloud-lts-support)=
+#### Support
+
+LTS releases receive standard support for five years, meaning that it receives continuous updates according to the support levels described below. An [Ubuntu Pro](https://ubuntu.com/pro) subscription can provide additional support and extends the support duration by an additional five years.
+
+Standard support for an LTS release starts at full support for its first two years, then moves to maintenance support for the remaining three years. Once an LTS reaches End of Life (EOL), it no longer receives any updates.
+
+- **Full support**: Bugfixes and security updates are provided regularly.
+- **Maintenance support**: High impact bugfixes and critical security updates are provided as needed.
+
+The only currently supported MicroCloud LTS release is 2.1._z_. This LTS is supported until June 2029 and is currently in full support phase.
+
+(ref-releases-microcloud-feature)=
+### Feature releases
+
+MicroCloud feature releases contain the newest features. Since they are less tested than LTS releases, they are **not recommended for production use**.
+
+These releases follow the format _x.y_, and they never include a point number _z_. Feature releases for MicroCloud are numbered {{current_feature_track}}._y_, with _y_ incrementing for each new release.
+
+Each feature release replaces the one before it, up to the next LTS release. After an LTS release, no feature release is considered to exist until the next feature release cycle begins, incrementing the major version number.
+
+(ref-releases-microcloud-feature-support)=
+#### Support
+
+Feature releases receive continuous updates via each new release. The newest release at any given time is also eligible for additional support through an [Ubuntu Pro](https://ubuntu.com/pro) subscription.
+
+Currently, since no feature release has been published since the last LTS, there is no supported feature release.
+
+(ref-snaps-microcloud)=
+## MicroCloud snap
+
+MicroCloud is distributed as a [snap](https://snapcraft.io/docs). A key benefit of snap packaging is that it includes all required dependencies. This allows packages to run in a consistent environment on many different Linux distributions. Using the snap also streamlines updates through its [channels](https://snapcraft.io/docs/channels).
+
+(ref-snaps-microcloud-channels)=
+### Channels
+
+Each installed snap follows a [channel](https://snapcraft.io/docs/channels). Channels include a {ref}`track <ref-snaps-microcloud-tracks>` and a {ref}`risk level <ref-snaps-microcloud-risk>` (for example, the {{current_feature_track}}/stable channel). Each channel points to one release at a time, and when a new release is published to a channel, it replaces the previous one. {ref}`Updating the snap <howto-update-upgrade>` then updates to that release.
+
+To view all available channels for MicroCloud, run:
+
+```bash
+snap info microcloud
+```
+
+(ref-snaps-microcloud-tracks)=
+### Tracks
+
+MicroCloud releases are grouped under [snap tracks](https://snapcraft.io/docs/channels#heading--tracks).
+
+The current feature track is {{current_feature_track}}, and the currently supported LTS track is {{current_lts_track}}. The `1` track reached {abbr}`EOL (End of Life)` at the end of April 2025.
+
+(ref-snaps-microcloud-tracks-lts)=
+#### LTS tracks
+
+MicroCloud LTS tracks use the format _x.y_, corresponding to the major and minor numbers of {ref}`ref-releases-microcloud-lts`.
+
+(ref-snaps-microcloud-track-feature)=
+#### Feature track
+
+The MicroCloud feature track uses the major number of the current {ref}`feature release <ref-releases-feature>` series. Feature releases within the same major version are published to the same track, replacing the previous release. This simplifies updates, as you don't need to switch channels to access new feature releases within the same major version.
+
+The current feature track is {{current_feature_track}}. No feature release has yet been published to this track. The most recent development updates can be found in the {{current_feature_track}}/`edge` channel, for testing purposes only.
+
+(ref-snaps-microcloud-track-default)=
+#### The default track
+
+If you {ref}`install the MicroCloud snap <installing-snap-package>` without specifying a track, the recommended default is used. The default track always points to the most recent LTS track, which is currently {{current_lts_track}}.
+
+(ref-snaps-microcloud-risk)=
+### Risk levels
+
+For each MicroCloud track, there are three [risk levels](https://snapcraft.io/docs/channels#heading--risk-levels): `stable`, `candidate`, and `edge`.
+
+We recommend that you use the `stable` risk level to install fully tested releases; this is the only risk level supported under [Ubuntu Pro](https://ubuntu.com/pro), as well as the default risk level if one is not specified at install. The `candidate` and `edge` levels offer newer but less-tested updates, posing higher risk.
+
+(ref-releases-snaps-components)=
+## For MicroCloud components
+
+(ref-releases-snaps-lxd)=
+### LXD
+
+LXD follows a similar approach to its releases and snap as MicroCloud, including an LTS release every two years and more frequent feature releases on a feature track. For details, see {ref}`LXD releases and snap <lxd:ref-releases-snap>`.
+
+(ref-releases-snaps-microceph)=
+### MicroCeph
+
+[Ceph](https://ceph.io) is the upstream project of {doc}`microceph:index`.
+
+The version of Ceph initially included in the release of an LTS version of Ubuntu is supported for the entire lifecycle of that Ubuntu version. This support applies to MicroCeph as well.
+
+MicroCeph typically does not publish feature releases, but provides periodic non-breaking updates to existing releases, along with a new stable release corresponding to each Ceph release series. These MicroCeph releases share their upstream's release names (such as `quincy` or `squid`).
+
+For details about MicroCeph, see {doc}`microceph:index`. For more information about the Ceph release cycle, visit the Ceph documentation: {ref}`ceph:ceph-releases-general`.
+
+(ref-releases-snaps-microovn)=
+### MicroOVN releases and snap
+
+The upstream [OVN](https://www.ovn.org/) project follows a six-month release cadence. Every year, they release `YY.03` in March, and `YY.09` in September.
+
+Every two years, the March version of OVN becomes an LTS version, such as the `24.03` version released in March of 2024. MicroOVN publishes versions that correspond to these upstream LTS versions. Stable maintenance is provided through upstream point releases for OVN and bugfixes for the snap deployment.
+
+For more information, see the MicroOVN documentation:
+
+- {doc}`microovn:developers/release-process`
+- {ref}`microovn:snap channels`
+
+(ref-snaps-updates)=
+## Updates
+
+By default, installed snaps update automatically when new releases are published to the channel they're tracking. [Progressive snap releases](https://documentation.ubuntu.com/snapcraft/stable/how-to/publishing/manage-revisions-and-releases/#deliver-a-progressive-release) also mean that updates might not be immediately available to all machines at the same time.
+
+With MicroCloud, this can be problematic because its component snaps must always use {ref}`compatible versions <ref-releases-matrix>`, and because all members of a cluster must use the same version of each snap.
+
+To prevent issues, {ref}`hold updates for MicroCloud and its components <howto-update-hold>`. Furthermore, ensure that the all snaps are set to `in-cohort` (see {ref}`howto-update-sync`).
+
+## Related topics
+
+How-to guides:
+
+- {ref}`howto-support`
+- {ref}`howto-install`
+- {ref}`howto-snap`
+- {ref}`howto-update-upgrade`

--- a/doc/reference/requirements.md
+++ b/doc/reference/requirements.md
@@ -146,4 +146,4 @@ To run MicroCloud, you must install the following snaps:
 - [MicroCeph snap](https://snapcraft.io/microceph)
 - [MicroOVN snap](https://snapcraft.io/microovn)
 
-See {ref}`howto-install` for installation instructions.
+See {ref}`howto-install` for installation instructions, as well as {ref}`ref-releases-snaps` for a {ref}`matrix of supported and compatible versions <ref-releases-matrix>`.

--- a/doc/substitutions.yaml
+++ b/doc/substitutions.yaml
@@ -1,0 +1,3 @@
+# Maintain the substitutions below as the single sources of truth for current LTS and feature tracks:
+current_lts_track: "2"
+current_feature_track: "3"

--- a/doc/tutorial/get_started.md
+++ b/doc/tutorial/get_started.md
@@ -256,7 +256,7 @@ Complete the following steps on each VM (`micro1`, `micro2`, `micro3`, and `micr
 
    ```{note}
    The `--cohort="+"` flag in the command ensures that the same version of the snap is installed on all machines.
-   See {ref}`howto-snap-cluster` for more information.
+   See {ref}`howto-update-sync` for more information.
    ```
 
 1. Repeat these steps on all VMs.


### PR DESCRIPTION
This PR:
- Adds a new Releases and snaps reference page, similar to the recently added LXD documentation [Releases and snap](https://documentation.ubuntu.com/lxd/latest/reference/releases-snap/) page. Updates/adds links to this page from other pages.
- Enables use of a sustitutions.yaml file similar to LXD's for facilitating documentation updates of the current LTS and feature tracks for MicroCloud.
- Moves the information about holding and synchronizing updates from the Manage the snap page to the Updates and upgrades page.
- Improves and adds to the Manage the snap and Updates and upgrades how-to guides.
- Updates the How to get support guide to align with LXD's [how to get support guide](https://documentation.ubuntu.com/lxd/latest/support/).
- Updates the How to install MicroCloud guide to use the recommended defaults for installation, indicate that specifying a channel is optional, clarify how to handle a previously installed snap, etc.