### PR TITLE
doc: Update MicroCeph URL for intersphinx extension

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -278,7 +278,7 @@ custom_tags = []
 if ('SINGLE_BUILD' in os.environ and os.environ['SINGLE_BUILD'] == 'True'):
     intersphinx_mapping = {
         'lxd': ('https://documentation.ubuntu.com/lxd/latest/', None),
-        'microceph': ('https://canonical-microceph.readthedocs-hosted.com/en/latest/', None),
+        'microceph': ('https://documentation.ubuntu.com/canonical-microceph/latest/', None),
         'microovn': ('https://canonical-microovn.readthedocs-hosted.com/en/latest/', None),
     }
 elif ('READTHEDOCS' in os.environ) and (os.environ['READTHEDOCS'] == 'True'):


### PR DESCRIPTION
MicroCeph has been migrated from Read the Docs to <https://documentation.ubuntu.com/canonical-microceph/latest/>. This PR updates `custom_conf.py` so that the MicroCeph `objects.inv` file can be accessed from the new URL. The `objects.inv` file is used by the `intersphinx` extension for cross references to MicroCeph documentation.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.