### PR TITLE
Test: Check cluster member health by checking the JSON response

### DIFF
--- a/test/includes/microcloud.sh
+++ b/test/includes/microcloud.sh
@@ -613,7 +613,8 @@ validate_system_lxd() {
     set_remote microcloud-test "${name}" test
 
     # Ensure we are clustered and online.
-    lxc cluster list -f csv | sed -e 's/,\?database-leader,\?//' | cut -d',' -f1,7 | grep -qxF "${name},ONLINE"
+    # Use the direct API response to not be affected by CLI changes.
+    lxc cluster list -f json | jq -e '.[] | select(.server_name == "'"${name}"'" and .status == "Online")' >/dev/null
     [ "$(lxc cluster list -f csv | wc -l)" = "${num_peers}" ]
 
     # Check core config options


### PR DESCRIPTION
Whilst checking the weekly test run, I figured that in LXD `6/edge` the CLI output changed slightly so the cluster member check fails during test execution.

Instead use `jq` and check the JSON reponse fields directly. This should work for both LXD 5.21 and 6.

See https://github.com/canonical/microcloud/actions/runs/20886652608/job/60604468647