### PR TITLE
CLI: Exit `add` command in case no new system got selected

### DIFF
--- a/cmd/microcloud/add.go
+++ b/cmd/microcloud/add.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -111,6 +112,11 @@ func (c *cmdAdd) Run(cmd *cobra.Command, args []string) error {
 	})
 	if err != nil {
 		return err
+	}
+
+	// Exit early if no new systems got selected during the trust establishment session.
+	if len(cfg.systems) == 0 {
+		return errors.New("At least one new system has to be selected")
 	}
 
 	reverter := revert.New()


### PR DESCRIPTION
In case no new system got selected with the `init` subcommand, the questionnaire falls back to creating a single node MicroCloud. In case of the `add` subcommand, there has to be at least one new system to continue.

The check itself cannot be done inside the initiating session because the same session func is used for both the init and add subcommands.