### PR TITLE
Doc: Use Go 1.25

### DIFF
--- a/doc/.readthedocs.yaml
+++ b/doc/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    golang: "1.23"
+    golang: "1.25"
     python: "3.12"
   commands:
       - git fetch --unshallow || true


### PR DESCRIPTION
RTD is complaining https://app.readthedocs.com/projects/canonical-microcloud/builds/3574825/:

`go: go.mod requires go >= 1.25.4 (running go 1.23.12; GOTOOLCHAIN=local)`