### PR TITLE
CLI: Fix profile replacement for storage pools

### DIFF
--- a/cmd/microcloud/main_init.go
+++ b/cmd/microcloud/main_init.go
@@ -667,6 +667,12 @@ func (c *initConfig) setupCluster(s *service.Handler) error {
 		}
 	}
 
+	for _, pool := range system.StoragePools {
+		if pool.Driver == "ceph" || profile.Devices["root"] == nil {
+			profile.Devices["root"] = map[string]string{"path": "/", "pool": pool.Name, "type": "disk"}
+		}
+	}
+
 	newProfile, err := c.askUpdateProfile(profile, profiles, lxdClient)
 	if err != nil {
 		return err
@@ -940,10 +946,6 @@ func (c *initConfig) setupCluster(s *service.Handler) error {
 
 	cephFSPool := lxdAPI.StoragePoolsPost{}
 	for _, pool := range system.StoragePools {
-		if pool.Driver == "ceph" || profile.Devices["root"] == nil {
-			profile.Devices["root"] = map[string]string{"path": "/", "pool": pool.Name, "type": "disk"}
-		}
-
 		// Ensure the cephfs pool is created after the ceph pool so we set up crush rules.
 		if pool.Driver == "cephfs" {
 			cephFSPool = pool

--- a/test/includes/microcloud.sh
+++ b/test/includes/microcloud.sh
@@ -634,17 +634,17 @@ validate_system_lxd() {
     if [ -n "${profile_pool}" ]; then
       lxc profile device get default root pool | grep -q "${profile_pool}"
     elif [ "${has_microceph}" = 1 ] && [ "${remote_disks}" -gt 0 ] ; then
-       lxc profile device get default root pool | grep -q "remote"
+      lxc profile device get default root pool | grep -q "remote"
     elif [ -n "${local_disk}" ] ; then
-       lxc profile device get default root pool | grep -q "local"
+      lxc profile device get default root pool | grep -q "local"
     else
-       ! lxc profile device list default | grep -q "root" || false
+      ! lxc profile device list default | grep -q "root" || false
     fi
 
     if [ "${has_microovn}" = 1 ] && [ -n "${ovn_interface}" ] ; then
-       lxc profile device get default eth0 network | grep -q "default"
+      lxc profile device get default eth0 network | grep -q "default"
     else
-       lxc profile device get default eth0 network | grep -q "lxdfan0"
+      lxc profile device get default eth0 network | grep -q "lxdfan0"
     fi
 
     # Only check these if MicroCloud is at least > 2.1.0.

--- a/test/includes/microcloud.sh
+++ b/test/includes/microcloud.sh
@@ -580,6 +580,7 @@ validate_system_lxd() {
     ipv4_ranges=${8:-}
     ipv6_gateway=${9:-}
     dns_namesersers=${10:-}
+    profile_pool=${11:-}
 
     echo "==> ${name} Validating LXD with ${num_peers} peers"
     echo "    ${name} Local Disk: {${local_disk}}, Remote Disks: {${remote_disks}}, OVN Iface: {${ovn_interface}}"
@@ -630,7 +631,9 @@ validate_system_lxd() {
     fi
 
     echo "    ${name} Validating Profiles"
-    if [ "${has_microceph}" = 1 ] && [ "${remote_disks}" -gt 0 ] ; then
+    if [ -n "${profile_pool}" ]; then
+      lxc profile device get default root pool | grep -q "${profile_pool}"
+    elif [ "${has_microceph}" = 1 ] && [ "${remote_disks}" -gt 0 ] ; then
        lxc profile device get default root pool | grep -q "remote"
     elif [ -n "${local_disk}" ] ; then
        lxc profile device get default root pool | grep -q "local"

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -761,11 +761,14 @@ test_disk_mismatch() {
 }
 
 # services_validator: A basic validator of 3 systems with typical expected inputs.
+# An optional pool name can be provided which has to be present in the default profile's root device.
 services_validator() {
+  profile_pool="${1:-}"
+
   for m in micro01 micro02 micro03 ; do
-    validate_system_lxd ${m} 3 disk1 1 1 enp6s0 10.1.123.1/24 10.1.123.100-10.1.123.254 fd42:1:1234:1234::1/64 10.1.123.1,8.8.8.8
-    validate_system_microceph ${m} 1 disk2
-    validate_system_microovn ${m}
+    validate_system_lxd "${m}" 3 disk1 1 1 enp6s0 10.1.123.1/24 10.1.123.100-10.1.123.254 fd42:1:1234:1234::1/64 10.1.123.1,8.8.8.8 "${profile_pool}"
+    validate_system_microceph "${m}" 1 disk2
+    validate_system_microovn "${m}"
   done
 }
 

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -1099,7 +1099,9 @@ test_add_services() {
   unset SETUP_OVN
   export REPLACE_PROFILE="no"
   microcloud_interactive "service add" micro01
-  services_validator
+  # The initial cluster got setup with only local storage.
+  # Due to REPLACE_PROFILE="no" the default profile's device doesn't get replaced.
+  services_validator local
 
   reset_systems 3 3 3
   set_cluster_subnet 3  "${ceph_cluster_subnet_iface}" "${ceph_cluster_subnet_prefix}"


### PR DESCRIPTION
Preceded by https://github.com/canonical/microcloud/pull/864

The question to ask for profile device replacement was only applicable for networks because the storage section was missed when migrating the code into a helper in https://github.com/canonical/microcloud/commit/29764bcd6a4e54819a2a575f657970cfb7cc7f7a.
This had the effect that only in case distributed network got configured the question got asked to replace the FAN with OVN network.
However when configuring distributed storage the profile's root device got replaced in any case without asking the user.

Another check is added in this PR to explicitly check the behavior which went unnoticed when refactoring the code.