### PR TITLE
doc: backport fix to LXD configuration (v2-edge)

### DIFF
--- a/doc/.sphinx/_integration/add_config.py
+++ b/doc/.sphinx/_integration/add_config.py
@@ -11,8 +11,8 @@ html_context['microovn_tag'] = "../microovn/_static/microovn.png"
 
 if project == "LXD":
     html_baseurl = "https://documentation.ubuntu.com/lxd/stable-5.21/"
-    custom_html_js_files.append('rtd-search.js')
-    custom_tags.append('integrated')
+    html_js_files.append('rtd-search.js')
+    tags.add('integrated')
 elif project == "MicroCeph":
     html_baseurl = "https://canonical-microceph.readthedocs-hosted.com/en/latest/"
     # Override default header templates

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -62,7 +62,7 @@ integrate:
 	cp .sphinx/_integration/rtd-search.js integration/microceph/docs/.sphinx/_static/
 	cp .sphinx/_integration/rtd-search.js integration/microovn/docs/.sphinx/_static/
 	# Add information about where to find the tags/docs to the doc sets
-	cat .sphinx/_integration/add_config.py >> integration/lxd/doc/custom_conf.py
+	cat .sphinx/_integration/add_config.py >> integration/lxd/doc/conf.py
 	cat .sphinx/_integration/add_config.py >> integration/microceph/docs/conf.py
 	cat .sphinx/_integration/add_config.py >> integration/microovn/docs/custom_conf.py
 	# Override the MicroOVN tag with the circle of friends one (for consistency)


### PR DESCRIPTION
Backports fix in https://github.com/canonical/microcloud/pull/1160 to align with updates to docs configuration in the LXD repository.