### PR TITLE
version: Set 3.0 for latest version

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -3,10 +3,10 @@ package version
 
 // RawVersion is the current daemon version of MicroCloud.
 // LTS versions also include the patch number.
-const RawVersion = "2.1.0"
+const RawVersion = "3.0"
 
 // LTS should be set if the current version is an LTS (long-term support) version.
-const LTS = true
+const LTS = false
 
 // Version appends "LTS" to the raw version string if MicroCloud is an LTS version.
 func Version() string {


### PR DESCRIPTION
It looks for the last release we set the version on 'main' and then backported it into 'v2-edge'. However MicroCloud 'main' is the latest which should be indicated by the proper version number. Also 3.0 allows having a feature release (like LXD) at some point in the future.