### PR TITLE
doc: ignore anchor titles in spellcheck

### DIFF
--- a/doc/.sphinx/spellingcheck.yaml
+++ b/doc/.sphinx/spellingcheck.yaml
@@ -29,3 +29,4 @@ matrix:
       - img
       - a.p-navigation__link
       - a.contributor
+      - a[title]


### PR DESCRIPTION
Anchor titles for intersphinx links (in the form of `<a ... title="in MicroCeph vv19.2.0-squid">`, for example) are affected by what other documentation sets put as the `Version` in their `objects.inv` metadata. This can cause spellcheck to fail, as seen [here](https://github.com/canonical/microcloud/actions/runs/15992724155/job/45109080075).

This PR prevents anchor titles from being checked in spellcheck, so that we don't have to spellcheck what intersphinx pulls into that title. Anchor titles are rarely used and this should have little to no impact otherwise. 
