### PR TITLE
doc: backport config and URL updates (v2-edge)

### DIFF
--- a/doc/.sphinx/_integration/add_config.py
+++ b/doc/.sphinx/_integration/add_config.py
@@ -13,7 +13,7 @@ html_context['microovn_tag'] = "../microovn/_static/microovn.png"
 custom_html_js_files.append('rtd-search.js')
 
 if project == "LXD":
-    html_baseurl = "https://documentation.ubuntu.com/lxd/en/latest/"
+    html_baseurl = "https://documentation.ubuntu.com/lxd/stable-5.21/"
 elif project == "MicroCeph":
     html_baseurl = "https://canonical-microceph.readthedocs-hosted.com/en/latest/"
 elif project == "MicroOVN":

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -50,7 +50,7 @@ copyright = '%s, %s' % (datetime.date.today().year, author)
 # don't know yet)
 # NOTE: If no ogp_* variable is defined (e.g. if you remove this section) the
 # sphinxext.opengraph extension will be disabled.
-ogp_site_url = 'https://canonical-microcloud.readthedocs-hosted.com/en/latest/'
+ogp_site_url = 'https://documentation.ubuntu.com/microcloud/'
 # The documentation website name (usually the same as the product name)
 ogp_site_name = project
 # The URL of an image or logo that is used in the preview
@@ -122,7 +122,7 @@ html_context = {
 
 # If your project is on documentation.ubuntu.com, specify the project
 # slug (for example, "lxd") here.
-slug = ""
+slug = "microcloud"
 
 ############################################################
 ### Redirects

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -124,6 +124,22 @@ html_context = {
 # slug (for example, "lxd") here.
 slug = "microcloud"
 
+#######################
+# Sitemap configuration: https://sphinx-sitemap.readthedocs.io/
+#######################
+
+# Base URL of RTD hosted project
+
+html_baseurl = 'https://documentation.ubuntu.com/microcloud/'
+
+# Configures URL scheme for sphinx-sitemap to generate correct URLs
+# based on the version if built in RTD
+if 'READTHEDOCS_VERSION' in os.environ:
+    rtd_version = os.environ["READTHEDOCS_VERSION"]
+    sitemap_url_scheme = f'{rtd_version}/{{link}}'
+else:
+    sitemap_url_scheme = '{link}'
+
 ############################################################
 ### Redirects
 ############################################################
@@ -197,6 +213,7 @@ custom_extensions = [
     'canonical.terminal-output',
     'notfound.extension',
     'sphinx.ext.intersphinx',
+    'sphinx_sitemap',
     ]
 
 # Add custom required Python modules that must be added to the
@@ -206,7 +223,9 @@ custom_extensions = [
 # pyspelling, sphinx, sphinx-autobuild, sphinx-copybutton, sphinx-design,
 # sphinx-notfound-page, sphinx-reredirects, sphinx-tabs, sphinxcontrib-jquery,
 # sphinxext-opengraph
-custom_required_modules = []
+custom_required_modules = [
+    'sphinx-sitemap',
+]
 
 # Add files or directories that should be excluded from processing.
 custom_excludes = [

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -136,7 +136,7 @@ html_baseurl = 'https://documentation.ubuntu.com/microcloud/'
 # based on the version if built in RTD
 if 'READTHEDOCS_VERSION' in os.environ:
     rtd_version = os.environ["READTHEDOCS_VERSION"]
-    sitemap_url_scheme = f'{rtd_version}/{{link}}'
+    sitemap_url_scheme = f'{rtd_version}/microcloud/{{link}}'
 else:
     sitemap_url_scheme = '{link}'
 

--- a/doc/how-to/recover.md
+++ b/doc/how-to/recover.md
@@ -8,7 +8,7 @@ similar for each service, this document only covers cluster recovery for the
 `microcloudd` daemon. For cluster recovery procedures for LXD, MicroCeph and
 MicroOVN, see:
 
-- [LXD Cluster Recovery](https://documentation.ubuntu.com/lxd/en/latest/howto/cluster_recover/)
+- {ref}`How to recover a LXD cluster <lxd:cluster-recover>`
 - [MicroOVN Launchpad Bug](https://bugs.launchpad.net/microovn/+bug/2072377)
 - [MicroCeph Issue](https://github.com/canonical/microceph/issues/380)
 ```

--- a/test/e2e/run
+++ b/test/e2e/run
@@ -22,7 +22,7 @@ init() {
 
     if ! remoteAccessible; then
         echo "The ${REMOTE}: remote is not usable." >&2
-        echo "Please see https://documentation.ubuntu.com/lxd/en/latest/howto/server_expose/#authenticate-with-the-lxd-server" >&2
+        echo "Please see https://documentation.ubuntu.com/lxd/stable-5.21/howto/server_expose/#authenticate-with-the-lxd-server" >&2
         exit 1
     fi
 


### PR DESCRIPTION
This PR cherry-picks the following commits from `main` to v2-edge`:
* `9d17880` update absolute URL links to LXD docs
* `e5f96c2` doc: update config for move to documentation.ubuntu.com
* `125f226` doc: fix sitemap URL scheme
* `808f420` doc: add sphinx-sitemap to generate sitemap for SEO

A few manual edits were added to use URLs corresponding to the v2-edge docs version (e.g., `stable-5.21` instead of `latest` docs version for LXD)