### PR TITLE
Backport pin myst-parser version (v2-edge)

### DIFF
--- a/doc/.sphinx/build_requirements.py
+++ b/doc/.sphinx/build_requirements.py
@@ -106,7 +106,7 @@ if __name__ == "__main__":
         requirements.append("sphinxext-opengraph")
 
     if IsMyStParserUsed():
-        requirements.append("myst-parser")
+        requirements.append("myst-parser==4.0.1")
         requirements.append("linkify-it-py")
 
     # removes duplicate entries


### PR DESCRIPTION
Latest myst-parser version (5.0) introduces breaking changes to dependencies that affect our docs build. Pinning to the last working version (4.0.1).


(cherry picked from commit fba5eb9699e21c8864b9318c60ca4f1d19ab7129)