### PR TITLE
doc: update to sync with microceph adoption of sphinx-starter-pack

### DIFF
--- a/doc/.custom_wordlist.txt
+++ b/doc/.custom_wordlist.txt
@@ -62,6 +62,7 @@ SVG
 TinyPNG
 uplink
 VLAN
+vlatest
 VM
 VMs
 VPC

--- a/doc/.sphinx/_integration/add_config.py
+++ b/doc/.sphinx/_integration/add_config.py
@@ -9,15 +9,23 @@ html_context['microceph_tag'] = "../microceph/_static/tag.png"
 html_context['microovn_path'] = "../microovn"
 html_context['microovn_tag'] = "../microovn/_static/microovn.png"
 
-# Add the search JavaScript file
-custom_html_js_files.append('rtd-search.js')
-
 if project == "LXD":
     html_baseurl = "https://documentation.ubuntu.com/lxd/latest/"
+    custom_html_js_files.append('rtd-search.js')
+    custom_tags.append('integrated')
 elif project == "MicroCeph":
     html_baseurl = "https://canonical-microceph.readthedocs-hosted.com/en/latest/"
+    # Override default header templates
+    templates_path = globals().get('templates_path', []) + [".sphinx/_templates"]
+    # Override default header styles
+    html_static_path = globals().get('html_static_path', []) + [".sphinx/_static"]
+    html_css_files = globals().get('html_css_files', []) + ['override-header.css']
+    # Add rtd-search.js to the list of JS files
+    html_js_files = globals().get('html_js_files', []) + ['rtd-search.js']
+    # Add "integrated" to the list of custom tags
+    custom_tags = globals().get('custom_tags', []) + ['integrated']
 elif project == "MicroOVN":
     html_baseurl = "https://canonical-microovn.readthedocs-hosted.com/en/latest/"
+    custom_html_js_files.append('rtd-search.js')
+    custom_tags.append('integrated')
 
-# Include integrated tag
-custom_tags.append('integrated')

--- a/doc/.sphinx/_integration/override-header.css
+++ b/doc/.sphinx/_integration/override-header.css
@@ -1,0 +1,20 @@
+/* This CSS file overrides the default header.css injected by the canonical-sphinx
+   theme extension used by docs sets that use the sphinx-starter-pack.
+*/
+
+body ul.p-navigation__links {
+  max-width: none;
+}
+
+body ul.p-navigation__links li {
+  padding-left: 20px;
+}
+
+ul.p-navigation__links li.active {
+    background-color: #E95420;
+}
+
+body ul.p-navigation__links li a:hover,
+body ul.p-navigation__links li a:visited:hover {
+  text-decoration: none;
+}

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -46,13 +46,14 @@ integrate:
 	git -C integration/microovn reset --hard $(MICROOVNVERSION)
 	# Create a directory for files to override in MicroCloud docs
 	mkdir -p integration/microcloud/_templates/ integration/microcloud/_static
-	# Copy the header HTML and CSS files for the doc sets
+	mkdir -p integration/microceph/docs/.sphinx/_templates integration/microceph/docs/.sphinx/_static
+	# Copy the header HTML and CSS files for the doc sets  
 	cp .sphinx/_integration/microcloud.html integration/microcloud/_templates/header.html
 	cp .sphinx/_integration/header.css integration/microcloud/_static/
 	cp .sphinx/_integration/lxd.html integration/lxd/doc/.sphinx/_templates/header.html
 	cp .sphinx/_integration/header.css integration/lxd/doc/.sphinx/_static/
 	cp .sphinx/_integration/microceph.html integration/microceph/docs/.sphinx/_templates/header.html
-	cp .sphinx/_integration/header.css integration/microceph/docs/.sphinx/_static/
+	cp .sphinx/_integration/override-header.css integration/microceph/docs/.sphinx/_static/
 	cp .sphinx/_integration/microovn.html integration/microovn/docs/.sphinx/_templates/header.html
 	cp .sphinx/_integration/header.css integration/microovn/docs/.sphinx/_static/
 	# Copy the search JavaScript file
@@ -62,7 +63,7 @@ integrate:
 	cp .sphinx/_integration/rtd-search.js integration/microovn/docs/.sphinx/_static/
 	# Add information about where to find the tags/docs to the doc sets
 	cat .sphinx/_integration/add_config.py >> integration/lxd/doc/custom_conf.py
-	cat .sphinx/_integration/add_config.py >> integration/microceph/docs/custom_conf.py
+	cat .sphinx/_integration/add_config.py >> integration/microceph/docs/conf.py
 	cat .sphinx/_integration/add_config.py >> integration/microovn/docs/custom_conf.py
 	# Override the MicroOVN tag with the circle of friends one (for consistency)
 	cp .sphinx/_integration/tag.png integration/microovn/docs/.sphinx/_static/microovn.png


### PR DESCRIPTION
MicroCeph's recent adoption of the [Sphinx Starter Pack](https://github.com/canonical/sphinx-docs-starter-pack) meant changes to its config file to where our MicroCeph integration was no longer compatible. This PR updates our MicroCeph integration, including:
- Updates the Makefile to create folders that no longer exist in the standalone but are needed by the integration
- Updates the Makefile to use `conf.py` instead of `custom_conf.py` for the MicroCeph configuration file
- Adds a new `override-header.css` file because sphinx-starter-pack overwrites the `header.css` file (via the `canonical-sphinx` extension that it uses). This `override-header.css` file only includes the CSS rules we need to change, modified for higher specificity to override the sphinx-starter-pack's `header.css`. 
- Updates `add_config.py` to use new variable names in `conf.py`.