### PR TITLE
Service: Bump MicroCeph disk add timeout

### DIFF
--- a/service/microceph.go
+++ b/service/microceph.go
@@ -144,7 +144,10 @@ func (s CephService) AddDisk(ctx context.Context, data cephTypes.DisksPost, targ
 	// Allow MicroCeph time to bootstrap the new OSDs.
 	// In case we are adding a lot of disks, the request might run for a while.
 	// By default the underlying Microcluster client sets a default deadline of 30 seconds.
-	ctx, cancel = context.WithTimeout(ctx, 60*time.Second)
+	// In the pipeline runners we often see runtimes > 1 minute.
+	// To prevent any issues with slow environments set a more forgiving upper limit.
+	// As long as the MicroCeph API doesn't return an error, the process is still running and we have to wait for it.
+	ctx, cancel = context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
 	err = c.Query(ctx, "POST", types.APIVersion, api.NewURL().Path("disks"), data, &response)


### PR DESCRIPTION
Over the last week I saw countless pipelines failing because the timeout exceeded and MicroCeph was still setting up the OSDs. 
Usually this happens when we setup multiple OSDs per member but I also found it happening with single OSD setup requests.

As an example: `⨯ Error: Failed to request disk addition: Post "http://control.socket/1.0/services/microceph/1.0/disks?target=micro02": context deadline exceeded` (from https://github.com/canonical/microcloud/actions/runs/18754586694/job/53503447221)

At 16:51:34 we see this line:

`2025-10-23T16:51:34Z microceph.daemon[677]: time=2025-10-23T16:51:34.560Z level=INFO msg="Created disk record for osd.3"`

At 16:52:12 we see this line:

`2025-10-23T16:52:12Z microceph.daemon[677]: time=2025-10-23T16:52:12.506Z level=INFO msg="Spawning OSD 3"`

And at 16:53:06 we see this line (already exceeding the previous 60s timeout limit):

`2025-10-23T16:53:06Z microceph.daemon[677]: time=2025-10-23T16:53:06.538Z level=INFO msg="Added osd.3"`

So this time it took around one and a half minutes to provision the OSDs. Putting a more forgiving upper limit of 5min seems reasonable to cope with slow environments and when adding multiple disks in those environments. In the example above it was a single disk.