### PR TITLE
doc: Remove notion about `--wipe`

### DIFF
--- a/doc/how-to/add_machine.md
+++ b/doc/how-to/add_machine.md
@@ -11,7 +11,6 @@ On the new machine use the {command}`microcloud join` command:
     sudo microcloud join
 
 Answer the prompts on both sides to add the machine.
-You can also add the `--wipe` flag to automatically wipe any disks you add to the cluster.
 
 ## Non-interactive configuration
 


### PR DESCRIPTION
Before releasing 2 LTS the flag was already removed and it's a left over in the docs.