### PR TITLE
doc: replace old explanation-networking link target

### DIFF
--- a/doc/explanation/microcloud.md
+++ b/doc/explanation/microcloud.md
@@ -15,7 +15,6 @@ MicroCloud sets up a LXD cluster. You can use the {command}`microcloud cluster` 
 
 Apart from that, you can use LXD commands to manage the cluster. In the LXD documentation, see {ref}`lxd:clustering` for how-to guides on cluster management, or {ref}`lxd:exp-clusters` for an explanation of LXD clusters.
 
-(explanation-networking)=
 (exp-microcloud-microovn)=
 ## MicroOVN networking
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -48,7 +48,7 @@ MicroCloud is designed for small-scale private clouds and hybrid cloud extension
 
 ```{grid-item} [Explanation](/explanation/index)
 
-**Discussion and clarification** of key topics such as {ref}`networking <explanation-networking>` and the [initialization process](/explanation/initialization/)
+**Discussion and clarification** of key topics such as {ref}`networking <exp-networking>` and the [initialization process](/explanation/initialization/)
 ```
 
 ````

--- a/doc/tutorial/multi-member.md
+++ b/doc/tutorial/multi-member.md
@@ -141,7 +141,7 @@ Complete the following steps to create the required disks in a LXD storage pool:
 ## 3. Create a network
 
 MicroCloud requires an uplink network that the cluster members can use for external connectivity.
-See {ref}`explanation-networking` for more information.
+See {ref}`exp-networking-ovn-architecture` for more information.
 
 Complete the following steps to set up this network:
 


### PR DESCRIPTION
This PR removes a deprecated internal link target (`explanation-networking`) and updates internal links. Note that both internal links I found actually needed to be re-directed to an entirely different page, since a new page dedicated to networking was added since those links were created.