### PR TITLE
GitHub: Watch `.github/actions/*` directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,9 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     labels: []
     schedule:
       interval: "weekly"
@@ -15,7 +18,9 @@ updates:
     target-branch: "main"
 
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     labels: []
     schedule:
       interval: "weekly"


### PR DESCRIPTION
When only using `"/"`, dependabot will just watch for action updates in the `workflows` directory but not inside `actions`.

You can see that the custom actions in this repo are outdated.

See https://github.com/dependabot/dependabot-core/issues/6345#issuecomment-3376986288.