### PR TITLE
doc: update references to the multi-member tutorial

### DIFF
--- a/doc/how-to/ceph_networking.md
+++ b/doc/how-to/ceph_networking.md
@@ -39,7 +39,7 @@ You could also decide to put both types of traffic on the same high throughput a
 
 To use a fully or partially disaggregated Ceph networking setup with your MicroCloud, specify the corresponding subnets during the MicroCloud initialization process.
 
-The following instructions build on the {ref}`get-started` tutorial and show how you can test setting up a MicroCloud with disaggregated Ceph networking inside a LXD setup.
+The following instructions build on our {ref}`multi-member tutorial <tutorial-multi>` and show how you can test setting up a MicroCloud with disaggregated Ceph networking inside a LXD setup.
 
 1. Create the dedicated networks for Ceph:
 

--- a/doc/how-to/ovn_underlay.md
+++ b/doc/how-to/ovn_underlay.md
@@ -12,7 +12,7 @@ You can choose to skip this question (just hit `Enter`). MicroCloud then uses it
 You could also choose to configure a dedicated underlay network for OVN by typing `yes`. A list of available network interfaces with an IP address will be displayed.
 You can then select one network interface per cluster member to be used as the interfaces for the underlay network of OVN.
 
-The following instructions build on the {ref}`get-started` tutorial and show how you can test setting up a MicroCloud with an OVN underlay network.
+The following instructions build on our {ref}`multi-member tutorial <tutorial-multi>` and show how you can test setting up a MicroCloud with an OVN underlay network.
 
 1. Create the dedicated network for the OVN underlay:
 

--- a/doc/how-to/terraform_automation.md
+++ b/doc/how-to/terraform_automation.md
@@ -1,13 +1,13 @@
 (howto-terraform-automation)=
 # How to automate a MicroCloud test deployment with Terraform
 
-This guide shows you how to automatically deploy a MicroCloud test environment using Terraform and the LXD provider. The Terraform configuration replicates the same setup as in the {ref}`get-started` tutorial, which uses four VMs on a single physical machine for the MicroCloud cluster members. It automates all the manual steps from that tutorial, including VM creation, disk provisioning, network configuration, and MicroCloud initialization.
+This guide shows you how to automatically deploy a MicroCloud test environment using Terraform and the LXD provider. The Terraform configuration replicates the same setup as in our {ref}`multi-member tutorial <tutorial-multi>`, which uses four VMs on a single physical machine for the MicroCloud cluster members. It automates all the manual steps from that tutorial, including VM creation, disk provisioning, network configuration, and MicroCloud initialization.
 
 For production deployments, use physical machines instead of VMs and review the {ref}`reference-requirements` for proper hardware specifications.
 
 <!-- Include start rename-terraform-resources-note -->
 ```{note}
-This Terraform configuration creates the same infrastructure as the manual {ref}`get-started` tutorial. If you have already followed that tutorial, you may encounter naming conflicts with existing resources (VMs, networks, storage volumes). Either clean up the existing resources first or modify the variable names in the Terraform configuration.
+This Terraform configuration creates the same infrastructure as the manual {ref}`multi-member tutorial <tutorial-multi>`. If you have already followed that tutorial, you may encounter naming conflicts with existing resources (VMs, networks, storage volumes). Either clean up the existing resources first or modify the variable names in the Terraform configuration.
 ```
 <!-- Include end rename-terraform-resources-note -->
 
@@ -16,14 +16,14 @@ This Terraform configuration creates the same infrastructure as the manual {ref}
 Before using this Terraform configuration, ensure you have:
 
 - **Terraform installed** (version 1.0 or later)
-- **LXD installed and initialized** on your host machine (see {ref}`get-started` step 1)
-- **Sufficient storage space** as described in the {ref}`get-started` tutorial (step 2)
+- **LXD installed and initialized** on your host machine (see the {ref}`multi-member tutorial <tutorial-multi>` step 1)
+- **Sufficient storage space** as described in the {ref}`multi-member tutorial <tutorial-multi>` (step 2)
 - **Network connectivity** for downloading Ubuntu images and snaps
-- **Nested virtualization enabled** as mentioned in the {ref}`get-started` tutorial introduction
+- **Nested virtualization enabled** as mentioned in the {ref}`multi-member tutorial <tutorial-multi>` introduction
 
 The host LXD should have:
-- A storage pool that meets the requirements described in {ref}`get-started` step 2
-- A bridge network for VM connectivity (configured during LXD initialization in {ref}`get-started` step 1)
+- A storage pool that meets the requirements described in the {ref}`multi-member tutorial <tutorial-multi>` step 2
+- A bridge network for VM connectivity (configured during LXD initialization in the {ref}`multi-member tutorial <tutorial-multi>` step 1)
 
 ## Configuration overview
 
@@ -35,7 +35,7 @@ The Terraform configuration automates the entire MicroCloud setup process:
 - **Service installation**: Installs MicroCloud, LXD, MicroCeph, and MicroOVN snaps via cloud-init
 - **Cluster initialization**: Uses preseed configuration to automatically initialize the MicroCloud cluster
 
-The resulting setup matches the {ref}`get-started` tutorial:
+The resulting setup matches the {ref}`multi-member tutorial <tutorial-multi>`:
 - **4 VMs**: `micro1` (initiator), `micro2`, `micro3`, `micro4`
 - **Storage**: Local storage on all VMs, Ceph storage on first 3 VMs
 - **Networking**: OVN distributed networking with uplink connectivity


### PR DESCRIPTION
This PR fixes internal links that should go directly to the virtualized multi-member tutorial, since we now have two tutorials and the `get-started` link target now leads to a page that describes both tutorials.