### PR TITLE
CLI: Ensure a clean unknown command help message

### DIFF
--- a/cmd/tui/style.go
+++ b/cmd/tui/style.go
@@ -114,7 +114,18 @@ func (*ColorErr) Write(p []byte) (n int, err error) {
 	// customized error prefix using tui styling.
 	withoutPrefixErr := strings.TrimPrefix(trimmedErr, "Error: ")
 
-	return os.Stderr.WriteString(SprintError(withoutPrefixErr))
+	// In all cases format the error using the standard error colors.
+	// But only append the error symbol in case the error prefix got set by the caller.
+	// When cobra calls the error's Write, it does it twice when crafting an unknown command's help message.
+	// The first line should yield our standard error using the symbol, but all of the following lines should
+	// not repeat the prefix using the symbol to keep the output clean.
+	if trimmedErr != withoutPrefixErr {
+		withoutPrefixErr = SprintError(withoutPrefixErr)
+	} else {
+		withoutPrefixErr = fmt.Sprintln(ErrorColor(withoutPrefixErr, false))
+	}
+
+	return os.Stderr.WriteString(withoutPrefixErr)
 }
 
 // PrintWarning calls Println but it appends "! Warning:" to the front of the message.


### PR DESCRIPTION
When cobra crafts an unknown command's help message, only the first line should use the prefix with error symbol:

![Screenshot from 2025-07-08 15-46-57](https://github.com/user-attachments/assets/c3b4e7be-6c2e-42ac-8151-362bae9f96a4)

Before such a message looked like this:

![Screenshot from 2025-07-08 15-49-27](https://github.com/user-attachments/assets/3e0ef954-eff3-48c8-ba16-42147f406c78)
