### PR TITLE
GitHub: Run scheduled tests fully also for doc only changes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
           glob: ":!doc/*"
 
   code-tests:
-    if: ${{ needs.changes.outputs.except_docs == 'true' && github.repository == 'canonical/microcloud' }}
+    if: ${{ (needs.changes.outputs.except_docs == 'true' || github.event_name == 'schedule') && github.repository == 'canonical/microcloud' }}
     name: Code
     runs-on: ubuntu-22.04
     needs: [changes]


### PR DESCRIPTION
In one of the last scheduled weekly test runs I have observed that in case the last commit on main consists only of doc changes, it doesn't run the full test suite: https://github.com/canonical/microcloud/actions/runs/16545336169 This is due to the fact that we run only the resource intensive code and system tests for changes that actually affect this part of the code.

By making the check for except_docs dependent on the github.event_name, we can ensure that the code (and system) tests will always run regardless whether or not the last commit on main contains only doc changes.