### PR TITLE
GitHub: Install snapd for the trivy job

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -96,6 +96,10 @@ jobs:
           key: download-failed # Use a non existing key to fallback to restore-keys
           restore-keys: trivy-cache-
 
+      - name: Install snapd
+        run: |
+          sudo apt-get install --no-install-recommends -y snapd
+
       - name: Download snap for scan
         run: |
           snap download microcloud --channel=${{ matrix.channel }}


### PR DESCRIPTION
When using the ubuntu-slim runners, we have to make sure snapd is installed before we try to download the snap.

See failure https://github.com/canonical/microcloud/actions/runs/20117465378/job/57801448919