### PR TITLE
doc: Move the description of CLI commands to reference material

### DIFF
--- a/doc/explanation/microcloud.md
+++ b/doc/explanation/microcloud.md
@@ -56,7 +56,7 @@ For details, refer to {ref}`howto-ui`.
 
 ```{admonition} Other client interfaces
 :class: tip
-You can also manage MicroCloud through the {ref}`command line <howto-commands>` or LXD's {ref}`lxd:rest-api`.
+You can also manage MicroCloud through the {ref}`command line <ref-commands>` or LXD's {ref}`lxd:rest-api`.
 ```
 
 (exp-microcloud-scale)=

--- a/doc/how-to/index.md
+++ b/doc/how-to/index.md
@@ -18,7 +18,6 @@ Access the UI </how-to/ui>
 Automate a test deployment with Terraform </how-to/terraform_automation>
 Configure Ceph networking </how-to/ceph_networking>
 Configure OVN underlay </how-to/ovn_underlay>
-Work with MicroCloud </how-to/commands>
 Manage cluster members <members_manage>
 Update and upgrade </how-to/update_upgrade>
 Manage the snaps </how-to/snaps>

--- a/doc/index.md
+++ b/doc/index.md
@@ -13,7 +13,7 @@ Deploy a low-touch, open source cloud platform in minutes with MicroCloud.
 
 MicroCloud creates a lightweight cluster of machines that operates as a scalable private cloud. It combines LXD for virtualization, MicroCeph for distributed storage, and MicroOVN for networking—all automatically configured by the [MicroCloud snap](https://snapcraft.io/microcloud) for {ref}`reproducible, scalable deployments <exp-microcloud-scale>`.
 
-With MicroCloud, you can eliminate the complexity of manual setup and quickly benefit from {ref}`high availability <exp-microcloud-ha>`, {ref}`streamlined security updates <ref-releases-snaps>`, and {ref}`fine-grained access control for multi-tenancy <exp-microcloud-access-control>`. Cluster members can run {ref}`full virtual machines or lightweight system containers <exp-microcloud-vms-containers>` with bare-metal performance. Manage it through your choice of client interfaces, including a {ref}`graphical UI <howto-ui>` and {ref}`CLI <howto-commands>`.
+With MicroCloud, you can eliminate the complexity of manual setup and quickly benefit from {ref}`high availability <exp-microcloud-ha>`, {ref}`streamlined security updates <ref-releases-snaps>`, and {ref}`fine-grained access control for multi-tenancy <exp-microcloud-access-control>`. Cluster members can run {ref}`full virtual machines or lightweight system containers <exp-microcloud-vms-containers>` with bare-metal performance. Manage it through your choice of client interfaces, including a {ref}`graphical UI <howto-ui>` and {ref}`CLI <ref-commands>`.
 
 MicroCloud is designed for small-scale private clouds and hybrid cloud extensions. Its efficiency and simplicity also make it an excellent choice for edge computing, test labs, and other resource-constrained use cases.
 

--- a/doc/redirects.py
+++ b/doc/redirects.py
@@ -5,4 +5,5 @@ redirects = {
     'how-to/remove_machine': '../member_remove',
     'how-to/add_machine': '../member_add',
     'how-to/shutdown_machine': '../member_shutdown',
+    'how-to/commands': '../../reference/commands',
 }

--- a/doc/reference/commands.md
+++ b/doc/reference/commands.md
@@ -4,8 +4,8 @@ myst:
     description: MicroCloud CLI command reference, a cheat sheet of essential MicroCloud/LXD commands for managing instances, storage, networks, and cluster operations.
 ---
 
-(howto-commands)=
-# How to work with MicroCloud via the CLI (command cheat sheet)
+(ref-commands)=
+# Common CLI commands
 
 This guide lists CLI commands for common operations in MicroCloud.
 This command list is not meant to be exhaustive, but it gives a general overview and serves as an entry point to working with MicroCloud through the CLI. 

--- a/doc/reference/index.md
+++ b/doc/reference/index.md
@@ -30,3 +30,10 @@ Learn about the MicroCloud Cluster Manager's architecture and how it connects mu
 Cluster Manager architecture </reference/cluster-manager-architecture>
 /reference/cluster-manager-api
 ```
+
+## Commands
+
+```{toctree}
+:maxdepth: 1
+/reference/commands
+```

--- a/doc/tutorial/multi-member.md
+++ b/doc/tutorial/multi-member.md
@@ -1098,7 +1098,7 @@ See {ref}`lxd:access-ui` for more information.
 (tutorial-multi-next)=
 ## Next steps
 
-Now that your MicroCloud is up and running, you can start using it! If you're already familiar with LXD, see {ref}`howto-commands` for a reference of the most common commands.
+Now that your MicroCloud is up and running, you can start using it! If you're already familiar with LXD, see {ref}`ref-commands` for a reference of the most common commands.
 
 If you're new to LXD, check out the {ref}`LXD tutorial <lxd:tutorial-first-steps>` to familiarize yourself with what you can do in LXD. It guides you through common initial operations in LXD, using either the CLI or a web-based graphical UI. Skip the first section about installing and initializing LXD, because LXD is already operational as part of your MicroCloud setup.
 

--- a/doc/tutorial/single-member.md
+++ b/doc/tutorial/single-member.md
@@ -721,6 +721,6 @@ You should now see the LXD UI prompting you to set up a certificate. Follow the 
 
 To learn how to add more physical machines as cluster members to your MicroCloud, refer to {ref}`howto-member-add`.
 
-Consult {ref}`howto-commands` for a reference of the most common commands.
+Consult {ref}`ref-commands` for a reference of the most common commands.
 
 If you're new to LXD, check out the {ref}`LXD tutorials <lxd:first-steps>` to familiarize yourself with what you can do in LXD. You can skip the sections for installing and initializing LXD, because LXD is already operational as part of your MicroCloud setup.


### PR DESCRIPTION
This PR moves the page that describes CLI commands from the how-to guides to the reference material. In the process, this PR also changes the title of that page as well as its label to reflect its new categorization.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.