### PR TITLE
doc: how-to about storage.backups_volume and images_volume

### DIFF
--- a/doc/tutorial/single-member.md
+++ b/doc/tutorial/single-member.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: Step-by-step tutorial to learn the basics of how to install, initialize, and use MicroCloud using a physical machine as a single cluster member.
+---
+
 (tutorial-single)=
 # MicroCloud tutorial using a single physical cluster member
 
@@ -170,6 +176,12 @@ Would you like to set up CephFS remote storage? (yes/no) [default=yes]:
 
 Press {kbd}`Enter` to accept the default of `yes`.
 
+```{admonition} If you did not set up local storage
+:class: note
+
+If you did not set up local storage _and_ you set up CephFS storage, there will be an additional step for you at the end of the initialization process.
+```
+
 Next, you'll be prompted to select the CIDR subnet for Ceph internal and public traffic:
 
 ```{terminal}
@@ -257,6 +269,11 @@ Initializing new services ...
 Awaiting cluster formation ...
 Configuring cluster-wide devices ...
 MicroCloud is ready
+```
+
+```{admonition} Possible final step
+:class: note
+If you initialized MicroCloud without local storage _and_ with CephFS storage, visit the {ref}`howto-initialize-images-backups` how-to guide to complete your initialization, then continue this tutorial.
 ```
 
 (tutorial-single-inspect)=


### PR DESCRIPTION
Adds information about how to set `storage.backups_volume` and `storage.images_volume` manually, including when to do so.

Note: In testing the behavior of these settings, I found that they are not used for persistent storage. Instead, they are used as working directories when dealing with packing/unpacking/exporting/importing image and instance backup files. The actual image and instance tarballs are stored in other places. Thus, the main reason to recommend them is that, in the absence of local storage, they will prevent the host filesystem from being filled up during work. It does not seem to be a concern related to persistent storage of tarballs.