### PR TITLE
GitHub: Split tests into smaller suites

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -149,15 +149,19 @@ jobs:
         # Define this first in the matrix so that it's readable
         # after GitHub as formed the name for the respective check.
         suite:
-          - "add"
+          - "add_interactive"
+          - "add_services"
+          - "cluster_manager"
           - "e2e"
           - "instances"
-          - "basic"
-          - "recover"
           - "interactive"
+          - "interactive_combinations"
           - "mismatch"
+          - "non_ha"
           - "preseed"
-          - "cluster-manager"
+          - "recover"
+          - "remove_cluster"
+          - "reuse_cluster"
         # Set of versions to use for the matrix tests.
         os: ["24.04"]
         microceph: ["latest/edge"]

--- a/test/main.sh
+++ b/test/main.sh
@@ -266,19 +266,11 @@ run_instances_tests() {
   run_test test_instances_launch "instances launch"
 }
 
-run_basic_tests() {
-  run_test test_reuse_cluster "reuse_cluster"
-  run_test test_add_services "add_services"
-  run_test test_remove_cluster_member "remove_cluster_member"
-  run_test test_non_ha "non_ha"
-}
-
-run_recover_tests() {
-  run_test test_recover "recover"
-}
-
 run_interactive_tests() {
   run_test test_interactive "interactive"
+}
+
+run_interactive_combinations_tests() {
   run_test test_interactive_combinations "interactive combinations"
 }
 
@@ -287,8 +279,28 @@ run_mismatch_tests() {
   run_test test_disk_mismatch "disk mismatch"
 }
 
+run_non_ha_tests() {
+  run_test test_non_ha "non_ha"
+}
+
 run_preseed_tests() {
   run_test test_preseed "preseed"
+}
+
+run_recover_tests() {
+  run_test test_recover "recover"
+}
+
+run_remove_cluster_tests() {
+  run_test test_remove_cluster_member "remove_cluster_member"
+}
+
+run_reuse_cluster_tests() {
+  run_test test_reuse_cluster "reuse_cluster"
+}
+
+run_service_tests() {
+  run_test test_add_services "add_services"
 }
 
 run_upgrade_tests() {

--- a/test/main.sh
+++ b/test/main.sh
@@ -248,97 +248,30 @@ collect_go_cover_files() {
 	fi
 }
 
-# test groups
-run_add_tests() {
-  run_test test_add_interactive "add interactive"
-}
-
-run_cluster_manager_tests() {
-  run_test test_cluster_manager "cluster manager tests"
-}
-
-run_e2e_tests() {
-  run_test test_e2e "e2e with Terraform"
-}
-
-run_instances_tests() {
-  run_test test_instances_config "instances config"
-  run_test test_instances_launch "instances launch"
-}
-
-run_interactive_tests() {
-  run_test test_interactive "interactive"
-}
-
-run_interactive_combinations_tests() {
-  run_test test_interactive_combinations "interactive combinations"
-}
-
-run_mismatch_tests() {
-  run_test test_service_mismatch "service mismatch"
-  run_test test_disk_mismatch "disk mismatch"
-}
-
-run_non_ha_tests() {
-  run_test test_non_ha "non_ha"
-}
-
-run_preseed_tests() {
-  run_test test_preseed "preseed"
-}
-
-run_recover_tests() {
-  run_test test_recover "recover"
-}
-
-run_remove_cluster_tests() {
-  run_test test_remove_cluster_member "remove_cluster_member"
-}
-
-run_reuse_cluster_tests() {
-  run_test test_reuse_cluster "reuse_cluster"
-}
-
-run_service_tests() {
-  run_test test_add_services "add_services"
-}
-
-run_upgrade_tests() {
-  run_test test_upgrade "upgrade"
-}
-
 # allow for running a specific set of tests
 if [ "${1:-"all"}" = "all" ]; then
-  run_add_tests
-  run_cluster_manager_tests
-  run_e2e_tests
-  run_instances_tests
-  run_basic_tests
-  run_recover_tests
-  run_interactive_tests
-  run_mismatch_tests
-  run_preseed_tests
-  run_upgrade_tests
-elif [ "${1}" = "add" ]; then
-  run_add_tests
-elif [ "${1}" = "cluster-manager" ]; then
-  run_cluster_manager_tests
-elif [ "${1}" = "e2e" ]; then
-  run_e2e_tests
+  run_test test_add_interactive
+  run_test test_add_services
+  run_test test_cluster_manager
+  run_test test_e2e
+  run_test test_instances_config
+  run_test test_instances_launch
+  run_test test_interactive
+  run_test test_interactive_combinations
+  run_test test_service_mismatch
+  run_test test_disk_mismatch
+  run_test test_non_ha
+  run_test test_preseed
+  run_test test_recover
+  run_test test_remove_cluster
+  run_test test_reuse_cluster
+  run_test test_upgrade
 elif [ "${1}" = "instances" ]; then
-  run_instances_tests
-elif [ "${1}" = "basic" ]; then
-  run_basic_tests
-elif [ "${1}" = "recover" ]; then
-  run_recover_tests
-elif [ "${1}" = "interactive" ]; then
-  run_interactive_tests
+  run_test test_instances_config
+  run_test test_instances_launch
 elif [ "${1}" = "mismatch" ]; then
-  run_mismatch_tests
-elif [ "${1}" = "preseed" ]; then
-  run_preseed_tests
-elif [ "${1}" = "upgrade" ]; then
-  run_upgrade_tests
+  run_test test_service_mismatch
+  run_test test_disk_mismatch
 elif [ "${1}" = "setup" ]; then
   testbed_setup
 else

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -885,7 +885,7 @@ test_reuse_cluster() {
   lxc exec micro01 -- tail -1 out | grep "Some systems are already part of different MicroCeph clusters. Aborting initialization" -q
 }
 
-test_remove_cluster_member() {
+test_remove_cluster() {
   unset_interactive_vars
 
   microcloud_internal_net_addr="$(ip_config_to_netaddr lxdbr0)"


### PR DESCRIPTION
This allows getting faster test feedback.
Currently the `interactive` test suite runs for over 2h which is tedious.

The PRs finally splits tests into more granular suites.