### PR TITLE
CLI: Reject setup in case uplink network's gateway isn't set

### DIFF
--- a/cmd/microcloud/preseed.go
+++ b/cmd/microcloud/preseed.go
@@ -366,6 +366,10 @@ func (p *Preseed) validate(name string, bootstrap bool) error {
 
 		if system.UplinkInterface != "" {
 			uplinkCount++
+
+			if p.OVN.IPv4Gateway == "" && p.OVN.IPv6Gateway == "" && bootstrap {
+				return errors.New("Either the IPv4 or IPv6 gateway has to be set on the uplink network")
+			}
 		}
 
 		if system.UnderlayIP != "" {

--- a/cmd/tui/handler.go
+++ b/cmd/tui/handler.go
@@ -15,7 +15,15 @@ import (
 var ContextError error = tea.ErrProgramKilled
 
 // InvalidInputError is used to indicate false input to an asked question.
-var InvalidInputError func() = func() { PrintError("Invalid input, try again") }
+var InvalidInputError func(err error) = func(err error) {
+	errorMsg := "Invalid input, try again"
+
+	if err != nil {
+		PrintError(fmt.Sprintf("%s: %s", errorMsg, err.Error()))
+	} else {
+		PrintError(errorMsg)
+	}
+}
 
 // InputHandler handles input dialogs.
 type InputHandler struct {
@@ -121,7 +129,7 @@ func (i *InputHandler) AskBool(question string, defaultAnswer bool) (bool, error
 			return false, nil
 		}
 
-		InvalidInputError()
+		InvalidInputError(nil)
 	}
 }
 
@@ -145,7 +153,7 @@ func (i *InputHandler) AskString(question string, defaultAnswer string, validato
 		if validator != nil {
 			err = validator(answer)
 			if err != nil {
-				InvalidInputError()
+				InvalidInputError(err)
 				continue
 			}
 
@@ -156,6 +164,6 @@ func (i *InputHandler) AskString(question string, defaultAnswer string, validato
 			return answer, err
 		}
 
-		InvalidInputError()
+		InvalidInputError(nil)
 	}
 }

--- a/test/suites/instances.sh
+++ b/test/suites/instances.sh
@@ -187,6 +187,10 @@ systems:
     local:
       path: /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk1
       wipe: true
+ovn:
+  ipv4_gateway: 10.1.123.1/24
+  ipv4_range: 10.1.123.100-10.1.123.254
+  ipv6_gateway: fd42:1:1234:1234::1/64
 EOF
   )"
 


### PR DESCRIPTION
Not configuring the gateway on the uplink configures an OVN network without external connectivity.
Whilst that might be a valid use case, currently this is not really supported in LXD as you have to provide an uplink network even though it's not used.

Until this is supported in LXD, we simply don't allow this type of configuration.

Furthermore the asker's error message printer is modified to allow passing underlying errors to the user for better understanding why an input might be invalid.
