### PR TITLE
github: Remove redundant 'directory' statement

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
     directories:
       - "/"
       - "/.github/actions/*"


### PR DESCRIPTION
Follow up on https://github.com/canonical/microcloud/pull/1041.

We already have a 'directories' statement so also having 'directory' is wrong. See https://github.com/canonical/microcloud/runs/53495741971

