### PR TITLE
cmd/microcloud/cluster_manager: send status message also if other members lxd service is unreachable

### DIFF
--- a/cmd/microcloudd/cluster_manager_task.go
+++ b/cmd/microcloudd/cluster_manager_task.go
@@ -198,7 +198,9 @@ func enrichClusterMemberMetrics(lxdClient lxd.InstanceServer, result *types.Clus
 		statusFrequencies[member.Status]++
 		memberState, _, err := lxdClient.GetClusterMemberState(member.ServerName)
 		if err != nil {
-			return err
+			// If we can't get the state of a member, skip it but continue with others.
+			logger.Warn("Failed to get LXD cluster member state", logger.Ctx{"member": member.ServerName, "err": err})
+			continue
 		}
 
 		result.MemoryTotalAmount += int64(memberState.SysInfo.TotalRAM)


### PR DESCRIPTION
# Done
- make cluster manager status command more resilient:
- send status message also if other member's lxd service is unreachable