### PR TITLE
CLI: Use consistent colors

### DIFF
--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -645,7 +645,7 @@ func (c *initConfig) askRemotePool(sh *service.Handler) error {
 		}
 
 		if availableDiskCount == 0 {
-			fmt.Println(tui.WarningColor("Warning: No disks available for distributed storage. Skipping configuration", false))
+			tui.PrintWarning("No disks available for distributed storage. Skipping configuration")
 
 			return nil
 		}
@@ -1125,7 +1125,7 @@ func (c *initConfig) askOVNNetwork(sh *service.Handler) error {
 	canOVNUnderlay := true
 	for peer, system := range c.systems {
 		if len(c.state[system.ServerInfo.Name].AvailableOVNInterfaces) == 0 {
-			fmt.Println(tui.WarningColor(fmt.Sprintf("Not enough interfaces available on %s to create an underlay network, skipping", peer), false))
+			tui.PrintWarning(fmt.Sprintf("Not enough interfaces available on %s to create an underlay network. Skipping configuration", peer))
 			canOVNUnderlay = false
 			break
 		}
@@ -1323,7 +1323,7 @@ func (c *initConfig) askCephNetwork(sh *service.Handler) error {
 	availableCephNetworkInterfaces := map[string]map[string]service.DedicatedInterface{}
 	for name, state := range c.state {
 		if len(state.AvailableCephInterfaces) == 0 {
-			fmt.Println(tui.WarningColor(fmt.Sprintf("No network interfaces found with IPs on %q to set a dedicated Ceph network, skipping Ceph network setup", name), false))
+			tui.PrintWarning(fmt.Sprintf("No network interfaces found with IPs on %q to set up a dedicated Ceph network. Skipping Ceph network setup", name))
 
 			return nil
 		}

--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -1657,7 +1657,7 @@ func (c *initConfig) askJoinConfirmation(gw *cloudClient.WebsocketGateway, servi
 		fmt.Println(tui.SummarizeResult("Received confirmation from system %s", session.Intent.Name))
 		fmt.Println("")
 		fmt.Println(tui.Note(tui.Yellow, tui.WarningSymbol()+tui.SetColor(tui.Bright, " Do not exit out to keep the session alive", true)) + "\n")
-		fmt.Println(tui.Printf(tui.Fmt{Arg: "Complete the remaining configuration on %s ..."}, tui.Fmt{Arg: session.Intent.Name, Color: tui.Yellow, Bold: true}))
+		fmt.Println(tui.Printf(tui.Fmt{Arg: "Complete the remaining configuration on %s ..."}, tui.Fmt{Arg: session.Intent.Name, Bold: true}))
 	}
 
 	err = gw.ReceiveWithContext(gw.Context(), &session)

--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -146,7 +146,7 @@ func (c *initConfig) askRetry(question string, f func() error) error {
 				return err
 			}
 
-			fmt.Printf("%s %s\n", tui.ErrorSymbol(), tui.ErrorColor(err.Error(), true))
+			tui.PrintError(err.Error())
 			retry, err = c.asker.AskBool(question, true)
 			if err != nil {
 				return err

--- a/cmd/microcloud/preseed.go
+++ b/cmd/microcloud/preseed.go
@@ -24,6 +24,7 @@ import (
 	"github.com/canonical/microcloud/microcloud/api"
 	"github.com/canonical/microcloud/microcloud/api/types"
 	cloudClient "github.com/canonical/microcloud/microcloud/client"
+	"github.com/canonical/microcloud/microcloud/cmd/tui"
 	"github.com/canonical/microcloud/microcloud/multicast"
 	"github.com/canonical/microcloud/microcloud/service"
 )
@@ -695,7 +696,7 @@ func (p *Preseed) Parse(s *service.Handler, c *initConfig, installedServices map
 
 		for serviceType, cluster := range existingClusters {
 			if len(cluster) > 0 {
-				fmt.Printf("Existing %s cluster is incompatible with MicroCloud, skipping %s setup\n", serviceType, serviceType)
+				tui.PrintWarning(fmt.Sprintf("Existing %s cluster is incompatible with MicroCloud. Skipping %s setup", serviceType, serviceType))
 
 				delete(s.Services, serviceType)
 			}

--- a/cmd/microcloud/session.go
+++ b/cmd/microcloud/session.go
@@ -201,8 +201,8 @@ func (c *initConfig) joiningSession(gw *cloudClient.WebsocketGateway, sh *servic
 		fmt.Printf("\n%s %s\n\n", tmpl, fingerprintArg)
 
 		tmplArg := tui.Fmt{Arg: "Select %s on %s to let it join the cluster"}
-		localArg := tui.Fmt{Arg: sh.Name, Color: tui.Yellow, Bold: true}
-		remoteArg := tui.Fmt{Arg: session.InitiatorName, Color: tui.Yellow, Bold: true}
+		localArg := tui.Fmt{Arg: sh.Name, Bold: true}
+		remoteArg := tui.Fmt{Arg: session.InitiatorName, Bold: true}
 		fmt.Println(tui.Printf(tmplArg, localArg, remoteArg))
 	}
 

--- a/cmd/tui/handler.go
+++ b/cmd/tui/handler.go
@@ -58,11 +58,6 @@ func (i *InputHandler) countAllRows() int {
 	return i.table.countRawRows()
 }
 
-// printWarning prints the given warning with "!" appended to the front of the message.
-func (i *InputHandler) printWarning(warning string) {
-	fmt.Printf("%s %s\n", WarningSymbol(), warning)
-}
-
 // formatQuestion enriches the plain question string with default and accepted answers.
 func (i *InputHandler) formatQuestion(question string, defaultAnswer string, acceptedAnswers []string) string {
 	var acceptedAnswersBlock string

--- a/cmd/tui/handler.go
+++ b/cmd/tui/handler.go
@@ -80,7 +80,7 @@ func (i *InputHandler) formatQuestion(question string, defaultAnswer string, acc
 
 // AskBoolWarn is the same as AskBool but it prints the given warning before asking.
 func (i *InputHandler) AskBoolWarn(warning string, question string, defaultAnswer bool) (bool, error) {
-	i.printWarning(warning)
+	PrintWarning(warning)
 	return i.AskBool(question, defaultAnswer)
 }
 
@@ -99,7 +99,7 @@ func (i *InputHandler) AskBool(question string, defaultAnswer bool) (bool, error
 
 // AskStringWarn is the same as AskString but it prints the given warning before asking.
 func (i *InputHandler) AskStringWarn(warning string, question string, defaultAnswer string, validator func(string) error) (string, error) {
-	i.printWarning(warning)
+	PrintWarning(warning)
 	return i.AskString(question, defaultAnswer, validator)
 }
 

--- a/cmd/tui/selectable_table.go
+++ b/cmd/tui/selectable_table.go
@@ -90,7 +90,7 @@ type selectableTable struct {
 func SummarizeResult(tmpl string, args ...any) string {
 	fmtArgs := []Fmt{}
 	for _, arg := range args {
-		fmtArgs = append(fmtArgs, Fmt{Arg: arg, Color: Yellow, Bold: true})
+		fmtArgs = append(fmtArgs, Fmt{Arg: arg, Bold: true})
 	}
 
 	return Printf(Fmt{Arg: " " + tmpl, Color: White}, fmtArgs...)

--- a/cmd/tui/style.go
+++ b/cmd/tui/style.go
@@ -111,7 +111,7 @@ func (*ColorErr) Write(p []byte) (n int, err error) {
 
 // PrintWarning calls Println but it appends "! Warning:" to the front of the message.
 func PrintWarning(s string) {
-	fmt.Printf("%s %s: %s\n", WarningSymbol(), WarningColor("Warning", true), s)
+	fmt.Println(WarningSymbol(), WarningColor("Warning:", true), WarningColor(s, false))
 }
 
 // Fmt represents the data supplied to ColorPrintf. In particular, it takes a color to apply to the text, and the text itself.

--- a/cmd/tui/style.go
+++ b/cmd/tui/style.go
@@ -114,6 +114,11 @@ func PrintWarning(s string) {
 	fmt.Println(WarningSymbol(), WarningColor("Warning:", true), WarningColor(s, false))
 }
 
+// PrintError calls Println but it appends "⨯ Error:" to the front of the message.
+func PrintError(s string) {
+	fmt.Println(ErrorSymbol(), ErrorColor("Error:", true), ErrorColor(s, false))
+}
+
 // Fmt represents the data supplied to ColorPrintf. In particular, it takes a color to apply to the text, and the text itself.
 type Fmt struct {
 	Color lipgloss.TerminalColor

--- a/cmd/tui/style.go
+++ b/cmd/tui/style.go
@@ -114,9 +114,14 @@ func PrintWarning(s string) {
 	fmt.Println(WarningSymbol(), WarningColor("Warning:", true), WarningColor(s, false))
 }
 
+// SprintError crafts the error string without writing it to any output yet.
+func SprintError(s string) string {
+	return fmt.Sprintln(ErrorSymbol(), ErrorColor("Error:", true), ErrorColor(s, false))
+}
+
 // PrintError calls Println but it appends "⨯ Error:" to the front of the message.
 func PrintError(s string) {
-	fmt.Println(ErrorSymbol(), ErrorColor("Error:", true), ErrorColor(s, false))
+	fmt.Print(SprintError(s))
 }
 
 // Fmt represents the data supplied to ColorPrintf. In particular, it takes a color to apply to the text, and the text itself.

--- a/cmd/tui/style.go
+++ b/cmd/tui/style.go
@@ -106,7 +106,15 @@ type ColorErr struct{}
 
 // Write colors the given error red and sends it to os.Stderr.
 func (*ColorErr) Write(p []byte) (n int, err error) {
-	return os.Stderr.WriteString(ErrorColor(strings.TrimSpace(string(p)), false) + "\n")
+	trimmedErr := strings.TrimSpace(string(p))
+
+	// Cobra allows setting the error prefix using SetErrPrefix() func but
+	// it ignores the setting when assigning an empty string.
+	// Therefore we can only trim the prefix to be able to set our own
+	// customized error prefix using tui styling.
+	withoutPrefixErr := strings.TrimPrefix(trimmedErr, "Error: ")
+
+	return os.Stderr.WriteString(SprintError(withoutPrefixErr))
 }
 
 // PrintWarning calls Println but it appends "! Warning:" to the front of the message.

--- a/service/lxd.go
+++ b/service/lxd.go
@@ -643,7 +643,7 @@ func (s *LXDService) ValidateCephInterfaces(cephNetworkSubnetStr string, peerInt
 	}
 
 	if len(data) == 0 {
-		fmt.Println(tui.WarningColor("No network interfaces found with IPs in the specified subnet, skipping Ceph network setup", false))
+		tui.PrintWarning("No network interfaces found with IPs in the specified subnet. Skipping Ceph network setup")
 	}
 
 	return data, nil

--- a/service/version.go
+++ b/service/version.go
@@ -37,7 +37,7 @@ func validateVersion(serviceType types.ServiceType, daemonVersion string) error 
 
 		// Print a warning in case a non-LTS version of LXD is used.
 		if semver.Compare(semver.MajorMinor(lxdVersion), semver.MajorMinor(expectedVersion)) == 1 {
-			fmt.Printf("%s Discovered non-LTS version %q of LXD\n", tui.WarningSymbol(), daemonVersion)
+			tui.PrintWarning(fmt.Sprintf("Discovered non-LTS version %q of LXD", daemonVersion))
 		}
 
 	case types.MicroOVN:


### PR DESCRIPTION
Fixes https://github.com/canonical/microcloud/issues/797

### Overview

The reason for this PR is to be more cautious with colors in the new tui. 
We are using three central colors green, yellow and red to indicate:

* green: positive security related aspects (fingerprints, steps, passphrase)
* yellow: warning messages
* red: error messages

Especially user provided input should not be repeated using the warning color to not confuse the user and to really make warnings and errors stand out.
The new tui styling allows highlighting input using bold text which already is enough as it stands out from regular text.

In addition the way we output errors and warnings is now consistently performed through dedicated functions.
Furthermore we use our own asker (not anymore the one from LXD) so we can influence the error message using our own styling.

### Single node MicroCloud deployment

![Screenshot from 2025-06-26 18-39-37](https://github.com/user-attachments/assets/69ca09f8-e2ff-40f0-a964-75d59f2f0d12)

### Multi node MicroCloud deployment

![Screenshot from 2025-06-26 18-42-24](https://github.com/user-attachments/assets/1076c2d5-0e1c-4a3d-beb7-7e6f381337db)

### Standard errors

![Screenshot from 2025-06-26 18-40-27](https://github.com/user-attachments/assets/fa89f0e8-117e-4bc8-9e17-f9a7a7ddaf76)
