### PR TITLE
doc: linkcheck ignore cherrypicks (v2-edge)

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -150,6 +150,8 @@ linkcheck_ignore = [
     'http://localhost:8000',
     # These links may fail from time to time
     'https://ceph.io',
+    # Cloudflare protection on SourceForge domains often block linkcheck
+    r"https://.*\.sourceforge\.net/.*",
     ]
 
 # Pages on which to ignore anchors

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -147,7 +147,9 @@ redirects = {
 # Links to ignore when checking links
 linkcheck_ignore = [
     'http://127.0.0.1:8000',
-    'http://localhost:8000'
+    'http://localhost:8000',
+    # These links may fail from time to time
+    'https://ceph.io',
     ]
 
 # Pages on which to ignore anchors


### PR DESCRIPTION
Cherry-picks commits [7259265](https://github.com/canonical/microcloud/commit/7259265b09e5e9c034f146365d1d351262215ff5) and [f1893fa](https://github.com/canonical/microcloud/commit/f1893fa4407bc4d1781a887e20cf9b30f872620e) to add `ceph.io` and `sourceforge.net` to Sphinx's linkcheck_ignore list.