### PR TITLE
doc: fix breaking related links

### DIFF
--- a/doc/explanation/initialization.md
+++ b/doc/explanation/initialization.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: https://en.wikipedia.org/wiki/Multicast_DNS
+relatedlinks: "[Wikipedia&#32;-&#32;Multicast&#32;DNS](https://en.wikipedia.org/wiki/Multicast_DNS)"
 ---
 
 (explanation-initialization)=

--- a/doc/explanation/microcloud.md
+++ b/doc/explanation/microcloud.md
@@ -1,7 +1,3 @@
----
-relatedlinks: https://documentation.ubuntu.com/lxd/
----
-
 (explanation-microcloud)=
 # About MicroCloud
 

--- a/doc/explanation/networking.md
+++ b/doc/explanation/networking.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: https://docs.ovn.org,https://ubuntu.com/blog/data-centre-networking-what-is-ovn,https://en.wikipedia.org/wiki/Virtual_private_cloud
+relatedlinks: "[OVN&#32;Documentation](https://docs.ovn.org),[Ubuntu&#32;blog&#32;-&#32;Data&#32;centre&#32;networking:&#32;What&#32;is&#32;OVN?](https://ubuntu.com/blog/data-centre-networking-what-is-ovn),[Wikipedia&#32;-&#32;Virtual&#32;private&#32;cloud](https://en.wikipedia.org/wiki/Virtual_private_cloud)"
 ---
 
 (exp-networking)=

--- a/doc/tutorial/get_started.md
+++ b/doc/tutorial/get_started.md
@@ -1,7 +1,3 @@
----
-relatedlinks: https://documentation.ubuntu.com/lxd/
----
-
 (get-started)=
 # Get started with MicroCloud
 


### PR DESCRIPTION
I audited the `relatedlinks` front matter in MicroCloud docs and added manual link text to the Wikipedia links that have recently been causing issues (see: https://github.com/canonical/microcloud/pull/945), as well as other links for prevention's sake. This should cause the build to quit failing from 503 HTTP responses on those links. 

I also removed a couple of `relatedlinks` that were linking to the default LXD documentation, as the LXD docs are already linked at the top of the MicroCloud site so another link is unnecessary (and could send them to the wrong docs version, since they went to the default/stable version, and the user could be clicking on it from the latest version).