### PR TITLE
Storage: Fix backup and image vols for new systems

### DIFF
--- a/cmd/microcloud/main_init.go
+++ b/cmd/microcloud/main_init.go
@@ -990,16 +990,19 @@ func (c *initConfig) setupCluster(s *service.Handler) error {
 		}
 
 		poolNames := []string{}
-		if len(system.TargetStoragePools) > 0 {
-			for _, pool := range system.TargetStoragePools {
-				poolNames = append(poolNames, pool.Name)
-			}
-		} else {
-			for _, cfg := range system.JoinConfig {
-				if cfg.Name == "local" || cfg.Name == "remote" {
-					if cfg.Entity == "storage-pool" && cfg.Key == "source" {
-						poolNames = append(poolNames, cfg.Name)
-					}
+
+		// In case any storage pools are marked for initial setup,
+		// add them to the list of available storage pool names.
+		for _, pool := range system.TargetStoragePools {
+			poolNames = append(poolNames, pool.Name)
+		}
+
+		// When joining the selected system, it can grow either the local or remote storage pool.
+		// In this case add the pool's name to the list of available storage pools.
+		for _, cfg := range system.JoinConfig {
+			if cfg.Name == "local" || cfg.Name == "remote" {
+				if cfg.Entity == "storage-pool" && cfg.Key == "source" {
+					poolNames = append(poolNames, cfg.Name)
 				}
 			}
 		}

--- a/test/suites/add.sh
+++ b/test/suites/add.sh
@@ -91,6 +91,7 @@ test_add_interactive() {
   for m in micro01 micro02 micro03 ; do
     lxc exec "${m}" -- snap disable microovn || true
     lxc exec "${m}" -- snap disable microceph || true
+    lxc exec "${m}" -- snap restart microcloud
   done
 
   lxc exec micro04 -- snap disable microcloud

--- a/test/suites/add.sh
+++ b/test/suites/add.sh
@@ -118,7 +118,7 @@ test_add_interactive() {
   done
 
   reset_systems 4 2 1
-  echo "Test growing a MicroCloud when storage & networks were not already set up"
+  echo "Test growing a MicroCloud when remote storage & networks were not already set up"
   unset_interactive_vars
   export MULTI_NODE="yes"
   export LOOKUP_IFACE="enp5s0"

--- a/test/suites/add.sh
+++ b/test/suites/add.sh
@@ -168,4 +168,63 @@ test_add_interactive() {
     validate_system_microceph "${m}" 1 "${default_cluster_subnet}" disk2
     validate_system_microovn "${m}"
   done
+
+  reset_systems 4 2 1
+  echo "Test growing a MicroCloud when remote storage was not already set up (REPLACE_PROFILE=yes)"
+  unset_interactive_vars
+  export MULTI_NODE="yes"
+  export LOOKUP_IFACE="enp5s0"
+  export EXPECT_PEERS=2
+  export SETUP_ZFS="yes"
+  export ZFS_FILTER="lxd_disk1"
+  export ZFS_WIPE="yes"
+  export SETUP_CEPH="no"
+  export SETUP_OVN="yes"
+  export OVN_FILTER="enp6s0"
+  export IPV4_SUBNET="10.1.123.1/24"
+  export IPV4_START="10.1.123.100"
+  export IPV4_END="10.1.123.254"
+  export IPV6_SUBNET="fd42:1:1234:1234::1/64"
+  export DNS_ADDRESSES="10.1.123.1,fd42:1:1234:1234::1"
+  export OVN_UNDERLAY_NETWORK="no"
+
+  join_session init micro01 micro02 micro03
+  lxc exec micro01 -- tail -1 out | grep "MicroCloud is ready" -q
+
+  for m in micro01 micro02 micro03; do
+    validate_system_lxd "${m}" 3 disk1 0 0 enp6s0 10.1.123.1/24 10.1.123.100-10.1.123.254 fd42:1:1234:1234::1/64 10.1.123.1,fd42:1:1234:1234::1
+    validate_system_microceph "${m}"
+    validate_system_microovn "${m}"
+  done
+
+  unset_interactive_vars
+  export EXPECT_PEERS=1
+  export SETUP_ZFS="yes"
+  export ZFS_FILTER="lxd_disk1"
+  export ZFS_WIPE="yes"
+  export SETUP_CEPH="yes"
+  export SETUP_CEPHFS="yes"
+  export CEPH_WIPE="yes"
+  export CEPH_ENCRYPT="no"
+  export SETUP_OVN="yes"
+  export OVN_FILTER="enp6s0"
+  export OVN_UNDERLAY_NETWORK="no"
+  export REPLACE_PROFILE="yes"
+
+  # Join the fourth MicroCloud which allows reiterating on the storage/network question and
+  # setting it up for the entire cluster (new and existing cluster members).
+  join_session add micro01 micro04
+  lxc exec micro01 -- tail -1 out | grep "MicroCloud is ready" -q
+  lxc exec micro04 -- tail -2 out | head -1 | grep "Successfully joined the MicroCloud cluster and closing the session" -q
+
+  # Check the new system micro04 has the storage.* config keys set.
+  # validate_system_lxd cannot be used for this check as the profile's storage was overwritten to the remote pool.
+  [ "$(lxc exec micro04 -- lxc config get storage.backups_volume)" == "local/backups" ]
+  [ "$(lxc exec micro04 -- lxc config get storage.images_volume)" == "local/images" ]
+
+  default_cluster_subnet="$(lxc exec micro01 -- ip -4 -br a show enp5s0 | awk '{print $3}')"
+  for m in micro01 micro02 micro03 micro04 ; do
+    validate_system_lxd "${m}" 4 disk1 1 1 enp6s0 10.1.123.1/24 10.1.123.100-10.1.123.254 fd42:1:1234:1234::1/64 10.1.123.1,fd42:1:1234:1234::1
+    validate_system_microceph "${m}" 1 "${default_cluster_subnet}" disk2
+  done
 }

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -328,6 +328,7 @@ test_interactive() {
   lxc exec micro03 -- snap disable microcloud || true
   for m in micro01 micro02 ; do
     lxc exec "${m}" -- snap disable microovn
+    lxc exec "${m}" -- snap restart microcloud
   done
 
   unset_interactive_vars
@@ -348,6 +349,7 @@ test_interactive() {
   lxc exec micro01 -- tail -1 out | grep "MicroCloud is ready" -q
   for m in micro01 micro02 ; do
     lxc exec "${m}" -- snap enable microovn
+    lxc exec "${m}" -- snap restart microcloud
   done
 
   lxc exec micro03 -- microovn cluster bootstrap
@@ -667,8 +669,10 @@ test_service_mismatch() {
   # Install the remaining services on the other systems.
   lxc exec micro02 -- snap enable microceph
   lxc exec micro02 -- snap enable microovn
+  lxc exec micro02 -- snap restart microcloud
   lxc exec micro03 -- snap enable microceph
   lxc exec micro03 -- snap enable microovn
+  lxc exec micro03 -- snap restart microcloud
 
   # Init should now work.
   echo "Creating a MicroCloud with MicroCeph and MicroOVN, but without their LXD devices"
@@ -968,6 +972,7 @@ test_remove_cluster_member() {
 
   reset_systems 3 3 3
   lxc exec micro01 -- snap disable microceph
+  lxc exec micro01 -- snap restart microcloud
   echo "Create a MicroCloud and remove a node from all services"
   join_session init micro01 micro02 micro03
 
@@ -990,6 +995,7 @@ test_remove_cluster_member() {
 
   reset_systems 3 3 3
   lxc exec micro01 -- snap disable microceph
+  lxc exec micro01 -- snap restart microcloud
   echo "Create a MicroCloud and remove a node from all services, but manually remove it from the MicroCloud daemon first"
   join_session init micro01 micro02 micro03
 
@@ -1021,6 +1027,7 @@ test_remove_cluster_member() {
 
   reset_systems 3 3 3
   lxc exec micro01 -- snap disable microceph
+  lxc exec micro01 -- snap restart microcloud
   echo "Create a MicroCloud and fail to remove a non-existent member"
   join_session init micro01 micro02 micro03
 
@@ -1076,10 +1083,12 @@ test_add_services() {
   set_cluster_subnet 3  "${ceph_public_subnet_iface}" "${ceph_public_subnet_prefix}"
   echo Add MicroCeph to MicroCloud that was set up without it, and setup remote storage without updating the profile.
   lxc exec micro01 -- snap disable microceph
+  lxc exec micro01 -- snap restart microcloud
   unset SETUP_CEPH
   export SKIP_SERVICE="yes"
   join_session init micro01 micro02 micro03
   lxc exec micro01 -- snap enable microceph
+  lxc exec micro01 -- snap restart microcloud
   export SETUP_CEPH="yes"
   export SKIP_LOOKUP=1
   unset MULTI_NODE
@@ -1094,6 +1103,7 @@ test_add_services() {
   set_cluster_subnet 3  "${ceph_public_subnet_iface}" "${ceph_public_subnet_prefix}"
   echo Add MicroCeph to MicroCloud that was set up without it, and setup remote storage.
   lxc exec micro01 -- snap disable microceph
+  lxc exec micro01 -- snap restart microcloud
   unset SETUP_CEPH
   unset REPLACE_PROFILE
   unset SKIP_LOOKUP
@@ -1103,6 +1113,7 @@ test_add_services() {
   export SETUP_OVN="yes"
   join_session init micro01 micro02 micro03
   lxc exec micro01 -- snap enable microceph
+  lxc exec micro01 -- snap restart microcloud
   export SETUP_CEPH="yes"
   export SKIP_LOOKUP=1
   unset MULTI_NODE
@@ -1118,11 +1129,13 @@ test_add_services() {
 
   echo Add MicroOVN to MicroCloud that was set up without it, and setup ovn network
   lxc exec micro01 -- snap disable microovn
+  lxc exec micro01 -- snap restart microcloud
   export MULTI_NODE="yes"
   export SETUP_ZFS="yes"
   unset SKIP_LOOKUP
   join_session init micro01 micro02 micro03
   lxc exec micro01 -- snap enable microovn
+  lxc exec micro01 -- snap restart microcloud
   export SETUP_OVN="yes"
   export SKIP_LOOKUP=1
   unset MULTI_NODE
@@ -1138,6 +1151,7 @@ test_add_services() {
   echo Add both MicroOVN and MicroCeph to a MicroCloud that was set up without it
   lxc exec micro01 -- snap disable microovn
   lxc exec micro01 -- snap disable microceph
+  lxc exec micro01 -- snap restart microcloud
   export MULTI_NODE="yes"
   export SETUP_ZFS="yes"
   unset SKIP_LOOKUP
@@ -1145,6 +1159,7 @@ test_add_services() {
   join_session init micro01 micro02 micro03
   lxc exec micro01 -- snap enable microovn
   lxc exec micro01 -- snap enable microceph
+  lxc exec micro01 -- snap restart microcloud
   export SETUP_OVN="yes"
   export SETUP_CEPH="yes"
   export SKIP_LOOKUP=1
@@ -1159,6 +1174,7 @@ test_add_services() {
 
   echo Reuse a MicroCeph that was set up on one node of the MicroCloud
   lxc exec micro01 -- snap disable microceph
+  lxc exec micro01 -- snap restart microcloud
   bootstrap_microceph micro02
   export MULTI_NODE="yes"
   export SETUP_ZFS="yes"
@@ -1166,6 +1182,7 @@ test_add_services() {
   unset SKIP_LOOKUP
   join_session init micro01 micro02 micro03
   lxc exec micro01 -- snap enable microceph
+  lxc exec micro01 -- snap restart microcloud
   export REUSE_EXISTING_COUNT=1
   export REUSE_EXISTING="yes"
   export SETUP_CEPH="yes"

--- a/test/suites/preseed.sh
+++ b/test/suites/preseed.sh
@@ -180,6 +180,7 @@ EOF
   # Create a MicroCloud if we don't have MicroOVN or MicroCeph installed.
   lxc exec micro01 -- snap disable microceph
   lxc exec micro01 -- snap disable microovn
+  lxc exec micro01 -- snap restart microcloud
   sleep 1
 
   preseed="$(cat << EOF


### PR DESCRIPTION
This fixes a bug when adding new systems to MicroCloud.

If the already existing MicroCloud only has local storage configured, you can decide to configure distributed storage when adding new systems.
In this situation the new systems haven't had their LXD `storage.images_volume` and `storage.backups_volume` settings configured due to a limitation which was setup by MicroCloud which either tracked new or existing pool's.

Another test is added to explicitly check this behavior.
Also a race when enabling optional services is fixed by adding a consequent restart of MicroCloud (see last commit).