### PR TITLE
doc: edits for consistency, style guide alignment

### DIFF
--- a/doc/explanation/microcloud.md
+++ b/doc/explanation/microcloud.md
@@ -19,16 +19,16 @@ At the end of this, you’ll have an OVN cluster, a Ceph cluster, and a LXD clus
 
 MicroCloud sets up a LXD cluster. You can use the {command}`microcloud cluster` command to show information about the cluster members, or to remove specific members.
 
-Apart from that, you can use LXD commands to manage the cluster. In the LXD documentation, see {ref}`lxd:clustering` for how-to guides on cluster management, or {ref}`lxd:exp-clusters` for an explanation of LXD clusters.
+Apart from that, you can use LXD commands to manage the cluster. In the LXD documentation, refer to {ref}`lxd:clustering` for how-to guides on cluster management, or {ref}`lxd:exp-clusters` for an explanation of LXD clusters.
 
 (exp-microcloud-microovn)=
 ## MicroOVN networking
 
 By default, MicroCloud uses MicroOVN for networking, which is a minimal wrapper around OVN (Open Virtual Network).
 
-- For an overview of MicroCloud networking with OVN, see: {ref}`exp-networking`.
-- For networking requirements, see: {ref}`reference-requirements-network`.
-- To learn how to use a dedicated underlay network, see: {ref}`howto-ovn-underlay`.
+- For an overview of MicroCloud networking with OVN, refer to {ref}`exp-networking`.
+- For networking requirements, refer to {ref}`reference-requirements-network`.
+- To learn how to use a dedicated underlay network, refer to {ref}`howto-ovn-underlay`.
 
 (exp-microcloud-storage)=
 ## Storage
