### PR TITLE
doc: fix microovn object inventory issue in CI build (v2-edge)

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -270,7 +270,7 @@ if ('SINGLE_BUILD' in os.environ and os.environ['SINGLE_BUILD'] == 'True'):
     intersphinx_mapping = {
         'lxd': ('https://documentation.ubuntu.com/lxd/stable-5.21/', None),
         'microceph': ('https://canonical-microceph.readthedocs-hosted.com/en/v19.2.0-squid/', None),
-        'microovn': ('https://canonical-microovn.readthedocs-hosted.com/en/latest/', None),
+        'microovn': ('https://documentation.ubuntu.com/microcloud/v2-edge/microovn/', None),
         'ceph': ('https://docs.ceph.com/en/latest/', None),
     }
 elif ('READTHEDOCS' in os.environ) and (os.environ['READTHEDOCS'] == 'True'):


### PR DESCRIPTION
In the GitHub CI checks, the docs spellcheck test runs on a test build that uses the `SINGLE_BUILD` flag in MicroCloud's custom Sphinx configuration. This makes it so that the integrated repositories are not unnecessarily cloned for CI tests. However, this was pulling the `objects.inv` file (Sphinx's object inventory file used for intersphinx linking) from https://canonical-microovn.readthedocs-hosted.com/en/latest/objects.inv for both MicroCloud's `v2-edge` and `main` branches. The `latest` version is is the only ReadTheDocs version offered by the MicroOVN docs, and it sources from the MicroOVN repository's `main` GitHub branch.

MicroOVN recently changed a document, causing the spellcheck CI test to fail on MicroCloud's `v2-edge` only with `/home/runner/work/microcloud/microcloud/doc/reference/releases-snaps.md:139: WARNING: unknown document: 'microovn:developers/release-process' [ref.doc]`. On a full build it doesn't fail, because the full build retrieves its `objects.inv` for MicroOVN from a clone based on their `branch-24.03` branch.

To stop the documentation CI tests from failing on the v2-edge branch, this PR points to the MicroOVN objects.inv last built for the integrated docs within MicroCloud's `v2-edge` version instead, so that it's using the same `objects.inv` as the full build.