### PR TITLE
doc: linkcheck ignore sourceforge domain

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -167,6 +167,8 @@ linkcheck_ignore = [
     'http://localhost:8000',
     # These links may fail from time to time
     'https://ceph.io',
+    # Cloudflare protection on SourceForge domains often block linkcheck
+    r"https://.*\.sourceforge\.net/.*",
     ]
 
 # Pages on which to ignore anchors


### PR DESCRIPTION
`https://optipng.sourceforge.net` just started returning 403 Forbidden during linkcheck only; able to access via `curl` and in browser. 

Output from `curl -I https://optipng.sourceforge.net` shows Cloudflare as the `server` and a `set_cookie` of `__cf_bm` (see [Cloudflare docs on this cookie](https://developers.cloudflare.com/fundamentals/reference/policies-compliances/cloudflare-cookies/#__cf_bm-cookie-for-cloudflare-bot-products)):

```
HTTP/2 200 
date: Mon, 07 Jul 2025 21:11:54 GMT
content-type: text/html
vary: Accept-Encoding
vary: Host
vary: Accept-Encoding
last-modified: Fri, 23 May 2025 16:16:35 GMT
etag: W/"25c4-635cfec0c5ec0"
cache-control: max-age=3600
expires: Mon, 07 Jul 2025 22:11:46 GMT
x-from: sfp-ioweb82-4
cf-cache-status: DYNAMIC
set-cookie: __cf_bm=FMJl3f2ePElV1hnhqjFko6TR4H_GKpnNGQ1Bh9JE56o-1751922714-1.0.1.1-Nmq3aaOUxjlixwDx4RMcyu5tRvy3DmbMtc8knN7IFx8ab.gC60IQZ2qHcLHsS.Dvf4JMkzRAKs6l.1lYqRs6gLUj22wxIB5a_70ftagDOKw; path=/; expires=Mon, 07-Jul-25 21:41:54 GMT; domain=.sourceforge.net; HttpOnly; Secure; SameSite=None
content-security-policy: upgrade-insecure-requests
server: cloudflare
cf-ray: 95ba5642c9409869-PHX
alt-svc: h3=":443"; ma=86400
```

It's likely that increased bot protection rules are blocking linkcheck. This PR adds `sourceforge.net` to list of domains to exclude from linkcheck.