### PR TITLE
doc: reorder how-to guides navigation menu

### DIFF
--- a/doc/how-to/index.md
+++ b/doc/how-to/index.md
@@ -1,23 +1,23 @@
 (howto)=
 # How-to guides
 
-These how-to guides cover key operations and processes in MicroCloud.
+These MicroCloud how-to guides cover key operations and processes, including installation and configuration instructions, how to add and remove cluster members, update and upgrade procedures, and more.
 
 ```{toctree}
 :maxdepth: 1
 
 Install MicroCloud </how-to/install>
 Initialize MicroCloud </how-to/initialize>
-Update and upgrade </how-to/update_upgrade>
-Manage the snaps </how-to/snaps>
 Configure Ceph networking </how-to/ceph_networking>
 Configure OVN underlay </how-to/ovn_underlay>
+Work with MicroCloud </how-to/commands>
 Add a machine </how-to/add_machine>
 Remove a machine </how-to/remove_machine>
 Shut down a machine </how-to/shutdown_machine>
+Update and upgrade </how-to/update_upgrade>
+Manage the snaps </how-to/snaps>
+Recover MicroCloud </how-to/recover>
 Add a service </how-to/add_service>
 Get support </how-to/support>
 Contribute to MicroCloud </how-to/contribute>
-Work with MicroCloud </how-to/commands>
-Recover MicroCloud </how-to/recover>
 ```


### PR DESCRIPTION
This PR reorders the navigation menu per discussion with @mseralessandri, in preparation for adding a Terraform how-to guide to this section. It also improves the introductory text (the first 200 characters of which is used for the meta description of the page).

A separate forthcoming PR will also rename the "Add a machine" "Remove a machine" and "Shut down a machine" guides to use "cluster member" instead of "machine" and group them under a "Manage cluster members" subsection. 