### PR TITLE
make: Use dqlite v1.17.x LTS for v3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GOMIN=1.24.4
 GOCOVERDIR ?= $(shell go env GOCOVERDIR)
 GOPATH ?= $(shell go env GOPATH)
 DQLITE_PATH=$(GOPATH)/deps/dqlite
-DQLITE_BRANCH=master
+DQLITE_BRANCH=lts-1.17.x
 
 .PHONY: default
 default: build


### PR DESCRIPTION
MicroCloud v3 is using Microcluster v2 (not v3) so it doesn't make sense to pull latest dqlite from master branch. Instead MicroCloud should start using Microcluster v3, which uses the latest version of go-dqlite which then supports using dqlite from master branch.

This unblocks MicroCloud v3 edge builds for now due to the most recent dqlite changes that have removed disk mode.