### PR TITLE
make: Install golangci-lint from recommended source (v2-edge)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ check-system:
 .PHONY: check-static
 check-static:
 ifeq ($(shell command -v golangci-lint 2> /dev/null),)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$HOME/go/bin latest
+	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $$HOME/go/bin latest
 endif
 ifeq ($(shell command -v revive 2> /dev/null),)
 	go install github.com/mgechev/revive@latest


### PR DESCRIPTION
Backports https://github.com/canonical/microcloud/pull/1369