### PR TITLE
Service: Allow distributed storage config without adding new disks

### DIFF
--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -744,7 +744,6 @@ func (c *initConfig) askRemotePool(sh *service.Handler) error {
 			insufficientDisks = !useJoinConfigRemote && len(targetDisks) < RecommendedOSDHosts
 
 			if insufficientDisks {
-				// This error will be printed to STDOUT as a normal message, so it includes a new-line for readability.
 				return fmt.Errorf("Disk configuration does not meet recommendations for fault tolerance. At least %d systems must supply disks. Continuing with this configuration will inhibit MicroCloud's ability to retain data on system failure", RecommendedOSDHosts)
 			}
 

--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -582,7 +582,7 @@ func getTargetCephNetworks(sh *service.Handler, s *InitSystem) (publicCephNetwor
 }
 
 func (c *initConfig) askRemotePool(sh *service.Handler) error {
-	// If MicroCeph is not installed, skip this block entirely.
+	// If MicroCeph is not installed or an existing Ceph cluster should not be added, skip this block entirely.
 	if sh.Services[types.MicroCeph] == nil {
 		return nil
 	}

--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -706,115 +706,124 @@ func (c *initConfig) askRemotePool(sh *service.Handler) error {
 			return err
 		}
 
-		// Ask if the user is okay with fully remote ceph on some systems.
-		if len(askSystemsRemote) != availableDiskCount && wantsDisks {
-			warning := "Unable to find disks on some systems"
-			question := "Continue anyway?"
-			wantsDisks, err = c.asker.AskBoolWarn(warning, question, true)
-			if err != nil {
-				return err
-			}
-		}
+		if len(existingClusterDisks) > 0 && wantsDisks {
+			fmt.Println()
 
-		if !wantsDisks {
-			return nil
+			for target, disks := range existingClusterDisks {
+				if len(disks) > 0 {
+					fmt.Println(tui.SummarizeResult("Using %d disk(s) already setup on %s for remote storage pool", len(disks), target))
+				}
+			}
+
+			fmt.Println()
 		}
 
 		var insufficientDisks bool
-		err = c.askRetry("Change disk selection?", func() error {
-			selectedDisks = map[string][]string{}
-			wipeDisks = map[string]map[string]bool{}
-			header := []string{"LOCATION", "MODEL", "CAPACITY", "TYPE", "PATH"}
-			data := [][]string{}
-			for peer, disks := range availableDisks {
-				sortedDisks := []api.ResourcesStorageDisk{}
-				for _, disk := range disks {
-					sortedDisks = append(sortedDisks, disk)
-				}
 
-				// Ensure the list of disks is sorted by name.
-				sort.Slice(sortedDisks, func(i, j int) bool {
-					return service.FormatDiskPath(sortedDisks[i]) < service.FormatDiskPath(sortedDisks[j])
-				})
+		if availableDiskCount > 0 && wantsDisks {
+			err = c.askRetry("Change disk selection?", func() error {
+				selectedDisks = map[string][]string{}
+				wipeDisks = map[string]map[string]bool{}
+				header := []string{"LOCATION", "MODEL", "CAPACITY", "TYPE", "PATH"}
+				data := [][]string{}
+				for peer, disks := range availableDisks {
+					sortedDisks := []api.ResourcesStorageDisk{}
+					for _, disk := range disks {
+						sortedDisks = append(sortedDisks, disk)
+					}
 
-				for _, disk := range sortedDisks {
-					// Skip any disks that have been reserved for the local storage pool.
-					devicePath := service.FormatDiskPath(disk)
-					data = append(data, []string{peer, disk.Model, units.GetByteSizeStringIEC(int64(disk.Size), 2), disk.Type, devicePath})
-				}
-			}
+					// Ensure the list of disks is sorted by name.
+					sort.Slice(sortedDisks, func(i, j int) bool {
+						return service.FormatDiskPath(sortedDisks[i]) < service.FormatDiskPath(sortedDisks[j])
+					})
 
-			if len(data) == 0 {
-				return errors.New("Invalid disk configuration. Found no available disks")
-			}
-
-			sort.Sort(cli.SortColumnsNaturally(data))
-			var toWipe []map[string]string
-			table := tui.NewSelectableTable(header, data)
-			selected, err := table.Render(context.Background(), c.asker, "Select from the available unpartitioned disks:")
-			if err != nil {
-				return err
-			}
-
-			if len(selected) > 0 {
-				newRows := make([][]string, len(selected))
-				for row := range selected {
-					newRows[row] = make([]string, len(header))
-					for j, h := range header {
-						newRows[row][j] = selected[row][h]
+					for _, disk := range sortedDisks {
+						// Skip any disks that have been reserved for the local storage pool.
+						devicePath := service.FormatDiskPath(disk)
+						data = append(data, []string{peer, disk.Model, units.GetByteSizeStringIEC(int64(disk.Size), 2), disk.Type, devicePath})
 					}
 				}
 
-				toWipe, err = table.Render(context.Background(), c.asker, "Select which disks to wipe:", newRows...)
+				if len(data) == 0 {
+					return errors.New("Invalid disk configuration. Found no available disks")
+				}
+
+				sort.Sort(cli.SortColumnsNaturally(data))
+				var toWipe []map[string]string
+				table := tui.NewSelectableTable(header, data)
+				selected, err := table.Render(context.Background(), c.asker, "Select from the available unpartitioned disks:")
 				if err != nil {
 					return err
 				}
-			}
 
-			targetDisks := map[string][]string{}
-			for _, entry := range selected {
-				target := entry["LOCATION"]
-				path := entry["PATH"]
-				if targetDisks[target] == nil {
-					targetDisks[target] = []string{}
+				if len(selected) > 0 {
+					newRows := make([][]string, len(selected))
+					for row := range selected {
+						newRows[row] = make([]string, len(header))
+						for j, h := range header {
+							newRows[row][j] = selected[row][h]
+						}
+					}
+
+					toWipe, err = table.Render(context.Background(), c.asker, "Select which disks to wipe:", newRows...)
+					if err != nil {
+						return err
+					}
 				}
 
-				targetDisks[target] = append(targetDisks[target], path)
-			}
+				targetDisks := map[string][]string{}
+				for _, entry := range selected {
+					target := entry["LOCATION"]
+					path := entry["PATH"]
+					if targetDisks[target] == nil {
+						targetDisks[target] = []string{}
+					}
 
-			wipeDisks = map[string]map[string]bool{}
-			for _, entry := range toWipe {
-				target := entry["LOCATION"]
-				path := entry["PATH"]
-				if wipeDisks[target] == nil {
-					wipeDisks[target] = map[string]bool{}
+					targetDisks[target] = append(targetDisks[target], path)
 				}
 
-				wipeDisks[target][path] = true
+				wipeDisks = map[string]map[string]bool{}
+				for _, entry := range toWipe {
+					target := entry["LOCATION"]
+					path := entry["PATH"]
+					if wipeDisks[target] == nil {
+						wipeDisks[target] = map[string]bool{}
+					}
+
+					wipeDisks[target][path] = true
+				}
+
+				selectedDisks = targetDisks
+
+				// Error in case no disks were selected or there isn't an existing Ceph cluster with disks configured.
+				if len(targetDisks) == 0 && len(existingClusterDisks) == 0 {
+					return errors.New("No disks were selected")
+				}
+
+				insufficientDisks = !useJoinConfigRemote && len(targetDisks) < RecommendedOSDHosts
+
+				if insufficientDisks {
+					return fmt.Errorf("Disk configuration does not meet recommendations for fault tolerance. At least %d systems must supply disks. Continuing with this configuration will inhibit MicroCloud's ability to retain data on system failure", RecommendedOSDHosts)
+				}
+
+				return nil
+			})
+			if err != nil {
+				return err
 			}
-
-			selectedDisks = targetDisks
-
-			if len(targetDisks) == 0 {
-				return errors.New("No disks were selected")
-			}
-
-			insufficientDisks = !useJoinConfigRemote && len(targetDisks) < RecommendedOSDHosts
-
-			if insufficientDisks {
-				return fmt.Errorf("Disk configuration does not meet recommendations for fault tolerance. At least %d systems must supply disks. Continuing with this configuration will inhibit MicroCloud's ability to retain data on system failure", RecommendedOSDHosts)
-			}
-
-			return nil
-		})
-		if err != nil {
-			return err
 		}
 
-		if len(selectedDisks) == 0 {
+		if len(selectedDisks) == 0 && len(existingClusterDisks) == 0 {
+			// Skip distributed storage if there are neither disks selected nor is there an existing cluster with disks configured.
 			return nil
-		} else {
-			fmt.Println()
+		} else if len(selectedDisks) > 0 {
+			// Print the newline only in case we haven't printed the notification about
+			// already existing disks for the remote storage pool.
+			// If we are reusing disks and also adding new ones, the two sections
+			// should only be separated by a single new line.
+			if len(existingClusterDisks) == 0 {
+				fmt.Println()
+			}
 
 			for target, disks := range selectedDisks {
 				if len(disks) > 0 {

--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -695,7 +695,7 @@ func (c *initConfig) askRemotePool(sh *service.Handler) error {
 			}
 		}
 
-		if availableDiskCount == 0 {
+		if availableDiskCount == 0 && len(existingClusterDisks) == 0 {
 			tui.PrintWarning("No disks available for distributed storage. Skipping configuration")
 
 			return nil

--- a/test/includes/microcloud.sh
+++ b/test/includes/microcloud.sh
@@ -34,7 +34,8 @@ microcloud_interactive() {
   SETUP_ZFS=${SETUP_ZFS:-}                       # (yes/no) input for initiating ZFS storage pool setup.
   ZFS_FILTER=${ZFS_FILTER:-}                     # filter string for ZFS disks.
   ZFS_WIPE=${ZFS_WIPE:-}                         # (yes/no) to wipe all disks.
-  SETUP_CEPH=${SETUP_CEPH:-}                     # (yes/no) input for initiating CEPH storage pool setup.
+  SETUP_CEPH=${SETUP_CEPH:-}                     # (yes/no) input for initiating Ceph storage pool setup.
+  SKIP_CEPH_DISKS=${SKIP_CEPH_DISKS:-}           # (yes/no) input to skip adding additional Ceph disks and only reuse the existing cluster and its disks.
   SETUP_CEPHFS=${SETUP_CEPHFS:-}                 # (yes/no) input for initialising CephFS storage pool setup.
   CEPH_FILTER=${CEPH_FILTER:-}                   # filter string for CEPH disks.
   CEPH_WIPE=${CEPH_WIPE:-}                       # (yes/no) to wipe all disks.
@@ -103,18 +104,26 @@ fi
 if [ -n "${SETUP_CEPH}" ]; then
   setup="${setup}
 ${SETUP_CEPH}                                           # add remote disks (yes/no)
-$([ "${SETUP_CEPH}" = "yes" ] && printf "table:wait 300ms")   # wait for the table to populate
+"
+  if [ "${SKIP_CEPH_DISKS}" != "yes" ]; then
+    setup="${setup}
+$([ "${SETUP_CEPH}" = "yes" ] && printf "table:wait 300ms")       # wait for the table to populate
 $([ -n "${CEPH_FILTER}" ] && printf "table:filter %s" "${CEPH_FILTER}")          # filter ceph disks
-$([ "${SETUP_CEPH}" = "yes" ] && printf "table:select-all")   # select all disk matching the filter
+$([ "${SETUP_CEPH}" = "yes" ] && printf "table:select-all")       # select all disk matching the filter
 $([ "${SETUP_CEPH}" = "yes" ] && printf -- "table:done")
-$([ "${CEPH_WIPE}"  = "yes" ] && printf "table:select-all")   # wipe all disks
+$([ "${CEPH_WIPE}"  = "yes" ] && printf "table:select-all")       # wipe all disks
 $([ "${SETUP_CEPH}" = "yes" ] && printf -- "table:done")
 $([ "${SETUP_CEPH}" = "yes" ] && printf "%s" "${CEPH_RETRY_HA}" ) # allow ceph setup without 3 systems supplying disks.
-${CEPH_ENCRYPT}                                         # encrypt disks? (yes/no)
+$(true)                                                           # workaround for set -e
+"
+  fi
+
+  setup="${setup}
+${CEPH_ENCRYPT}                                                          # encrypt disks? (yes/no)
 ${SETUP_CEPHFS}
 $([ "${SETUP_CEPH}" = "yes" ] && printf "%s" "${CEPH_CLUSTER_NETWORK}" ) # set ceph cluster network
 $([ "${SETUP_CEPH}" = "yes" ] && printf "%s" "${CEPH_PUBLIC_NETWORK}" )  # set ceph public network
-$(true)                                                 # workaround for set -e
+$(true)                                                                  # workaround for set -e
 "
 fi
 

--- a/test/includes/microcloud.sh
+++ b/test/includes/microcloud.sh
@@ -4,7 +4,7 @@
 unset_interactive_vars() {
   unset SKIP_LOOKUP LOOKUP_IFACE SKIP_SERVICE EXPECT_PEERS PEERS_FILTER REUSE_EXISTING REUSE_EXISTING_COUNT \
     SETUP_ZFS ZFS_FILTER ZFS_WIPE \
-    SETUP_CEPH CEPH_MISSING_DISKS CEPH_FILTER CEPH_WIPE CEPH_ENCRYPT SETUP_CEPHFS CEPH_CLUSTER_NETWORK CEPH_PUBLIC_NETWORK \
+    SETUP_CEPH CEPH_FILTER CEPH_WIPE CEPH_ENCRYPT SETUP_CEPHFS CEPH_CLUSTER_NETWORK CEPH_PUBLIC_NETWORK \
     PROCEED_WITH_NO_OVERLAY_NETWORKING SETUP_OVN OVN_UNDERLAY_NETWORK OVN_UNDERLAY_FILTER OVN_WARNING OVN_FILTER IPV4_SUBNET IPV4_START IPV4_END DNS_ADDRESSES IPV6_SUBNET \
     REPLACE_PROFILE CEPH_RETRY_HA MULTI_NODE
 }
@@ -36,7 +36,6 @@ microcloud_interactive() {
   ZFS_WIPE=${ZFS_WIPE:-}                         # (yes/no) to wipe all disks.
   SETUP_CEPH=${SETUP_CEPH:-}                     # (yes/no) input for initiating CEPH storage pool setup.
   SETUP_CEPHFS=${SETUP_CEPHFS:-}                 # (yes/no) input for initialising CephFS storage pool setup.
-  CEPH_MISSING_DISKS=${CEPH_MISSING_DISKS:-}     # (yes/no) input for warning about eligible disk detection.
   CEPH_FILTER=${CEPH_FILTER:-}                   # filter string for CEPH disks.
   CEPH_WIPE=${CEPH_WIPE:-}                       # (yes/no) to wipe all disks.
   CEPH_RETRY_HA=${CEPH_RETRY_HA:-}                     # (yes/no) input for warning setup is not HA.
@@ -104,7 +103,6 @@ fi
 if [ -n "${SETUP_CEPH}" ]; then
   setup="${setup}
 ${SETUP_CEPH}                                           # add remote disks (yes/no)
-${CEPH_MISSING_DISKS}                                   # continue with some peers missing disks? (yes/no)
 $([ "${SETUP_CEPH}" = "yes" ] && printf "table:wait 300ms")   # wait for the table to populate
 $([ -n "${CEPH_FILTER}" ] && printf "table:filter %s" "${CEPH_FILTER}")          # filter ceph disks
 $([ "${SETUP_CEPH}" = "yes" ] && printf "table:select-all")   # select all disk matching the filter

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -740,7 +740,6 @@ test_disk_mismatch() {
   export ZFS_WIPE="yes"
   export SETUP_CEPH="yes"
   export SETUP_CEPHFS="yes"
-  export CEPH_MISSING_DISKS="yes"
   export CEPH_WIPE="yes"
   export CEPH_ENCRYPT="no"
   export SETUP_OVN="no"

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -885,6 +885,43 @@ test_reuse_cluster() {
   bootstrap_microceph micro03
   ! join_session init micro01 micro02 micro03 || false
   lxc exec micro01 -- tail -1 out | grep "Some systems are already part of different MicroCeph clusters. Aborting initialization" -q
+
+  reset_systems 3 2 3
+  echo "Create a MicroCloud that re-uses an existing MicroCeph with disks already setup to configure distributed storage"
+  unset_interactive_vars
+
+  export MULTI_NODE="yes"
+  export LOOKUP_IFACE="enp5s0"
+  export EXPECT_PEERS=2
+  export REUSE_EXISTING_COUNT=1
+  export REUSE_EXISTING="yes"
+  export SETUP_ZFS="yes"
+  export ZFS_FILTER="lxd_disk1"
+  export ZFS_WIPE="yes"
+  export SETUP_CEPH="yes"
+  export SKIP_CEPH_DISKS="yes"
+  export SETUP_CEPHFS="yes"
+  export SETUP_OVN="yes"
+  export OVN_FILTER="enp6s0"
+  export IPV4_SUBNET="10.1.123.1/24"
+  export IPV4_START="10.1.123.100"
+  export IPV4_END="10.1.123.254"
+  export DNS_ADDRESSES="10.1.123.1,8.8.8.8"
+  export IPV6_SUBNET="fd42:1:1234:1234::1/64"
+  export OVN_UNDERLAY_NETWORK="no"
+
+  bootstrap_microceph micro01
+  for m in micro02 micro03; do
+    token="$(lxc exec micro01 -- microceph cluster add "${m}")"
+    lxc exec "${m}" -- microceph cluster join "${token}"
+  done
+
+  for m in micro01 micro02 micro03; do
+    lxc exec "${m}" -- microceph disk add /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk2
+  done
+
+  join_session init micro01 micro02 micro03
+  services_validator
 }
 
 test_remove_cluster() {


### PR DESCRIPTION
Preceded by:
* https://github.com/canonical/microcloud/pull/864
* https://github.com/canonical/microcloud/pull/863

Fixes https://github.com/canonical/microcloud/issues/812.

The PR ensures that an existing (configured) MicroCeph cluster can be reused by MicroCloud without the need of having to add additional disks during the process.

In a scenario with multiple nodes running MicroCeph, a user might decide to leverage the MicroCeph cluster which is already configured with OSDs for MicroCloud. MicroCloud allows this re-use and asks during the interactive questionnaire if the user wants to reuse this existing cluster.
However until now MicroCloud required to add additional disks (OSDs) to be able to include this existing cluster.
This limitation is now removed and the re-use of disks is made more transparent to the user by printing the already configured disks if the user decides to re-use the existing MicroCeph cluster.