### PR TITLE
version: Set 2.1.1 LTS (v2-edge)

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -7,7 +7,7 @@ import (
 
 // RawVersion is the current daemon version of MicroCloud.
 // LTS versions also include the patch number.
-const RawVersion = "2.1.0"
+const RawVersion = "2.1.1"
 
 // LTS should be set if the current version is an LTS (long-term support) version.
 const LTS = true


### PR DESCRIPTION
This has to be merged as the last PR in line right before cutting the next LTS release.