### PR TITLE
Revert "doc: add vlatest to custom wordlist"

### DIFF
--- a/doc/.custom_wordlist.txt
+++ b/doc/.custom_wordlist.txt
@@ -66,7 +66,6 @@ TinyPNG
 uplink
 upstream's
 VLAN
-vlatest
 VM
 VMs
 VPC


### PR DESCRIPTION
This reverts one of the commits in https://github.com/canonical/microcloud/pull/839 as the links are now skipped generally.