@@ -52,7 +52,7 @@ To use distributed storage, you must have at least three disks (attached to at l
 
 You can securely access a browser-based graphical UI for managing your MicroCloud deployment.
 
-For details, see: {ref}`howto-ui`.
+For details, refer to {ref}`howto-ui`.
 
 ```{admonition} Other client interfaces
 :class: tip
@@ -66,7 +66,7 @@ MicroCloud is designed to be replicable at scale, enabling you to create consist
 
 Once deployed, each MicroCloud component (LXD, MicroCeph, MicroOVN) is designed to scale horizontally, meaning you can add more machines to increase capacity, performance, and redundancy. When new cluster members are added, these components automatically integrate them as control plane, storage, and networking peers without requiring manual reconfiguration. This includes {doc}`automatic failure domain adjustment <microceph:explanation/cluster-scaling>` for MicroCeph.
 
-Furthermore, MicroCloud's snap-based updates help keep deployments consistent at scale. By updating cluster members to the latest version available on the LTS snap channel, you can ensure that all machines are using the same version with the latest security updates and bugfixes. See: {ref}`ref-releases-snaps`.
+Furthermore, MicroCloud's snap-based updates help keep deployments consistent at scale. By updating cluster members to the latest version available on the LTS snap channel, you can ensure that all machines are using the same version with the latest security updates and bugfixes. Refer to {ref}`ref-releases-snaps` to learn more.
 
 (exp-microcloud-ha)=
 ## High availability
@@ -75,9 +75,9 @@ MicroCloud achieves high availability (HA) through its distributed architecture:
 
 LXD provides control plane HA by allowing each cluster member to manage the cluster. If one member goes down, another can serve requests in its place. For data plane HA, LXD also provides automatic {ref}`cluster healing <lxd:cluster-healing>`. For more information, refer to the LXD documentation on {ref}`lxd:clusters-high-availability`.
 
-Using distributed storage with MicroCeph means that data is replicated across the cluster, so even if one member goes offline, its data remains available on others. Ceph's {doc}`Controlled Replication Under Scalable Hashing (CRUSH) algorithm <ceph:rados/operations/crush-map>` automatically redistributes data when parts of the system fail, maintaining availability. Also see: the {ref}`MicroCloud storage requirements for high availability <reference-requirements-storage-ha>` and the {doc}`MicroCeph documentation on its failure domain management <microceph:explanation/cluster-scaling>`.
+Using distributed storage with MicroCeph means that data is replicated across the cluster, so even if one member goes offline, its data remains available on others. Ceph's {doc}`Controlled Replication Under Scalable Hashing (CRUSH) algorithm <ceph:rados/operations/crush-map>` automatically redistributes data when parts of the system fail, maintaining availability. For more information, refer to the {ref}`MicroCloud storage requirements for high availability <reference-requirements-storage-ha>` and the {doc}`MicroCeph documentation on its failure domain management <microceph:explanation/cluster-scaling>`.
 
-MicroOVN brings a distributed overlay network, meaning that switching and routing functions are not centralized on any single cluster member. Each member hosts its own virtual switch, avoiding a single point of failure for internal, intra-cluster traffic: every member can continue forwarding packets even if others are offline. External connectivity relies on a virtual router that is active on one member at a time; if that member fails, another takes over to keep uplink connectivity available. For more information, see: {ref}`exp-networking-ovn`.
+MicroOVN brings a distributed overlay network, meaning that switching and routing functions are not centralized on any single cluster member. Each member hosts its own virtual switch, avoiding a single point of failure for internal, intra-cluster traffic: every member can continue forwarding packets even if others are offline. External connectivity relies on a virtual router that is active on one member at a time; if that member fails, another takes over to keep uplink connectivity available. For more information, refer to {ref}`exp-networking-ovn`.
 
 (exp-microcloud-access-control)=
 ## Fine-grained access control and multi-tenancy

--- a/doc/how-to/install.md
+++ b/doc/how-to/install.md
@@ -19,7 +19,7 @@ A physical or virtual machine intended for use as a MicroCloud cluster member mu
 - Networking:
   - Fixed IP addresses (DHCP not supported)
   - At least two network interfaces per cluster member: one for intra-cluster communication and one for external connectivity to the uplink network
-    - Partially or fully disaggregated networking setups require more interfaces; see: {ref}`howto-ceph-networking`
+    - Partially or fully disaggregated networking setups require more interfaces; refer to {ref}`howto-ceph-networking` to learn more
     - To use a {ref}`dedicated underlay network for OVN traffic <exp-networking-ovn-underlay>`, an additional interface per cluster member is required
   - Uplink network must support both broadcast and multicast
   - Intra-cluster interface must have IPs assigned; external connectivity interface (to uplink) must not have any IPs assigned
@@ -47,7 +47,7 @@ These requirements are in addition to those listed in the General tab.
 - Memory:
   - Minimum 8 GiB RAM per cluster member
 - Networking:
-  - It is possible to use a single network interface per cluster member. However, such a configuration is neither supported nor recommended. For details, see: {ref}`reference-requirements-network-interface-single`.
+  - It is possible to use a single network interface per cluster member. However, such a configuration is neither supported nor recommended. For details, refer to {ref}`reference-requirements-network-interface-single`.
 - Storage:
   - If high availability is required, use distributed storage with:
     - a minimum of 3 cluster members
@@ -79,7 +79,7 @@ These requirements are in addition to those listed in the General tab.
 ````
 `````
 
-For detailed information, see: {ref}`reference-requirements`.
+For detailed information, refer to {ref}`reference-requirements`.
 
 ## Installation
 
@@ -90,7 +90,7 @@ Install all required {ref}`snaps <reference-requirements-software-snaps>` on eac
 
 ```{admonition} Snap channels
 :class: note
-The snap channels shown below install the current {ref}`feature release <ref-releases-microcloud-feature>` of MicroCloud, along with the most recent compatible releases for its components. To install the {ref}`current LTS release <ref-releases-microcloud-lts>` of MicroCloud instead, see the [install guide for that version](https://documentation.ubuntu.com/microcloud/v2/microcloud/how-to/install/).
+The snap channels shown below install the current {ref}`feature release <ref-releases-microcloud-feature>` of MicroCloud, along with the most recent compatible releases for its components. To install the {ref}`current LTS release <ref-releases-microcloud-lts>` of MicroCloud instead, refer to the [install guide for that version](https://documentation.ubuntu.com/microcloud/v2/microcloud/how-to/install/).
 ```
 
 ```bash
@@ -143,7 +143,7 @@ A channel includes both a {ref}`track <ref-snaps-microcloud-tracks>` (such as `3
 
 MicroCloud's component snaps must use tracks that correspond to the same MicroCloud release within the {ref}`matrix of compatible versions <ref-releases-matrix>`. 
 
-For production deployments, use the `stable` risk level for all snaps. For testing or development, you might use a different risk level for some snaps. See {ref}`ref-snaps-microcloud-risk` for more information.
+For production deployments, use the `stable` risk level for all snaps. For testing or development, you might use a different risk level for some snaps. Refer to {ref}`ref-snaps-microcloud-risk` for more information.
 
 To specify a different channel, use the `--channel` flag at installation:
 
@@ -159,9 +159,9 @@ sudo snap install lxd --cohort="+" --channel=6/edge
 
 Even if the risk level for a snap differs from the other snaps, the same channel must be used for that snap on all cluster members. For example, if you use the `6/edge` channel for the LXD snap, then _all_ cluster members must use that channel for the LXD snap.
 
-For details about the MicroCloud snap channels, see: {ref}`ref-snaps-microcloud-channels`.
+For details about the MicroCloud snap channels, refer to {ref}`ref-snaps-microcloud-channels`.
 
 (howto-install-hold-updates)=
 ## Hold updates
 
-When a new release is published to a snap channel, installed snaps following that channel update automatically by default. This is undesired behavior for MicroCloud and its components, and you should override this default behavior by holding updates. See: {ref}`howto-update-hold`.
+When a new release is published to a snap channel, installed snaps following that channel update automatically by default. This is undesired behavior for MicroCloud and its components, and you should override this default behavior by holding updates. Refer to {ref}`howto-update-hold` for details.

--- a/doc/how-to/recover.md
+++ b/doc/how-to/recover.md
@@ -18,11 +18,12 @@ accessible in order to perform database operations. If a cluster has less than
 a quorum of voters up and accessible, then database operations will no longer
 be possible on the entire cluster.
 
-If the loss of quorum is temporary (e.g. some members temporarily lose power),
-database operations will be restored when the offline members come back online.
+If the loss of quorum is temporary (for example, some members temporarily lose
+power), database operations will be restored when the offline members come back
+online.
 
 This document describes how to recover database access if the offline members
-have been lost without the possibility of recovery (e.g. disk failure).
+have been lost without the possibility of recovery (for example, disk failure).
 
 ## Recovery procedure
 

--- a/doc/how-to/snaps.md
+++ b/doc/how-to/snaps.md
@@ -3,7 +3,7 @@
 
 Manage MicroCloud and its components (LXD, MicroCeph, and MicroOVN) through their snap packages.
 
-For the installation guide, see: {ref}`howto-install`. For details about the snaps, including {ref}`supported and compatible releases <ref-releases-matrix>`, {ref}`tracks <ref-snaps-microcloud-tracks>`, and {ref}`release processes <ref-releases-microcloud>`, see: {ref}`ref-releases-snaps`.
+For the installation guide, refer to {ref}`howto-install`. For details about the snaps, including {ref}`supported and compatible releases <ref-releases-matrix>`, {ref}`tracks <ref-snaps-microcloud-tracks>`, and {ref}`release processes <ref-releases-microcloud>`, refer to {ref}`ref-releases-snaps`.
 
 (howto-snap-info)=
 ## View snap information

--- a/doc/how-to/support.md
+++ b/doc/how-to/support.md
@@ -1,7 +1,7 @@
 (howto-support)=
 # How to get support
 
-For information about supported and compatible releases of MicroCloud and its components, see: {ref}`ref-releases-matrix`.
+Refer to {ref}`ref-releases-matrix` for the matrix of compatible releases across MicroCloud and its components.
 
 ## Community support
 
@@ -27,5 +27,5 @@ You can find additional resources on the [MicroCloud website](https://canonical.
 
 LTS releases of MicroCloud receive standard support for five years, which means they receive continuous updates. Commercial support for MicroCloud is provided as part of [Ubuntu Pro](https://ubuntu.com/pro) (both Infra-only and full Ubuntu Pro). See the [full service description](https://ubuntu.com/legal/ubuntu-pro-description) for details.
 
-Managed solutions and firefighting support are also available for MicroCloud deployments. See: [Managed services](https://ubuntu.com/managed).
+Managed solutions and firefighting support are also available for MicroCloud deployments. Visit [Managed services](https://ubuntu.com/managed) for details.
 

--- a/doc/how-to/update_upgrade.md
+++ b/doc/how-to/update_upgrade.md
@@ -1,7 +1,7 @@
 (howto-update-upgrade)=
 # How to update and upgrade
 
-The snaps for MicroCloud, LXD, MicroCeph, and MicroOVN installed on MicroCloud cluster members must always run the same version of each snap. Thus, when the snaps on any cluster member are refreshed, they must also be refreshed on all other cluster members. See {ref}`howto-update-upgrade-order` for the recommended order.
+The snaps for MicroCloud, LXD, MicroCeph, and MicroOVN installed on MicroCloud cluster members must always run the same version of each snap. Thus, when the snaps on any cluster member are refreshed, they must also be refreshed on all other cluster members. Refer to {ref}`howto-update-upgrade-order` for the recommended order.
 
 If the cluster members' snaps are not synchronized, MicroCloud continues to function as normal in regards to its data plane. However, the configuration of its control plane cannot be altered. For example, you cannot add or remove cluster members or instances. To prevent automatic updates from causing snaps to run different versions, make sure to always {ref}`hold updates <howto-update-hold>` as well as {ref}`synchronize updates using the cohort flag <howto-update-sync>`.
 
@@ -10,12 +10,12 @@ Performing an update or upgrade requires going through the list of snaps one aft
 (howto-update-upgrade-backup)=
 ## Back up data
 Before performing an update or upgrade, make sure to back up your data to prevent any data loss in case of failure.
-See the following backup guides for each of the snaps:
+Consult the following backup guides for each of the snaps:
 
 * {doc}`How to back up MicroCeph <microceph:explanation/taking-snapshots>`
 * {ref}`How to back up LXD <lxd:backups>`
 
-In case of error, see {ref}`howto-recover` for troubleshooting details.
+In case of error, refer to {ref}`howto-recover` for troubleshooting details.
 
 (howto-update-upgrade-running-instances)=
 ## Keep instances running during an update or upgrade
@@ -27,12 +27,12 @@ For the LXD snap, this won't affect the running instances. However, for the Micr
 To avoid such possible effects entirely, use the live migration approach described below when updating or upgrading the MicroCeph and MicroOVN snaps.
 
 - Use virtual machines (VMs) instead of system containers for crucial workloads; in general, containers cannot be live-migrated.
-- Each VM must be pre-configured for live migration. See: {ref}`lxd:live-migration` for information on the required configurations.
+- Each VM must be pre-configured for live migration. Refer to {ref}`lxd:live-migration` for information on the required configurations.
 - Before you update or upgrade a cluster member, use the {ref}`cluster evacuate <lxd:cluster-evacuate>` operation to migrate all instances on the host to other members in the same cluster.
 - Once the update or upgrade is complete, use the {ref}`cluster restore <lxd:cluster-restore>` operation to migrate all evacuated instances back to the original host.
 - The evacuate and restore operations can live-migrate any VMs that are configured to allow it. If any instances on the cluster member are ineligible for live migration (such as a container, or a VM that is not configured for live migration), then during both evacuation and restoration, those instances are stopped, migrated, and restarted.
 
-For more information on the cluster evacuate and restore operations, see: {ref}`lxd:cluster-evacuate-restore`.
+For more information on the cluster evacuate and restore operations, refer to {ref}`lxd:cluster-evacuate-restore`.
 
 (howto-update-upgrade-order)=
 ## Update and upgrade order
@@ -49,7 +49,7 @@ Update the same component's snap on all cluster members before moving to the nex
 (howto-update-sync)=
 ## Synchronize updates using the cohort flag
 
-Even with manual snap updates, versions can fall out of sync; see {ref}`ref-snaps-updates` for details.
+Even with manual snap updates, versions can fall out of sync; refer to {ref}`ref-snaps-updates` for details.
 
 To ensure synchronized updates, the `--cohort="+"` flag must be set on all cluster members. You only need to set this flag once per snap on each cluster member, either during {ref}`installation <howto-install>`, or the first time you {ref}`perform a manual update <howto-update>`.
 
@@ -120,7 +120,7 @@ The {ref}`snap:how-to-guides-work-with-snaps-manage-updates` page in the Snap do
 ```{admonition} Users of the 1 track
 :class: important
 The `1` MicroCloud track reached {abbr}`EOL (End of Life)` at the end of April 2025.
-If you use this track, make sure to upgrade to the `2` LTS track, as no further updates will be released to the `1` track. See the {ref}`howto-upgrade` guide below for more information. Specific command syntax is provided in {ref}`howto-upgrade-microcloud-full-example`.
+If you use this track, make sure to upgrade to the `2` LTS track, as no further updates will be released to the `1` track. Refer to the {ref}`howto-upgrade` guide below for more information. Specific command syntax is provided in {ref}`howto-upgrade-microcloud-full-example`.
 ```
 
 Updating MicroCloud allows access to the latest set of features and fixes in the tracked channels for the various snaps. During an update, snaps are refreshed to the most up-to-date version for their tracked channel. This does not introduce breaking changes.
@@ -178,7 +178,7 @@ sudo microcloud status
 
 ```{note}
 The status command was introduced in MicroCloud version 2.
-See {ref}`howto-upgrade` on how to upgrade to another track.
+Refer to {ref}`howto-upgrade` on how to upgrade to another track.
 ```
 
 (howto-upgrade)=
@@ -188,7 +188,7 @@ Upgrading MicroCloud means to switch to a newer track with major improvements an
 
 During an upgrade, the snaps channel will be switched to another track.
 This might introduce breaking changes for MicroCloud and its components and should be done with care.
-See {ref}`howto-update` for regular non-breaking updates.
+Refer to {ref}`howto-update` for regular non-breaking updates.
 
 Before you update, ensure that all snaps are {ref}`synchronized using the cohort flag <howto-update-sync>`. The `--cohort` flag is only necessary if the snap is not `in-cohort`.
 
@@ -249,7 +249,7 @@ sudo microcloud status
 
 Use the commands below to upgrade all components from MicroCloud 1 to MicroCloud 2.
 
-Omit the `--cohort="+"` flag if the MicroCeph snap is already `in-cohort`. If unsure, see: {ref}`howto-update-sync`.
+Omit the `--cohort="+"` flag if the MicroCeph snap is already `in-cohort`. If unsure, refer to {ref}`howto-update-sync`.
 
 First, upgrade MicroCeph on all cluster members, one by one:
 

--- a/doc/reference/release-notes/index.md
+++ b/doc/reference/release-notes/index.md
@@ -11,14 +11,14 @@ This page lists recent release notes for MicroCloud, which highlight new feature
 
 ## Release policy and schedule
 
-For details about the release policy and schedule, along with information about the MicroCloud snaps and channels, see: {ref}`ref-releases-snaps`.
+For details about the release policy and schedule, along with information about the MicroCloud snaps and channels, refer to {ref}`ref-releases-snaps`.
 
 ## Upgrade instructions
 
-For full instructions on updating or upgrading MicroCloud, see {ref}`howto-update-upgrade`:
+For full instructions on updating or upgrading MicroCloud, refer to {ref}`howto-update-upgrade`:
 
-- Feature releases are published on the {ref}`current feature track <ref-snaps-microcloud-track-feature>`. If you are already following this track and you want to manually update to the most recent feature release, see the {ref}`howto-update` section.
-- To move from one {ref}`LTS track <ref-snaps-microcloud-tracks-lts>` to a higher LTS track or the feature track, see the {ref}`howto-upgrade` section.
+- Feature releases are published on the {ref}`current feature track <ref-snaps-microcloud-track-feature>`. If you are already following this track and you want to manually update to the most recent feature release, consult the {ref}`howto-update` section.
+- To move from one {ref}`LTS track <ref-snaps-microcloud-tracks-lts>` to a higher LTS track or the feature track, consult the {ref}`howto-upgrade` section.
 
 (ref-release-notes-releases)=
 ## Releases
@@ -39,4 +39,4 @@ MicroCloud 2.1.0 LTS <https://discourse.ubuntu.com/t/microcloud-2-1-0-lts-has-be
 
 MicroOVN does not yet publish release notes.
 
-See {ref}`ref-releases-matrix` for the matrix of compatible releases across MicroCloud and its components.
+Refer to {ref}`ref-releases-matrix` for the matrix of compatible releases across MicroCloud and its components.

--- a/doc/reference/releases-snaps.md
+++ b/doc/reference/releases-snaps.md
@@ -19,7 +19,7 @@ The releases above are currently under standard support, meaning they receive bu
 
 The snaps for MicroCloud, LXD, MicroCeph, and MicroOVN must be installed on all members of the same MicroCloud cluster. The versions installed by each snap must be compatible with one another, and the same version of each snap must be installed on all cluster members.
 
-Also see: {ref}`howto-update-upgrade` and {ref}`howto-snap`.
+Refer to {ref}`howto-update-upgrade` and {ref}`howto-snap` for additional details.
 
 (ref-releases-microcloud)=
 ## MicroCloud releases
@@ -75,7 +75,7 @@ To view all available channels for MicroCloud, run:
 snap info microcloud
 ```
 
-For more information about channels, see {ref}`snap:explanation-how-snaps-work-channels-and-tracks` in the Snap documentation.
+For more information about channels, refer to {ref}`snap:explanation-how-snaps-work-channels-and-tracks` in the Snap documentation.
 
 (ref-snaps-microcloud-tracks)=
 ### Tracks
@@ -108,7 +108,7 @@ For each MicroCloud track, there are three risk levels: `stable`, `candidate`, a
 
 We recommend that you use the `stable` risk level to install fully tested releases; this is the only risk level supported under [Ubuntu Pro](https://ubuntu.com/pro), as well as the default risk level if one is not specified at install. The `candidate` and `edge` levels offer newer but less-tested updates, posing higher risk.
 
-For more information about risk levels, see {ref}`snap:explanation-how-snaps-work-channels-and-tracks` in the Snap documentation.
+For more information about risk levels, refer to {ref}`snap:explanation-how-snaps-work-channels-and-tracks` in the Snap documentation.
 
 (ref-releases-snaps-components)=
 ## For MicroCloud components
@@ -116,7 +116,7 @@ For more information about risk levels, see {ref}`snap:explanation-how-snaps-wor
 (ref-releases-snaps-lxd)=
 ### LXD
 
-LXD follows a similar approach to its releases and snap as MicroCloud, including an LTS release every two years and more frequent feature releases on a feature track. For details, see {ref}`LXD releases and snap <lxd:ref-releases-snap>`.
+LXD follows a similar approach to its releases and snap as MicroCloud, including an LTS release every two years and more frequent feature releases on a feature track. For details, refer to {ref}`LXD releases and snap <lxd:ref-releases-snap>`.
 
 (ref-releases-snaps-microceph)=
 ### MicroCeph
@@ -127,7 +127,7 @@ The version of Ceph initially included in the release of an LTS version of Ubunt
 
 MicroCeph typically does not publish feature releases, but provides periodic non-breaking updates to existing releases, along with a new stable release corresponding to each Ceph release series. These MicroCeph releases share their upstream's release names (such as `quincy` or `squid`).
 
-For details about MicroCeph, see {doc}`microceph:index`. For more information about the Ceph release cycle, visit the Ceph documentation: {ref}`ceph:ceph-releases-general`.
+For details about MicroCeph, refer to the {doc}`MicroCeph documentation <microceph:index>`. For more information about the Ceph release cycle, visit the {ref}`Ceph documentation <ceph:ceph-releases-general>`.
 
 (ref-releases-snaps-microovn)=
 ### MicroOVN releases and snap
@@ -136,7 +136,7 @@ The upstream [OVN](https://www.ovn.org/) project follows a six-month release cad
 
 Every two years, the March version of OVN becomes an LTS version, such as the `24.03` version released in March of 2024. MicroOVN publishes versions that correspond to these upstream LTS versions. Stable maintenance is provided through upstream point releases for OVN and bugfixes for the snap deployment.
 
-For more information, see the MicroOVN documentation:
+For more information, refer to the MicroOVN documentation:
 
 - {doc}`microovn:reference/release-process`
 - {ref}`microovn:snap channels`
@@ -148,7 +148,7 @@ By default, installed snaps update automatically when new releases are published
 
 With MicroCloud, this can be problematic because its component snaps must always use {ref}`compatible versions <ref-releases-matrix>`, and because all members of a cluster must use the same version of each snap.
 
-To prevent issues, {ref}`hold updates for MicroCloud and its components <howto-update-hold>`. Furthermore, ensure that the all snaps are set to `in-cohort` (see {ref}`howto-update-sync`).
+To prevent issues, {ref}`hold updates for MicroCloud and its components <howto-update-hold>`. Furthermore, ensure that all snaps are set to `in-cohort` (refer to {ref}`howto-update-sync` for details).
 
 ## Related topics
 

--- a/doc/tutorial/single-member.md
+++ b/doc/tutorial/single-member.md
@@ -32,8 +32,8 @@ If you cannot meet the requirements below, try the {ref}`multi-member cluster tu
   sudo snap remove --purge lxd
   ```
 
-- If LXD is installed but not initialized, you do not need to remove it. However, ensure that it is running the most recent LTS version. See the LXD documentation: {ref}`lxd:howto-snap`.
-- If MicroCeph or MicroOVN are already installed, ensure that they are also running their most recent LTS versions. To ensure that the versions are compatible for MicroCloud, refer to: {ref}`ref-releases-matrix`.
+- If LXD is installed but not initialized, you do not need to remove it. However, ensure that it is running the most recent LTS version. Refer to {ref}`lxd:howto-snap` in the LXD documentation for details.
+- If MicroCeph or MicroOVN are already installed, ensure that they are also running their most recent LTS versions. To ensure that the versions are compatible for MicroCloud, refer to {ref}`ref-releases-matrix`.
 - Due to variation in physical machine setups, it is beyond the scope of this tutorial to instruct you on how to set up your network interfaces and storage disks. Thus, this tutorial requires a higher level of knowledge of server management on your part. If you require step-by-step instructions, follow the {ref}`multi-member cluster tutorial<tutorial-multi>` instead.
 
 (tutorial-single-requirements-storage)=
@@ -67,7 +67,7 @@ sudo snap install lxd microceph microovn microcloud --cohort="+"
 ```{admonition} About the cohort flag
 :class: note
 The `--cohort="+"` flag in the command ensures that the same version of the snap is installed on all cluster members.
-See {ref}`howto-update-sync` for more information.
+Refer to {ref}`howto-update-sync` for more information.
 ```
 
 (tutorial-single-hold-updates)=
@@ -81,14 +81,14 @@ Thus, whenever you install MicroCloud and its components, pause automatic update
 sudo snap refresh lxd microceph microovn microcloud --hold
 ```
 
-For more information, see {ref}`howto-update-hold`.
+For more information, refer to {ref}`howto-update-hold`.
 
 (tutorial-single-init)=
 ## Initialize MicroCloud
 
 The initialization process sets up LXD, MicroCeph, and MicroOVN to work together as a MicroCloud. When you initialize MicroCloud, you can optionally set up the MicroCloud cluster using a join mechanism to add multiple machines as cluster members. In this tutorial, we will set up a single cluster member during initialization; you can optionally add more cluster members afterward. The initialization also sets up MicroCloud storage and network configurations.
 
-For a detailed look at the initialization process, see: {ref}`explanation-initialization`.
+For a detailed look at the initialization process, refer to {ref}`explanation-initialization`.
 
 ```{tip}
 In this tutorial, we initialize MicroCloud interactively. Later, you might want to look into using a preseed file for {ref}`howto-initialize-preseed` to automate deployment with a pre-defined configuration.
@@ -193,13 +193,13 @@ By default, MicroCloud uses your internal network for both. Press {kbd}`Enter` t
 
 ```{admonition} Using other networks for Ceph
 :class: note
-MicroCloud and MicroCeph support using separate networks for Ceph internal and public traffic if needed. We don't need this for the purposes of this tutorial, but if you'd like to know more, see: {ref}`howto-ceph-networking`.
+MicroCloud and MicroCeph support using separate networks for Ceph internal and public traffic if needed. We don't need this for the purposes of this tutorial, but if you'd like to know more, refer to {ref}`howto-ceph-networking`.
 ```
 
 (tutorial-single-init-network-uplink)=
 ### Configure the uplink network
 
-Next, you'll set up the uplink network that provides external connectivity from your cluster members to other networks, such as the internet. This uplink network is configured with MicroOVN, a minimal wrapper around the OVN (Open Virtual Network) project. For more information about OVN networking, see {ref}`exp-networking`.
+Next, you'll set up the uplink network that provides external connectivity from your cluster members to other networks, such as the internet. This uplink network is configured with MicroOVN, a minimal wrapper around the OVN (Open Virtual Network) project. For more information about OVN networking, refer to {ref}`exp-networking`.
 
 MicroCloud will ask:
 
@@ -255,7 +255,7 @@ This refers to an OVN underlay network. Press {kbd}`Enter` to accept the default
 
 ```{admonition} Using a dedicated underlay network
 :class: note
-MicroCloud and MicroOVN support using a dedicated underlay network for OVN traffic. We don't need this for the purposes of this tutorial, but if you'd like to know more, see: {ref}`howto-ovn-underlay`.
+MicroCloud and MicroOVN support using a dedicated underlay network for OVN traffic. We don't need this for the purposes of this tutorial, but if you'd like to know more, refer to {ref}`howto-ovn-underlay`.
 ```
 
 You should then see the following output:
@@ -445,7 +445,7 @@ locations:
 project: default
 ```
 
-The OVN network spans across all MicroCloud cluster members and handles internal traffic. It also provides external connectivity to MicroCloud instances by connecting to the uplink network via a virtual router. This virtual router is active on only one cluster member at a time. When there are multiple cluster members, if the cluster member with the virtual router goes offline, the virtual router can migrate to a different cluster member to ensure uplink connectivity. For details, see: {ref}`exp-networking-ovn-architecture`.
+The OVN network spans across all MicroCloud cluster members and handles internal traffic. It also provides external connectivity to MicroCloud instances by connecting to the uplink network via a virtual router. This virtual router is active on only one cluster member at a time. When there are multiple cluster members, if the cluster member with the virtual router goes offline, the virtual router can migrate to a different cluster member to ensure uplink connectivity. For details, refer to {ref}`exp-networking-ovn-architecture`.
 
 Within the output of the previous command (`lxc network show default`), find the value for `volatile.network.ipv4.address`. It should match the first IPv4 address in the subnet range you provided for the uplink network during configuration. This is the IP address for the virtual router.
 
@@ -666,7 +666,7 @@ This ping should fail. Other instances should not be reachable because they are 
 
 ```{admonition} OVN peer routing
 :class: tip
-If you want to enable direct connectivity for instances on different OVN subnets, see: {ref}`lxd:network-ovn-peers`.
+If you want to enable direct connectivity for instances on different OVN subnets, refer to {ref}`lxd:network-ovn-peers`.
 ```
 
 Exit the `u4` container:
@@ -678,7 +678,7 @@ exit
 (tutorial-single-ui)=
 ## Access the UI
 
-Instead of managing your instances and your LXD setup from the command line, you can also use the LXD UI. See {ref}`lxd:access-ui` for more information.
+Instead of managing your instances and your LXD setup from the command line, you can also use the LXD UI. Refer to {ref}`lxd:access-ui` for more information.
 
 Check the LXD cluster list to determine the URL of the cluster member.
 
@@ -719,8 +719,8 @@ You should now see the LXD UI prompting you to set up a certificate. Follow the 
 (tutorial-single-next)=
 ## Next steps
 
-To learn how to add more physical machines as cluster members to your MicroCloud, see: {ref}`howto-member-add`.
+To learn how to add more physical machines as cluster members to your MicroCloud, refer to {ref}`howto-member-add`.
 
-See {ref}`howto-commands` for a reference of the most common commands.
+Consult {ref}`howto-commands` for a reference of the most common commands.
 
 If you're new to LXD, check out the {ref}`LXD tutorials <lxd:first-steps>` to familiarize yourself with what you can do in LXD. You can skip the sections for installing and initializing LXD, because LXD is already operational as part of your MicroCloud setup.


### PR DESCRIPTION
This PR includes edits intended to bring the documentation into alignment with inclusive language and style guide standards:

1. This PR replaces "see" (as in `see <cross reference>`) with alternatives such as "refer to", "consult", and "visit."
2. This PR removes Latinisms by replacing "e.g." with "for example."

This PR also aims for consistency in punctuation by removing colons that precede in-line cross references (for example, `Refer to: <ref> for details` becomes `Refer to <ref> for details`).

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.