### PR TITLE
Docs: Update link to MicroOVN release process

### DIFF
--- a/doc/reference/releases-snaps.md
+++ b/doc/reference/releases-snaps.md
@@ -136,7 +136,7 @@ Every two years, the March version of OVN becomes an LTS version, such as the `2
 
 For more information, see the MicroOVN documentation:
 
-- {doc}`microovn:developers/release-process`
+- {doc}`microovn:reference/release-process`
 - {ref}`microovn:snap channels`
 
 (ref-snaps-updates)=


### PR DESCRIPTION
The document was moved upstream as part of https://github.com/canonical/microovn/pull/255.