### PR TITLE
Questionnaire: Improve flow for fingerprint verification

### DIFF
--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -1806,7 +1806,7 @@ func (c *initConfig) askJoinConfirmation(gw *cloudClient.WebsocketGateway, servi
 		fmt.Println(tui.SummarizeResult("Received confirmation from system %s", session.Intent.Name))
 		fmt.Println("")
 		fmt.Println(tui.Note(tui.Yellow, tui.WarningSymbol()+tui.SetColor(tui.Bright, " Do not exit out to keep the session alive", true)) + "\n")
-		fmt.Println(tui.Printf(tui.Fmt{Arg: "Complete the remaining configuration on %s ..."}, tui.Fmt{Arg: session.Intent.Name, Bold: true}))
+		fmt.Println(tui.Printf(tui.Fmt{Arg: "Complete the remaining configuration on system %s ..."}, tui.Fmt{Arg: session.Intent.Name, Bold: true}))
 	}
 
 	err = gw.ReceiveWithContext(gw.Context(), &session)

--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -1665,18 +1665,6 @@ func (c *initConfig) askPassphrase(s *service.Handler) (string, error) {
 		return err
 	}
 
-	cloud := s.Services[types.MicroCloud].(*service.CloudService)
-	cert, err := cloud.ServerCert()
-	if err != nil {
-		return "", err
-	}
-
-	fingerprint, err := c.shortFingerprint(cert.Fingerprint())
-	if err != nil {
-		return "", fmt.Errorf("Failed to shorten fingerprint: %w", err)
-	}
-
-	fmt.Println(tui.Printf(tui.Fmt{Arg: "Verify the fingerprint %s is displayed on the other system."}, tui.Fmt{Arg: fingerprint, Color: tui.Green, Bold: true}))
 	msg := "Specify the passphrase for joining the system"
 	password, err := c.asker.AskPassphrase(msg, service.Wordlist, validator, service.PassphraseWordCount)
 	if err != nil {

--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -1641,7 +1641,7 @@ func (c *initConfig) shortFingerprint(fingerprint string) (string, error) {
 	return fingerprint[0:12], nil
 }
 
-func (c *initConfig) askPassphrase(s *service.Handler) (string, error) {
+func (c *initConfig) askPassphrase() (string, error) {
 	format := func(password string) (string, error) {
 		passwordSplit := strings.Split(password, " ")
 

--- a/cmd/microcloud/join.go
+++ b/cmd/microcloud/join.go
@@ -108,7 +108,7 @@ func (c *cmdJoin) Run(cmd *cobra.Command, args []string) error {
 		services[s.Type()] = version
 	}
 
-	passphrase, err := cfg.askPassphrase(s)
+	passphrase, err := cfg.askPassphrase()
 	if err != nil {
 		return err
 	}

--- a/cmd/microcloud/session.go
+++ b/cmd/microcloud/session.go
@@ -204,6 +204,21 @@ func (c *initConfig) joiningSession(gw *cloudClient.WebsocketGateway, sh *servic
 		localArg := tui.Fmt{Arg: sh.Name, Bold: true}
 		remoteArg := tui.Fmt{Arg: session.InitiatorName, Bold: true}
 		fmt.Println(tui.Printf(tmplArg, localArg, remoteArg))
+
+		cloud := sh.Services[types.MicroCloud].(*service.CloudService)
+		cert, err := cloud.ServerCert()
+		if err != nil {
+			return err
+		}
+
+		ourFingerprint, err := c.shortFingerprint(cert.Fingerprint())
+		if err != nil {
+			return fmt.Errorf("Failed to shorten fingerprint: %w", err)
+		}
+
+		tmplArg = tui.Fmt{Arg: "Verify the fingerprint %s is displayed on system %s."}
+		ourFingerprintArg := tui.Fmt{Arg: ourFingerprint, Color: tui.Green, Bold: true}
+		fmt.Println(tui.Printf(tmplArg, ourFingerprintArg, remoteArg))
 	}
 
 	return c.askJoinConfirmation(gw, services)

--- a/cmd/microcloud/session.go
+++ b/cmd/microcloud/session.go
@@ -200,7 +200,7 @@ func (c *initConfig) joiningSession(gw *cloudClient.WebsocketGateway, sh *servic
 		fingerprintArg := tui.SetColor(tui.Green, fingerprint, true)
 		fmt.Printf("\n%s %s\n\n", tmpl, fingerprintArg)
 
-		tmplArg := tui.Fmt{Arg: "Select %s on %s to let it join the cluster"}
+		tmplArg := tui.Fmt{Arg: "Select system %s on %s to let it join the cluster."}
 		localArg := tui.Fmt{Arg: sh.Name, Bold: true}
 		remoteArg := tui.Fmt{Arg: session.InitiatorName, Bold: true}
 		fmt.Println(tui.Printf(tmplArg, localArg, remoteArg))

--- a/cmd/tui/autocomplete.go
+++ b/cmd/tui/autocomplete.go
@@ -71,7 +71,7 @@ func (m model) View() string {
 		return m.textInput.Prompt + m.textInput.Value()
 	}
 
-	return m.textInput.View() + "\n\n"
+	return m.textInput.View() + "\n"
 }
 
 // refreshTokenSuggestions builds full-line suggestions by replacing only the last token.

--- a/cmd/tui/autocomplete.go
+++ b/cmd/tui/autocomplete.go
@@ -46,6 +46,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.Type {
 		case tea.KeyEnter, tea.KeyCtrlC, tea.KeyEsc:
+			m.textInput.Blur()
 			return m, tea.Quit
 
 		case tea.KeyTab:
@@ -81,7 +82,6 @@ func (m model) refreshTokenSuggestions(maxTokens uint8) model {
 
 	if len(strings.Fields(v)) >= int(maxTokens) && strings.HasSuffix(v, " ") {
 		m.textInput.SetSuggestions(nil)
-		m.textInput.Blur()
 		return m
 	}
 

--- a/cmd/tui/autocomplete.go
+++ b/cmd/tui/autocomplete.go
@@ -23,7 +23,6 @@ func autocompleteModel(prompt string, suggestions []string, maxTokens uint8, tes
 	ti := textinput.New()
 	ti.Prompt = prompt + ": "
 	ti.Cursor.Style = lipgloss.NewStyle().Foreground(Bright)
-	ti.PromptStyle = lipgloss.NewStyle().Foreground(Bright)
 	ti.ShowSuggestions = true
 
 	ti.Focus()


### PR DESCRIPTION
Fixes https://github.com/canonical/microcloud/issues/949.

We should not tell the user to verify the joiners fingerprint before this can actually be done on the initiator to avoid confusion.

Furthermore it fixes a few smaller inconsistencies in the new autocomplete tui model.