### PR TITLE
doc: update how-to, reference landing pages

### DIFF
--- a/doc/explanation/index.md
+++ b/doc/explanation/index.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: Deep-dive explanations that introduce you to concepts in MicroCloud, such as its networking approach and local versus distributed storage.
+    description: An index of explanations about MicroCloud concepts, such as its relationship to LXD, Ceph, and OVN and its approach to networking, storage, and security.
 ---
 
 (explanation)=

--- a/doc/how-to/index.md
+++ b/doc/how-to/index.md
@@ -9,11 +9,12 @@ myst:
 
 These MicroCloud how-to guides cover key operations and processes.
 
-## Initial setup
+## Set up and deploy
 
-Follow these guides to install MicroCloud in a testing or production environment
-and initialize MicroCloud through interactive or automated configuration
-processes. You can also set up access to the MicroCloud UI.
+MicroCloud can be installed in testing or production environments and
+initialized interactively or through an automated process. Once deployed, the
+MicroCloud UI provides an interface alongside the {ref}`MicroCloud CLI
+<ref-commands>`.
 
 ```{toctree}
 :maxdepth: 1
@@ -23,10 +24,19 @@ Initialize MicroCloud </how-to/initialize>
 Access the UI </how-to/ui>
 ```
 
+Terraform makes it possible to automate the MicroCloud deployment process.
+
+```{toctree}
+:maxdepth: 1
+
+Deploy a MicroCloud test environment with Terraform </how-to/terraform_automation>
+```
+
 ## Configure services
 
-You can configure storage with MicroCeph and networking with MicroOVN during the
-initialization process, or you can add a service later.
+MicroCeph and MicroOVN make it possible to configure storage and networking to
+meet your needs. Configure these services during a MicroCloud initialization, or
+add a service later.
 
 ```{toctree}
 :maxdepth: 1
@@ -38,8 +48,8 @@ Add a service </how-to/add_service>
 
 ## Manage clusters and cluster members
 
-As your needs change, follow these steps to manage your clusters and cluster
-members and keep your deployment up to date.
+As your needs change, manage clusters and cluster members to keep your
+deployment up to date.
 
 ```{toctree}
 :maxdepth: 1
@@ -51,20 +61,7 @@ Update and upgrade </how-to/update_upgrade>
 Manage the snaps </how-to/snaps>
 ```
 
-## Automated deployment with Terraform
-
-Follow this guide to automate the deployment of MicroCloud with Terraform.
-
-```{toctree}
-:maxdepth: 1
-
-Deploy a MicroCloud test environment with Terraform </how-to/terraform_automation>
-```
-
 ## Engage with us
-
-Find out how to get community and commercial support, and learn how to
-contribute to the MicroCloud project.
 
 ```{toctree}
 :maxdepth: 1

--- a/doc/how-to/index.md
+++ b/doc/how-to/index.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: How-to guides for key MicroCloud operations, including installation, initialization, UI access, configuration, cluster management, updates, and more.
+    description: An index of how-to guides for key MicroCloud operations, including installation, initialization, UI access, configuration, management, and updates.
 ---
 
 (howto)=

--- a/doc/reference/index.md
+++ b/doc/reference/index.md
@@ -9,18 +9,6 @@ myst:
 
 This section provides technical reference guides for MicroCloud.
 
-## Requirements and releases
-
-Find out about requirements for a MicroCloud deployment, as well as information
-about its release cycles, release types, and snaps.
-
-```{toctree}
-:maxdepth: 1
-MicroCloud requirements </reference/requirements>
-/reference/releases-snaps
-/reference/release-notes/index
-```
-
 ## MicroCloud Cluster Manager
 
 Consult these pages for information about the system architecture and API of the
@@ -29,16 +17,26 @@ clusters.
 
 ```{toctree}
 :maxdepth: 1
+
 Cluster Manager architecture </reference/cluster-manager-architecture>
 /reference/cluster-manager-api
 ```
 
 ## Commands
 
-Use this command reference to perform common MicroCloud operations through the
-CLI.
+Consult this command reference to work with MicroCloud through the CLI.
 
 ```{toctree}
 :maxdepth: 1
+
 /reference/commands
+```
+## Requirements and releases
+
+```{toctree}
+:maxdepth: 1
+
+MicroCloud requirements </reference/requirements>
+/reference/releases-snaps
+/reference/release-notes/index
 ```

--- a/doc/reference/index.md
+++ b/doc/reference/index.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: Reference guides for MicroCloud such as deployment requirements, releases and snaps details, and the architecture of the MicroCloud Cluster Manager.
+    description: An index of MicroCloud reference guides covering the Cluster Manager architecture, CLI commands, deployment requirements, releases, and snap details.
 ---
 
 (reference)=

--- a/doc/tutorial/index.md
+++ b/doc/tutorial/index.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: Hands-on tutorials to install, initialize, and try out test deployments of MicroCloud, on a single physical machine or multiple virtual machines.
+    description: An index to hands-on tutorials to install, initialize, and try out test deployments of MicroCloud, on a single physical machine or multiple virtual machines.
 ---
 
 (get-started)=


### PR DESCRIPTION
This PR is a further update to the MicroCloud landing pages (How-to guides and Reference), building on PR #1337.

- Some summaries have been removed when the organization of the section is clear from the TOC titles (for example, "Get support" and "Contribute to MicroCloud")
- Other summaries have been edited to (1) minimize redundancy with the TOC titles and/or (2) emphasize what MicroCloud, MicroCeph, and MicroOVN make possible for users
- The reference materials have been reorganized to foreground the Cluster Manager and CLI
- The how-to guide headers have been edited to consistently begin with action verbs (specifically, changing "Initial setup" to "Set up and deploy")

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.