### PR TITLE
Doc: Add charmub.io to link ignore list

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -134,6 +134,8 @@ linkcheck_ignore = [
     'http://localhost:8000',
     # These links may fail from time to time
     'https://ceph.io',
+    # Rejects us always with a "Connection aborted"
+    r'https://charmhub\.io/.*',
     # Cloudflare protection on SourceForge domains often block linkcheck
     r'https://.*\.sourceforge\.(net|io)/.*',
     # These links often fail due to infra issues or protection measures 


### PR DESCRIPTION
It's constantly failing since around two weeks now, see https://github.com/canonical/microcloud/actions/runs/26998965986/job/80081934604.