### PR TITLE
doc/tutorial: update hostname-username pairs

### DIFF
--- a/doc/tutorial/get_started.md
+++ b/doc/tutorial/get_started.md
@@ -28,6 +28,8 @@ MicroCloud requires LXD version 5.21:
 
       ```{terminal}
       :input: snap version
+      :user: ubuntu
+      :host: lxd-host
 
       snap    2.59.4
       snapd   2.59.4
@@ -118,8 +120,8 @@ Complete the following steps to create the required disks in a LXD storage pool:
 
    ```{terminal}
    :input: lxc storage volume list disks
-   :user: root
-   :host: micro1
+   :user: ubuntu
+   :host: lxd-host
 
    +--------+---------+-------------+--------------+---------+
    |  TYPE  |  NAME   | DESCRIPTION | CONTENT-TYPE | USED BY |
@@ -478,7 +480,7 @@ See the full process here for one of the joining sides (`micro2`):
 ```{terminal}
 :input: microcloud join
 :user: root
-:host: micro1
+:host: micro2
 :scroll:
 
 Select an address for MicroCloud's internal traffic:


### PR DESCRIPTION
The host-username pairs that could cause confusion for end users on the Get started with MicroCloud page have been updated as follows:

Updated:
<img width="742" height="185" alt="Screenshot from 2025-09-30 10-45-06" src="https://github.com/user-attachments/assets/c3ff67ba-f14f-469e-b374-fbd3fdff7197" />

Original:
<img width="728" height="185" alt="image" src="https://github.com/user-attachments/assets/275dba9c-beb4-4d77-aa4e-dc5a7da0c514" />


Updated:
<img width="728" height="185" alt="Screenshot from 2025-09-30 10-46-22" src="https://github.com/user-attachments/assets/9dbba1e4-edb8-452a-bb25-af31999d31fb" />

Original:
<img width="728" height="185" alt="image" src="https://github.com/user-attachments/assets/f4d4536a-48f1-4211-aad5-745c1df7acbf" />


Updated:
<img width="728" height="185" alt="Screenshot from 2025-09-30 10-47-02" src="https://github.com/user-attachments/assets/3ab610af-80b2-4901-a1e7-9e4680a1b1ce" />

Original:
<img width="728" height="185" alt="image" src="https://github.com/user-attachments/assets/8f7215f2-6d4c-4237-b441-e2f9d7a99734" />

