### PR TITLE
docs: homepage updates

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -2,8 +2,8 @@
 myst:
   html_meta:
     description: MicroCloud is a lightweight, open source cloud platform built on LXD, MicroCeph, and MicroOVN, ideal for private cloud, edge computing, and test labs.
-discourse: lxc:[Introducing&#32;MicroCloud](15871)
 relatedlinks: "[Install&#32;MicroCloud&#32;on&#32;Linux&#32;|&#32;Snap&#32;Store](https://snapcraft.io/microcloud)"
+discourse: lxc:[Introducing&#32;MicroCloud](15871)
 ---
 
 (home)=
@@ -52,6 +52,17 @@ Also, while each component's documentation includes instructions for removing cl
 
 ---
 
+## How this documentation is organized
+
+This documentation uses the [Diátaxis documentation structure](https://diataxis.fr/).
+
+- The {ref}`tutorials` introduce you to MicroCloud concepts and usage.
+- The {ref}`howto` provide detailed setup and usage instructions, including how to access the UI and manage cluster members.
+- The {ref}`reference` guides provide technical details, release notes, and common CLI commands.
+- The {ref}`explanation` section includes topic overviews and detailed explanations of key concepts, such as local versus distributed storage.
+
+---
+
 ## Project and community
 
 MicroCloud is a member of the [Canonical](https://canonical.com) family. It’s an open source project that warmly welcomes community contributions, suggestions, fixes, and constructive feedback.
@@ -74,15 +85,12 @@ MicroCloud is a member of the [Canonical](https://canonical.com) family. It’s 
 
 Thinking about using MicroCloud for your next project? [Get in touch](https://canonical.com/microcloud/contact-us)!
 
-
-
-
 ```{toctree}
 :hidden:
 :maxdepth: 2
 
 self
-Tutorials </tutorial/index>
+/tutorial/index
 /how-to/index
 /reference/index
 /explanation/index

--- a/doc/index.md
+++ b/doc/index.md
@@ -2,8 +2,7 @@
 myst:
   html_meta:
     description: MicroCloud is a lightweight, open source cloud platform built on LXD, MicroCeph, and MicroOVN, ideal for private cloud, edge computing, and test labs.
-relatedlinks: "[Install&#32;MicroCloud&#32;on&#32;Linux&#32;|&#32;Snap&#32;Store](https://snapcraft.io/microcloud)"
-discourse: lxc:[Introducing&#32;MicroCloud](15871)
+relatedlinks: "[MicroCloud:&#32;your&#32;open&#32;source&#32;cloud&#32;platform](https://canonical.com/microcloud)"
 ---
 
 (home)=


### PR DESCRIPTION
Per https://github.com/canonical/microcloud/pull/1368#discussion_r3201253653, this PR updates the "Related links" section of the MicroCloud home page to display only a link to the product page. I removed the Discourse link (likely added originally before there was a product page) as well as the link to the Snap store (already linked inline in the homepage). Note that if the MicroCloud integration is removed in the future and the MicroCloud docs use the standard header (like LXD's current header), this related link can be removed entirely, since the standard header already includes a link to the product page. MicroCloud's current header is customized for the integration and does not show this.

As long as I was updating the homepage, I took the opportunity to increase its alignment with the standard homepage structure across Canonical docs by adding the required "How this documentation is organized" section. See [LXD's homepage](https://documentation.ubuntu.com/lxd/latest/#how-this-documentation-is-organized) for another example. 

