### PR TITLE
doc: update references to v2-edge docs version to v2 (v2-edge)

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -10,7 +10,7 @@
 current_dir := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 
 # Set the path prefix and MicroCloud component versions corresponding to each MicroCloud docs version.
-PATH_PREFIX      = /microcloud/v2-edge/
+PATH_PREFIX      = /microcloud/v2/
 LXDVERSION       = origin/stable-5.21
 MICROCEPHVERSION = 64d02d9538a89be039707ecbf942ca1aeae29760 # origin/main.
 MICROOVNVERSION  = origin/branch-24.03

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -270,7 +270,7 @@ if ('SINGLE_BUILD' in os.environ and os.environ['SINGLE_BUILD'] == 'True'):
     intersphinx_mapping = {
         'lxd': ('https://documentation.ubuntu.com/lxd/stable-5.21/', None),
         'microceph': ('https://canonical-microceph.readthedocs-hosted.com/en/v19.2.0-squid/', None),
-        'microovn': ('https://documentation.ubuntu.com/microcloud/v2-edge/microovn/', None),
+        'microovn': ('https://documentation.ubuntu.com/microcloud/v2/microovn/', None),
         'ceph': ('https://docs.ceph.com/en/latest/', None),
     }
 elif ('READTHEDOCS' in os.environ) and (os.environ['READTHEDOCS'] == 'True'):


### PR DESCRIPTION
We changed the slug for the ReadTheDocs published docs version corresponding to the v2-edge branch from v2-edge to v2, adding redirects to prevent 404s. The branch name remains the same. This commit updates the references to the docs version in the Makefile and custom_conf.py.