### PR TITLE
doc: fix microovn html_baseurl (v2-edge)

### DIFF
--- a/doc/.sphinx/_integration/add_config.py
+++ b/doc/.sphinx/_integration/add_config.py
@@ -25,7 +25,7 @@ elif project == "MicroCeph":
     # Add "integrated" to the list of custom tags
     custom_tags = globals().get('custom_tags', []) + ['integrated']
 elif project == "MicroOVN":
-    html_baseurl = "https://canonical-microovn.readthedocs-hosted.com/en/latest/"
+    html_baseurl = "https://canonical-microovn.readthedocs-hosted.com/en/24.03/"
     custom_html_js_files.append('rtd-search.js')
     custom_tags.append('integrated')
 


### PR DESCRIPTION
The `html_baseurl` URL set for MicroOVN in `v2-edge` should reflect the version of the MicroOVN docs that are cloned for the `v2-edge` docs, which is `24.03`. This is used in Sphinx configuration to generate the [canonical URL](https://developers.google.com/search/docs/crawling-indexing/canonicalization), which should point to the correct version of the standalone MicroOVN documentation.