### PR TITLE
Test: Display correct total e2e evacuation tries number

### DIFF
--- a/test/e2e/run
+++ b/test/e2e/run
@@ -202,7 +202,7 @@ setup
 SUCCESFUL_EVACUATIONS=0
 connectivity
 for i in $(seq "${EVACUATION_COUNTS}"); do
-    echo "Evacuation test (${i}/$((EVACUATION_COUNTS - 1)))"
+    echo "Evacuation test (${i}/${EVACUATION_COUNTS})"
     evacuation
     connectivity
     SUCCESFUL_EVACUATIONS=$((SUCCESFUL_EVACUATIONS + 1))


### PR DESCRIPTION
The `EVACUATION_COUNTS` always starts at 1 so subtracting 1 causes the display of a wrong value for the total number of tries. 
When setting `EVACUATION_COUNTS` to 10, you can see the job printing `(10/9)` for the last try: https://github.com/canonical/microcloud/actions/runs/16188650147/job/45708968808#step:3:6339