### PR TITLE
doc: append version number in RTD version switcher flyout menu

### DIFF
--- a/doc/.sphinx/_templates/base.html
+++ b/doc/.sphinx/_templates/base.html
@@ -3,6 +3,7 @@
 {% block theme_scripts %}
 <script>
   const github_url = "{{ github_url }}";
+  window.flyoutDefaultVersionLabel = "{{ flyout_default_version_label }}";
 </script>
 {% endblock theme_scripts %}
 

--- a/doc/_static/rtd-versions-flyout.js
+++ b/doc/_static/rtd-versions-flyout.js
@@ -1,0 +1,59 @@
+document.addEventListener("readthedocs-addons-data-ready", function (event) {
+    // This script customizes the RTD flyout to show a version label next to "default", based on an RTD environment variable.
+
+    // The RTD flyout addon renders <readthedocs-flyout> before firing this
+    // event, so the element is already in the DOM by the time this listener
+    // runs. We check immediately, and also watch for any late insertion.
+
+    // Read the version label injected at build time from the FLYOUT_DEFAULT_VERSION_LABEL env var.
+    // This var needs to be manually defined in the RTD project dashboard, to whatever should appear in parenthese next to "default" in the flyout, such as "v2".
+    const versionLabel = window.flyoutDefaultVersionLabel;
+    if (!versionLabel) return;
+
+    function patchFlyout(root) {
+        let patched = false;
+        // Patch the version links in the dropdown list.
+        root.querySelectorAll("a").forEach(link => {
+            if (link.textContent.trim() === "default") {
+                link.textContent = `default (${versionLabel})`;
+                patched = true;
+            }
+        });
+        // Patch the "default" label shown on the flyout toggle button.
+        const versionSpan = root.querySelector("span.version");
+        if (versionSpan) {
+            versionSpan.childNodes.forEach(node => {
+                if (node.nodeType === Node.TEXT_NODE && node.textContent.trim() === "default") {
+                    node.textContent = node.textContent.replace("default", `default (${versionLabel})`);
+                    patched = true;
+                }
+            });
+        }
+        return patched;
+    }
+
+    function watchAndPatch(root) {
+        if (patchFlyout(root)) return;
+        // Shadow DOM content may not be fully rendered yet; watch for it.
+        const observer = new MutationObserver(function () {
+            if (patchFlyout(root)) observer.disconnect();
+        });
+        observer.observe(root, { childList: true, subtree: true });
+    }
+
+    // Check immediately — the flyout is likely already in the DOM.
+    const flyout = document.querySelector("readthedocs-flyout");
+    if (flyout) {
+        watchAndPatch(flyout.shadowRoot || flyout);
+        return;
+    }
+
+    // Fallback: watch for the element to be inserted later.
+    const bodyObserver = new MutationObserver(function () {
+        const flyout = document.querySelector("readthedocs-flyout");
+        if (!flyout) return;
+        bodyObserver.disconnect();
+        watchAndPatch(flyout.shadowRoot || flyout);
+    });
+    bodyObserver.observe(document.body, { childList: true, subtree: true });
+});

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -247,6 +247,7 @@ custom_html_css_files = [
 # Add JavaScript files (located in .sphinx/_static/ or from external link)
 custom_html_js_files = [
     'https://assets.ubuntu.com/v1/287a5e8f-bundle.js',
+    'rtd-versions-flyout.js',
 ]
 
 ## The following settings override the default configuration.
@@ -320,6 +321,9 @@ if os.path.exists('./substitutions.yaml'):
     with open('./substitutions.yaml', 'r') as fd:
         myst_substitutions = yaml.safe_load(fd.read())
 
+# Version label shown in the RTD flyout next to "default", in parentheses.
+# Set the FLYOUT_DEFAULT_VERSION_LABEL environment variable in the RTD project dashboard.
+html_context['flyout_default_version_label'] = os.environ.get('FLYOUT_DEFAULT_VERSION_LABEL', '')
 
 # SwaggerUI configuration
 


### PR DESCRIPTION
We recently updated the default version of the docs to use the name/slug of "default", and it's set up to use the branch corresponding to the most current LTS. This way, we can permanently point to the same URL for the default docs, without having to change the URL when we have a new LTS.

Unfortunately, this means that in the ReadTheDocs version switcher flyout menu, the default version appears as "default" without anything to indicate the version number. This PR adds custom JavaScript that, along with a custom ReadTheDocs environment variable, updates the flyout to add the version after default, like this:

<img width="341" height="360" alt="image" src="https://github.com/user-attachments/assets/7d6d0712-6157-493d-b0a1-de0176c1b5d8" />

Note for the future: the RTD environment variable is configured as FLYOUT_DEFAULT_VERSION_LABEL at https://app.readthedocs.com/dashboard/canonical-microcloud/environmentvariables/ and must be updated when a new LTS is released, along with the change to the branch corresponding to the "default" version slug in the RTD version configuration. RTD does not allow you to edit environment variables, only delete and create them, so you must delete the existing one and create a new one with the same name. It _must_ be set as Public (via checkbox at creation) so that the custom javascript can access it when run from the browser.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.