### PR TITLE
doc: update homepage to match standard pattern

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -25,36 +25,16 @@ MicroCloud is designed for small-scale private clouds and hybrid cloud extension
 
 ---
 
-## In the MicroCloud documentation
+## In this documentation
 
-````{grid} 1 1 2 2
-
-```{grid-item} [Tutorials](/tutorial/index)
-
-**Start here**: hands-on {ref}`introductions to MicroCloud <get-started>` for new users
-```
-
-```{grid-item} [How-to guides](/how-to/index)
-
-**Step-by-step guides** covering key operations and common tasks such as {ref}`installing MicroCloud <howto-install>`, {ref}`adding <howto-member-add>` and {ref}`removing <howto-member-remove>` cluster members, and {ref}`accessing the UI <howto-ui>`
-```
-
-````
-
-````{grid} 1 1 2 2
-:reverse:
-
-```{grid-item} [Reference](/reference/index)
-
-**Technical information** - Detailed [requirements](/reference/requirements)
-```
-
-```{grid-item} [Explanation](/explanation/index)
-
-**Discussion and clarification** of key topics such as {ref}`networking <exp-networking>` and the [initialization process](/explanation/initialization/)
-```
-
-````
+| | |
+|---|---|
+| Start here | {ref}`Tutorial using multiple virtualized cluster members <tutorial-multi>` • {ref}`Tutorial using a single physical cluster member <tutorial-single>` • {ref}`MicroCloud overview <exp-microcloud>` |
+| Storage and networks | {ref}`Understand local vs. distributed storage <exp-storage>` • {ref}`Understand MicroCloud's networking approach <exp-networking>` • {ref}`Configure an OVN underlay network <howto-ovn-underlay>` • {ref}`Configure a dedicated Ceph network <howto-ceph-networking>` • {ref}`Add a service <howto-add-service>` |
+| Cluster management | {ref}`Add <howto-member-add>`, {ref}`remove <howto-member-remove>`, and {ref}`shut down <howto-member-shutdown>` cluster members • {ref}`Access the web UI <howto-ui>` • {ref}`Common CLI commands reference <ref-commands>` |
+| Multiple clusters | {ref}`Cluster Manager how-to guide <howto-cluster-manager>`, {ref}`reference architecture <ref-cluster-manager-architecture>`, and {ref}`API reference <ref-cluster-manager-api>` |
+| Setup and maintenance | {ref}`Installation <howto-install>` • {ref}`Initialization <howto-initialize>` • {ref}`Automate initialization with Terraform <howto-terraform-automation>` • {ref}`Update and upgrade <howto-update-upgrade>` • {ref}`Recover a cluster <howto-recover>` • {ref}`security` |
+| Releases and requirements | {ref}`Supported and compatible releases <ref-releases-matrix>` •  {ref}`Snaps and releases reference <ref-releases-snaps>` • {ref}`ref-release-notes` • {ref}`Setup requirements <reference-requirements>` |
 
 ---
 
@@ -74,12 +54,27 @@ Also, while each component's documentation includes instructions for removing cl
 
 ## Project and community
 
-MicroCloud is a member of the Ubuntu family. It’s an open source project that warmly welcomes community projects, contributions, suggestions, fixes and constructive feedback.
+MicroCloud is a member of the [Canonical](https://canonical.com) family. It’s an open source project that warmly welcomes community contributions, suggestions, fixes, and constructive feedback.
 
-- [MicroCloud snap](https://snapcraft.io/microcloud)
-- [Contribute](https://github.com/canonical/microcloud)
-- [Get support](https://discourse.ubuntu.com/c/lxd/microcloud/145)
-- [Thinking about using MicroCloud for your next project? Get in touch!](https://canonical.com/microcloud)
+### Get involved
+
+- {ref}`Support <howto-support>`
+- [Discussion forum](https://discourse.ubuntu.com/c/lxd/microcloud/145)
+- {ref}`Contribute <howto-contribute>`
+
+### Releases
+
+- {ref}`ref-release-notes`
+
+### Governance and policies
+
+- [Code of conduct](https://ubuntu.com/community/docs/ethos/code-of-conduct)
+
+### Commercial support
+
+Thinking about using MicroCloud for your next project? [Get in touch](https://canonical.com/microcloud/contact-us)!
+
+
 
 
 ```{toctree}


### PR DESCRIPTION
This PR updates the MicroCloud homepage to meet the company-wide docs standard pattern, including a new "In this documentation" section. This is similar to https://github.com/canonical/lxd/pull/18118 but uses a simplified variation of the standard pattern used in LXD's homepage, since there are fewer pages in the MicroCloud documentation. 

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.