### PR TITLE
CLI: Consistent warning when skipping storage

### DIFF
--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -314,9 +314,7 @@ func (c *initConfig) askLocalPool(sh *service.Handler) error {
 	availableDisks := map[string]map[string]api.ResourcesStorageDisk{}
 	for name, state := range c.state {
 		if len(state.AvailableDisks) == 0 {
-			logger.Infof("Skipping local storage pool creation, peer %q has too few disks", name)
-
-			return nil
+			continue
 		}
 
 		if askSystems[name] {

--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -299,7 +299,7 @@ func (c *initConfig) askLocalPool(sh *service.Handler) error {
 	for _, info := range c.state {
 		hasPool, supportsPool := info.SupportsLocalPool()
 		if !supportsPool {
-			fmt.Println("Skipping local storage pool setup, some systems don't support it")
+			tui.PrintWarning("Skipping local storage pool setup. Some systems don't support it")
 
 			return nil
 		}
@@ -324,7 +324,7 @@ func (c *initConfig) askLocalPool(sh *service.Handler) error {
 
 	// Local storage is already set up on every system, or if not every system has a disk.
 	if len(askSystems) == 0 || len(availableDisks) != len(askSystems) {
-		fmt.Println("No disks available for local storage. Skipping configuration")
+		tui.PrintWarning("No disks available for local storage. Skipping configuration")
 
 		return nil
 	}


### PR DESCRIPTION
When no disks are available, MicroCloud notifies the user that neither local nor remote storage can be configured. For remote storage this was displayed to the user through a warning. Local storage was using a log message which is not directly visible to the user.

This PR ensures that both local and remote storage configuration consistently use the same warning message in case the configuration get skipped:

```bash
root@micro01:~# microcloud init
Waiting for services to start ...
Do you want to set up more than one cluster member? (yes/no) [default=yes]: no

 Using address 10.87.144.48 for MicroCloud

! Warning: Discovered non-LTS version "6.4" of LXD
Gathering system information ...
! Warning: No disks available for local storage. Skipping configuration
! Warning: No disks available for distributed storage. Skipping configuration
```