### PR TITLE
doc: fix internal link targets

### DIFF
--- a/doc/how-to/snaps.md
+++ b/doc/how-to/snaps.md
@@ -3,7 +3,7 @@
 
 Manage MicroCloud and its components (LXD, MicroCeph, and MicroOVN) through their snap packages.
 
-For the installation guide, see: {ref}`howto-install`. For details about the snaps, including {ref}`supported and compatible releases <ref-releases-matrix>`, {ref}`tracks <ref-snaps-microcloud-tracks>`, and {ref}`release processes <ref-releases-microcloud>`, see: {ref}`ref-releases-snap`.
+For the installation guide, see: {ref}`howto-install`. For details about the snaps, including {ref}`supported and compatible releases <ref-releases-matrix>`, {ref}`tracks <ref-snaps-microcloud-tracks>`, and {ref}`release processes <ref-releases-microcloud>`, see: {ref}`ref-releases-snaps`.
 
 (howto-snap-info)=
 ## View snap information

--- a/doc/how-to/update_upgrade.md
+++ b/doc/how-to/update_upgrade.md
@@ -49,7 +49,7 @@ Update the same component's snap on all cluster members before moving to the nex
 (howto-update-sync)=
 ## Synchronize updates using the cohort flag
 
-Even with manual snap updates, versions can fall out of sync; see {ref}`ref-snap-updates` for details.
+Even with manual snap updates, versions can fall out of sync; see {ref}`ref-snaps-updates` for details.
 
 To ensure synchronized updates, the `--cohort="+"` flag must be set on all cluster members. You only need to set this flag once per snap on each cluster member, either during {ref}`installation <howto-install>`, or the first time you {ref}`perform a manual update <howto-update>`.
 

--- a/doc/reference/releases-snaps.md
+++ b/doc/reference/releases-snaps.md
@@ -92,7 +92,7 @@ MicroCloud LTS tracks use the format _x.y_, corresponding to the major and minor
 (ref-snaps-microcloud-track-feature)=
 #### Feature track
 
-The MicroCloud feature track uses the major number of the current {ref}`feature release <ref-releases-feature>` series. Feature releases within the same major version are published to the same track, replacing the previous release. This simplifies updates, as you don't need to switch channels to access new feature releases within the same major version.
+The MicroCloud feature track uses the major number of the current {ref}`feature release <ref-releases-microcloud-feature>` series. Feature releases within the same major version are published to the same track, replacing the previous release. This simplifies updates, as you don't need to switch channels to access new feature releases within the same major version.
 
 The current feature track is {{current_feature_track}}. No feature release has yet been published to this track. The most recent development updates can be found in the {{current_feature_track}}/`edge` channel, for testing purposes only.
 


### PR DESCRIPTION
This PR fixes link targets that are intended to point to MicroCloud internal docs but are pointing at LXD's docs through intersphinx. Due to the link targets existing in LXD latest branch, the links did not raise an error, but the issue showed up in a [backport PR](https://github.com/canonical/microcloud/pull/893) where the LXD branch used in the backport (stable-5.21) does not yet have those link targets.