### PR TITLE
doc: remove duplicate /microcloud in URL path

### DIFF
--- a/doc/.sphinx/_integration/add_config.py
+++ b/doc/.sphinx/_integration/add_config.py
@@ -1,7 +1,7 @@
 # Links to other doc sets (used in the header)
 # All paths are relative to the URL of one doc set
-html_context['microcloud_path'] = "../microcloud"
-html_context['microcloud_tag'] = "../microcloud/_static/tag.png"
+html_context['microcloud_path'] = ".."
+html_context['microcloud_tag'] = "../_static/tag.png"
 html_context['lxd_path'] = "../lxd"
 html_context['lxd_tag'] = "../lxd/_static/tag.png"
 html_context['microceph_path'] = "../microceph"

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -82,7 +82,7 @@ html: integrate
 	cd integration/lxd/doc/ && $(MAKE) html BUILDDIR=$(current_dir)/_build/lxd
 	cd integration/microceph/docs/ && $(MAKE) html BUILDDIR=$(current_dir)/_build/microceph
 	cd integration/microovn/docs/ && $(MAKE) html BUILDDIR=$(current_dir)/_build/microovn
-	$(MAKE) -f Makefile.sp sp-html BUILDDIR=$(current_dir)/_build/microcloud ADDPREREQS='pyyaml'
+	$(MAKE) -f Makefile.sp sp-html BUILDDIR=$(current_dir)/_build ADDPREREQS='gitpython pyyaml'
 
 # `html-rtd` builds the integrated docs, with the correct paths for Read the Docs.
 # This target is used by the Read the Docs build.
@@ -90,7 +90,7 @@ html-rtd:
 	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -C integration/lxd/doc/ html-rtd BUILDDIR=$(READTHEDOCS_OUTPUT)/html/lxd
 	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -C integration/microceph/docs/ html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microceph
 	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -C integration/microovn/docs/ html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microovn
-	ADDPREREQS='gitpython pyyaml' PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -f Makefile.sp sp-html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microcloud
+	ADDPREREQS='gitpython pyyaml' PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -f Makefile.sp sp-html BUILDDIR=$(READTHEDOCS_OUTPUT)/html
 
 # `spelling` checks only the MicroCloud docs.
 spelling: clean-doc microcloud

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -143,7 +143,7 @@ html_baseurl = 'https://documentation.ubuntu.com/microcloud/'
 # based on the version if built in RTD
 if 'READTHEDOCS_VERSION' in os.environ:
     rtd_version = os.environ["READTHEDOCS_VERSION"]
-    sitemap_url_scheme = f'{rtd_version}/microcloud/{{link}}'
+    sitemap_url_scheme = f'{rtd_version}/{{link}}'
 else:
     sitemap_url_scheme = '{link}'
 
@@ -310,9 +310,15 @@ rst_prolog = '''
 
 if not ('SINGLE_BUILD' in os.environ and os.environ['SINGLE_BUILD'] == 'True'):
     exec(compile(source=open('.sphinx/_integration/add_config.py').read(), filename='.sphinx/_integration/add_config.py', mode='exec'))
+    # MicroCloud docs are at the URL root, so override the relative paths to sibling doc sets
+    html_context['lxd_path'] = "lxd"
+    html_context['lxd_tag'] = "lxd/_static/tag.png"
+    html_context['microceph_path'] = "microceph"
+    html_context['microceph_tag'] = "microceph/_static/tag.png"
+    html_context['microovn_path'] = "microovn"
+    html_context['microovn_tag'] = "microovn/_static/microovn.png"
     custom_html_static_path = ['integration/microcloud/_static']
     custom_templates_path = ['integration/microcloud/_templates']
-    redirects['../index'] = 'microcloud/'
     custom_tags.append('integrated')
 
 # Load substitutions from YAML file


### PR DESCRIPTION
This PR updates the path for the MicroCloud part of the integrated docs so that the second duplicate /microcloud is removed from the docs path. For example:

https://documentation.ubuntu.com/microcloud/latest/microcloud/reference/

becomes

https://documentation.ubuntu.com/microcloud/latest/reference

Per request from the Web team before we can migrate MicroCloud docs to canonical.com/microcloud/docs. 

Note: A RTD redirect (not in Sphinx configuration but in RTD settings) needs to be put in place at the same time this update is merged, and again when the update is backported to the v2-edge branch. I will set up the redirects in RTD and disable it for now, so that it's easy to enable them at merge time. 

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.