### PR TITLE
Test: Fixes to unblock the pipeline

### DIFF
--- a/test/includes/microcloud.sh
+++ b/test/includes/microcloud.sh
@@ -861,6 +861,11 @@ reset_system() {
       lxc exec "${name}" -- ip link set "${iface}" up
       lxc exec "${name}" -- sysctl -wq "net.ipv6.conf.${iface}.disable_ipv6=1"
     done
+
+    # Force LXD to start up.
+    # Slower runners might cause longer LXD startup times.
+    # To not force bumping numbers in MicroCloud, ensure LXD is started before MicroCloud starts checking the socket.
+    lxc exec "${name}" -- lxc info >/dev/null
   )
 
   echo "==> Reset ${name}"


### PR DESCRIPTION
Accommodate latest MicroOVN snap by installing latest core26 snap.

Also ensure LXD is started to prevent issues where MicroCloud exits because LXD didn't came up in time (slow runners). I saw these type of failures appear more often the last two weeks, e.g. https://github.com/canonical/microcloud/actions/runs/22100391546/job/64501597361#step:4:6490.