### PR TITLE
doc: add markdown linter

### DIFF
--- a/.github/workflows/markdown-style-checks.yml
+++ b/.github/workflows/markdown-style-checks.yml
@@ -1,0 +1,40 @@
+name: Markdown style checks
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    # Make sure bash is always invoked with `-eo pipefail`
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+    shell: bash
+
+on:
+  workflow_call:
+  push:
+    branches:
+    - main
+    paths:
+    - 'doc/**'   # Only run on changes to the doc directory
+  pull_request:
+    paths:
+    - 'doc/**'   # Only run on changes to the doc directory
+
+jobs:
+  markdown-lint:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+    - name: Create venv
+      working-directory: "doc"
+      run: make install
+    - name: Lint markdown
+      working-directory: "doc"
+      run: make lint-md

--- a/doc/.sphinx/.pymarkdown.json
+++ b/doc/.sphinx/.pymarkdown.json
@@ -1,0 +1,39 @@
+{
+    "plugins": {
+        "selectively_enable_rules": true,
+        "heading-style": {
+            "enabled": true,
+            "style": "atx"
+        },
+        "commands-show-output": {
+            "enabled": true
+        },
+        "no-missing-space-atx": {
+            "enabled": true
+        },
+        "heading-start-left": {
+            "enabled": true
+        },
+        "no-trailing-punctuation": {
+            "enabled": true,
+            "punctuation": ".,;。،；"
+        },
+        "blanks-around-lists": {
+            "enabled": true
+        },
+        "hr-style": {
+            "enabled": true
+        },
+        "no-empty-links": {
+            "enabled": true
+        },
+        "no-alt-text": {
+            "enabled": true
+        }
+    },
+    "extensions": {
+        "front-matter" : {
+            "enabled" : true
+        }
+    }
+}

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -15,6 +15,12 @@ LXDVERSION       = origin/main
 MICROCEPHVERSION = origin/main
 MICROOVNVERSION  = origin/main
 
+SPHINX_DIR       ?= .sphinx
+DOCS_SOURCEDIR   ?= .
+DOCS_VENVDIR     ?= $(SPHINX_DIR)/venv
+DOCS_VENV        ?= $(DOCS_VENVDIR)/bin/activate
+INTEGRATION_DIR  ?= integration
+
 # Put it first so that "make" without argument is like "make help".
 help:
 	@echo "\n" \
@@ -31,6 +37,7 @@ help:
         "* check accessibility:                       make pa11y \n" \
         "* check style guide compliance:              make vale \n" \
         "* check style guide compliance on target:    make vale TARGET=* \n" \
+        "* check markdown:                            make lint-md \n" \
         "* other possible targets:                    make <TAB twice> \n" \
         "------------------------------------------------------------- \n"
 
@@ -111,6 +118,35 @@ serve: html
 # `serve-microcloud` rebuilds the MicroCloud docs as a stand-along doc set and serves them.
 serve-microcloud: microcloud
 	cd $(current_dir)/_build/; python3 -m http.server --bind 127.0.0.1 8000
+
+pymarkdownlnt-install: install
+	@. $(DOCS_VENV); test -d $(DOCS_VENVDIR)/lib/python*/site-packages/pymarkdown || pip install pymarkdownlnt==0.9.35
+
+# Without --return-code-scheme explicit, pymarkdownlnt returns 1 for multiple scenarios
+# By using the explicit scheme, it only returns 1 when no files are found,
+# which should not result in failure
+lint lint-md: pymarkdownlnt-install
+	@echo "Running Markdown linting..."
+	@. $(DOCS_VENV); pymarkdownlnt \
+		--config $(SPHINX_DIR)/.pymarkdown.json \
+		--return-code-scheme explicit \
+		scan \
+			--recurse \
+			--exclude=$(SPHINX_DIR)/** \
+			--exclude=$(DOCS_VENVDIR)/** \
+			--exclude=$(INTEGRATION_DIR)/** \
+			$(DOCS_SOURCEDIR); \
+	status=$$?; \
+	if [ $$status -eq 1 ]; then \
+		echo "No Markdown files selected for linting"; \
+		echo "Passed"; \
+		exit 0; \
+	elif [ $$status -ne 0 ]; then \
+		echo "Failed"; \
+		exit $$status; \
+	else \
+		echo "Passed"; \
+	fi;
 
 install:
 	$(MAKE) -f Makefile.sp sp-install ADDPREREQS='pyyaml gitpython'

--- a/doc/how-to/snaps.md
+++ b/doc/how-to/snaps.md
@@ -67,6 +67,7 @@ For more information about managing snap services, visit {ref}`snap:how-to-guide
 ## Related topics
 
 How-to guides:
+
 - {ref}`howto-update-upgrade`
 - {ref}`howto-install`
 

--- a/doc/tutorial/multi-member.md
+++ b/doc/tutorial/multi-member.md
@@ -703,6 +703,7 @@ We continue using `micro1`, but you will see the same results on the others.
    1. Within the output of the previous command (`lxc network show default`), find the value for `volatile.network.ipv4.address`. This is the virtual router's IPv4 address.
 
    1. Ping that IPv4 address.
+   
    ```{terminal}
    :input: ping 192.0.2.100
    :user: root


### PR DESCRIPTION
This adds the pymarkdownlnt markdown linter as part of standard documentation tooling. It includes adding a GH CI workflow to run the linter when files inside doc/ are changed, and it also updates a couple of Markdown files that fail the linting rule that requires blank lines around lists.