### PR TITLE
doc: Add en.wikipedia.org to link ignore list

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -166,6 +166,8 @@ linkcheck_ignore = [
     'https://ceph.io',
     # Cloudflare protection on SourceForge domains often block linkcheck
     r"https://.*\.sourceforge\.net/.*",
+    # Wikipedia may return 403 possibly due to too many requests
+    r"https://en\.wikipedia\.org/.*",
     ]
 
 # Pages on which to ignore anchors


### PR DESCRIPTION
It looks wikipedia is blocking our link checks due to too many requests, see https://github.com/canonical/microcloud/actions/runs/17230818667/job/48884267655.