### PR TITLE
doc: fix css for LXD integrated docs header

### DIFF
--- a/doc/.sphinx/_integration/add_config.py
+++ b/doc/.sphinx/_integration/add_config.py
@@ -12,6 +12,7 @@ html_context['microovn_tag'] = "../microovn/_static/microovn.png"
 if project == "LXD":
     html_baseurl = "https://documentation.ubuntu.com/lxd/latest/"
     html_js_files.append('rtd-search.js')
+    html_css_files = globals().get('html_css_files', []) + ['override-header.css']
     tags.add('integrated')
 elif project == "MicroCeph":
     html_baseurl = "https://canonical-microceph.readthedocs-hosted.com/en/latest/"

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -51,7 +51,7 @@ integrate:
 	cp .sphinx/_integration/microcloud.html integration/microcloud/_templates/header.html
 	cp .sphinx/_integration/header.css integration/microcloud/_static/
 	cp .sphinx/_integration/lxd.html integration/lxd/doc/_templates/header.html
-	cp .sphinx/_integration/header.css integration/lxd/doc/_static/
+	cp .sphinx/_integration/override-header.css integration/lxd/doc/_static/
 	cp .sphinx/_integration/microceph.html integration/microceph/docs/.sphinx/_templates/header.html
 	cp .sphinx/_integration/override-header.css integration/microceph/docs/.sphinx/_static/
 	cp .sphinx/_integration/microovn.html integration/microovn/docs/.sphinx/_templates/header.html


### PR DESCRIPTION
This updates the docs configuration to use the correct CSS file for the integrated LXD docs header. Since recent docs tooling updates in the LXD repo, a different CSS file was being pulled in, causing the LXD integrated docs header to look like this:
<img width="1100" height="182" alt="image" src="https://github.com/user-attachments/assets/242ebf72-48aa-4e64-ae51-a4b7f17ff648" />

This should fix it so that it looks like the headers for the others, which looks like this:
<img width="1589" height="173" alt="image" src="https://github.com/user-attachments/assets/112512c5-92c9-4977-8c14-da493f152bcd" />



## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.