### PR TITLE
doc: linkcheck test

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -158,6 +158,15 @@ else:
 ### Link checker
 ############################################################
 
+# From LXD:
+    # 'https://www.dell.com/',
+    # 'https://www.dell.com/en-us/shop/powerflex/sf/powerflex',
+    # 'https://www.gnu.org/licenses/agpl-3.0.en.html',
+    # r"https://ceph\.io(/.*)?",
+    # # Blocked from GH runners
+    # 'https://www.schlachter.tech/solutions/pongo2-template-engine/',
+
+
 # Links to ignore when checking links
 linkcheck_ignore = [
     'http://127.0.0.1:8000',
@@ -167,6 +176,15 @@ linkcheck_ignore = [
     # Cloudflare protection on SourceForge domains often block linkcheck
     r"https://.*\.sourceforge\.net/.*",
     ]
+
+# Links to check in local linkcheck only due to site restrictions against requests from GitHub CI
+if os.environ.get("CI") == "true":
+    linkcheck_ignore.extend([
+        r"https://www\.hpe\.com/.*",
+        r"https://www\.schlachter\.tech.*",
+        r"https://www\.dell\.com.*",
+        r"https://www.\.gnu\.org.*",
+    ])
 
 # Pages on which to ignore anchors
 # (This list will be appended to linkcheck_anchors_ignore_for_url)

--- a/doc/index.md
+++ b/doc/index.md
@@ -6,6 +6,14 @@ relatedlinks: "[Install&#32;MicroCloud&#32;on&#32;Linux&#32;|&#32;Snap&#32;Store
 (home)=
 # MicroCloud
 
+Do not merge. Test to see if [{spellexception}`HPE Alletra` link](https://www.hpe.com/emea_europe/en/hpe-alletra.html) {spellexception}`linkcheck` still fails with different {spellexception}`linkcheck` configurations.
+
+Also test:
+- [Dell](https://www.dell.com/)
+- [Gnu](https://www.gnu.org/licenses/agpl-3.0.en.html)
+- [Ceph](https://ceph.io)
+- [{spellexception}`Schlachter`](https://www.schlachter.tech/solutions/pongo2-template-engine/)
+
 Deploy a scalable, low-touch cloud platform in minutes with MicroCloud.
 
 MicroCloud creates a lightweight cluster of machines that operates as an open source private cloud. It combines LXD for virtualization, MicroCeph for distributed storage, and MicroOVN for networking—all automatically configured by the [MicroCloud snap](https://snapcraft.io/microcloud) for {ref}`reproducible, scalable deployments <exp-microcloud-scale>`.


### PR DESCRIPTION
Testing to see whether rate limiting on the hpe.com site (and hopefully others) can be prevented using different [Sphinx linkcheck configurations](https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-the-linkcheck-builder). Note that the below options have already been configured in the past to try to address similar linkcheck issues for other sites:

```
linkcheck_rate_limit_timeout = 600
linkcheck_retries = 3
linkcheck_timeout = 45
```

What I will test:
```
linkcheck_workers # reduce worker threads for less concurrent requests
linkcheck_request_headers # try setting a browser user agent
```

## Conclusion after testing

Neither decreasing linkcheck_workers to reduce concurrent requests nor using linkcheck_request_headers to set a browser User-Agent in the request headers made a difference, at least for the HPE site. GET requests to hpe.com still fail with timeout in GitHub CI linkcheck while passing in local linkcheck. This is likely due to strict protections on the remote server's side against GH CI and other cloud CI requests (GH runs on Azure). This might vary by site; we can still try these configurations with other sites.

Conclusion: We should continue to ignore hpe.com from our linkcheck list, but we can adapt on our end to only ignore this link when `os.environ.get("CI") == "true"` (`CI` env var is set by GH) so that we can still catch the issue in local linkcheck. I've tested and this works (hpe.com is tested in local linkcheck but not GH CI). There are other sites as well that we have ignored due to CI linkcheck failures that pass in local linkchecks, and these can also be added to the list.

Note: The above applies to LXD docs, not MicroCloud, because we do not actually have a link to it in MicroCloud docs aside from for this testing. I used MicroCloud docs for this testing as recommended per LXD does not currently run linkchecks on PRs, only on scheduled tests.

## Test 1

Added link to https://www.hpe.com/emea_europe/en/hpe-alletra.html (which was [failing in LXD docs](https://github.com/canonical/lxd/actions/runs/17718673916/job/50366835970) and has since been added to the ignorelist there; likely it's the entire hpe.com domain and not just that specific URL) without making any changes to linkcheck configuration, to confirm that the rate limiting is still happening when run from GH (does not fail when linkcheck is run locally).

### Result

Linkcheck [failed with the same error](https://github.com/canonical/microcloud/actions/runs/18957834149/job/54138572578?pr=1069#step:6:211) as in LXD: 

```
(           index: line    9) timeout   https://www.hpe.com/emea_europe/en/hpe-alletra.html - HTTPSConnectionPool(host='www.hpe.com', port=443): Read timed out. (read timeout=45)
```

Linkcheck time: 2m 29s

## Test 2

Added `linkcheck_workers = 1` (default=5) to `custom_conf.py`. Though there is little information about this option, my theory is that less workers = less concurrent requests = potentially will not be rate limited.  However, this should make linkchecking take longer. Trying with the least # possible workers first to see if it helps, then if it does, will try with 3.

### Result

Still [timed out](https://github.com/canonical/microcloud/actions/runs/18957960659/job/54138986787?pr=1069#step:6:209) with the same error.

Linkcheck time: 10m 21s

## Test 3

Tried using `linkcheck_request_headers` in `custom_conf.py` to set a browser User-Agent:

```
linkcheck_request_headers = {
    "https://www.hpe.com/": {
        "User-Agent": (
            'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36'
        ),
    },
}
```

### Result

Still [failed](https://github.com/canonical/microcloud/actions/runs/18958895299/job/54141851952?pr=1069#step:6:212) with same error.

Linkcheck time: 58s

## Test 4

Noticed that running linkcheck locally passes without the User-Agent set above, but fails locally too with that User-Agent. HPE link responds OK. Sphinx by default uses this User-Agent:
```
        "User-Agent": (
            'Mozilla/5.0 (X11; Linux x86_64; rv:100.0) Gecko/20100101 Firefox/100.0 Sphinx/8.2.3'
        ),
```

Tested to see if explicitly setting the User-Agent to this for HPE links might help.

### Result

[Still fails](https://github.com/canonical/microcloud/actions/runs/18982574214/job/54218526321?pr=1069#step:6:209) with timeout. 
