### PR TITLE
doc: move redirects to external file and add new redirects

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 import yaml
+from redirects import redirects
 
 # Custom configuration for the Sphinx documentation builder.
 # All configuration specific to your project should be done in this file.
@@ -151,11 +152,7 @@ else:
 # (see https://docs.readthedocs.io/en/stable/guides/redirects.html).
 # NOTE: If this variable is not defined, set to None, or the dictionary is empty,
 # the sphinx_reredirects extension will be disabled.
-redirects = {
-    'tutorial/index': 'get_started/',
-    'explanation/initialisation': '../initialization',
-    'how-to/initialise': '../initialize'
-}
+# minae: Redirects is imported from redirects.py
 
 ############################################################
 ### Link checker

--- a/doc/redirects.py
+++ b/doc/redirects.py
@@ -1,0 +1,8 @@
+redirects = {
+    'tutorial/index': 'get_started/',
+    'explanation/initialisation': '../initialization',
+    'how-to/initialise': '../initialize',
+    'how-to/remove_machine': '../member_remove',
+    'how-to/add_machine': '../member_add',
+    'how-to/shutdown_machine': '../member_shutdown',
+}


### PR DESCRIPTION
I realized that along with https://github.com/canonical/microcloud/pull/892 I should have added redirects for the changed filenames (`add_machine` to `member_add`, `remove_machine` to `member_remove`, `shutdown_machine` to `member_shutdown`) for any external links or bookmarks. This PR adds the redirects.

I took the opportunity to also move the redirects to an external `redirects.py` file at the same time; it's easier to manage than leaving it in `custom_conf.py`. I made this change in LXD docs a couple of months ago (see [commit](https://github.com/canonical/lxd/commit/ad0a666506175f6434dcbe47bf5b4fd3a99dab1a)).