### PR TITLE
Test: Add list disks by id debug information

### DIFF
--- a/test/main.sh
+++ b/test/main.sh
@@ -72,6 +72,9 @@ cleanup() {
   fi
 
   for name in $(lxc list -c n -f csv micro); do
+    echo "${name} disks by id:"
+    lxc exec "${name}" -- ls -la /dev/disk/by-id
+
     echo -n "${name} CLI stdout:"
     if ! lxc exec "${name}" -- test -e out; then
         echo " was not found"


### PR DESCRIPTION
I started to see issues with disks like this `Error: Failed to notify peer micro03 at 10.207.207.182:8443: Failed to run: zpool create -f -m none -O compression=on local /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_disk1: exit status 1 (cannot create 'local': no such pool or dataset)` (from https://github.com/canonical/microcloud/actions/runs/18773890859/job/53564218439).

The PR adds a step in the debug section to list the disks by id present on each of the instances.