### PR TITLE
Revert "github/workflow/tests: Temporarily disable upgrade test on 22.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -206,9 +206,7 @@ jobs:
       matrix:
         suite: ["upgrade"]
         os:
-          # Temporarily disable the upgrade test on 22.04 due to issues with latest MicroCeph and LXD using CephFS.
-          # See https://chat.canonical.com/canonical/pl/ix7oj94web8wmm4wdt7rqq1etc.
-          #- "22.04"
+          - "22.04"
           - "24.04"
         microceph:
           - "squid/stable"


### PR DESCRIPTION
This reverts commit 46257258e252002f767f679e49bab252009ddf62.