### PR TITLE
doc: bump RTD go version

### DIFF
--- a/doc/.readthedocs.yaml
+++ b/doc/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    golang: "1.25"
+    golang: "1.25.6"
     python: "3.12"
   commands:
       - git fetch --unshallow || true


### PR DESCRIPTION
RTD docs build failing due to RTD attempting to use go version 1.25.4 when 1.25.5 is required for building the LXD client.

Bumped to 1.25.6 in doc/.readthedocs.yaml to prevent needing to bump it twice as LXD will shortly require 1.25.6.