### PR TITLE
cmd/microcloud: Wait for daemon readiness in preseed

### DIFF
--- a/cmd/microcloud/preseed.go
+++ b/cmd/microcloud/preseed.go
@@ -167,6 +167,11 @@ func (c *initConfig) RunPreseed(cmd *cobra.Command) error {
 		return err
 	}
 
+	err = cloudApp.Ready(context.Background())
+	if err != nil {
+		return fmt.Errorf("Failed to wait for MicroCloud to get ready: %w", err)
+	}
+
 	status, err := cloudApp.Status(context.Background())
 	if err != nil {
 		return fmt.Errorf("Failed to get MicroCloud status: %w", err)


### PR DESCRIPTION
Fix a [race condition](https://github.com/canonical/microcloud/actions/runs/20313222178/job/58350054580?pr=1163#step:4:5200) where `microcloud preseed` fails when executed immediately after snap installation.