### PR TITLE
doc: fix sitemap URL scheme

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -137,7 +137,7 @@ html_baseurl = 'https://documentation.ubuntu.com/microcloud/'
 # based on the version if built in RTD
 if 'READTHEDOCS_VERSION' in os.environ:
     rtd_version = os.environ["READTHEDOCS_VERSION"]
-    sitemap_url_scheme = f'{rtd_version}/{{link}}'
+    sitemap_url_scheme = f'{rtd_version}/microcloud/{{link}}'
 else:
     sitemap_url_scheme = '{link}'
 


### PR DESCRIPTION
The sitemap URL scheme needs `/microcloud` to generate links correctly. Currently they are being generated like this:
```<loc>https://documentation.ubuntu.com/microcloud/latest/doc-cheat-sheet-myst/</loc>```
instead of
```<loc>https://documentation.ubuntu.com/microcloud/latest/microcloud/doc-cheat-sheet-myst/</loc>```