### PR TITLE
fix: accept newer microceph versions

### DIFF
--- a/service/version.go
+++ b/service/version.go
@@ -80,16 +80,14 @@ func validateVersion(serviceType types.ServiceType, daemonVersion string) error 
 		}
 
 	case types.MicroCeph:
-		regex := regexp.MustCompile(`\d+\.\d+\.\d+`)
-		match := regex.FindString(daemonVersion)
+		match := regexp.MustCompile(`[0-9]+\.[0-9]+(?:\.[0-9]+)?`).FindString(daemonVersion)
 		if match == "" {
-			return fmt.Errorf("%s version format not supported (%s)", serviceType, daemonVersion)
+			return fmt.Errorf("%s version %q is not supported", serviceType, daemonVersion)
 		}
 
-		daemonVersion = semver.Canonical("v" + match)
-		expectedVersion := semver.Canonical("v" + microCephMinVersion)
-		if semver.Compare(semver.MajorMinor(daemonVersion), semver.MajorMinor(expectedVersion)) != 0 {
-			return fmt.Errorf("%s version %q is not supported", serviceType, daemonVersion)
+		err := compareVersion(match, microCephMinVersion, serviceType)
+		if err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
## Summary
- change MicroCeph version validation from exact major/minor matching to minimum-version comparison

## Why
MicroCloud currently rejects tentacle MicroCeph even though it is newer than 19.2. This blocks deployments that need tentacle for dashboard OAuth2 support.