### PR TITLE
Init: Explicit MicroOVN warning

### DIFF
--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -1111,7 +1111,7 @@ func (c *initConfig) askOVNNetwork(sh *service.Handler) error {
 
 		// Ask to continue and print a second warning here (the actual warning message) which contains some more reasoning.
 		question := "Continue anyway?"
-		wantsContinue, err := c.asker.AskBoolWarn(warningMessage, question, true)
+		wantsContinue, err := c.asker.AskBoolWarn(warningMessage, question, false)
 		if err != nil {
 			return err
 		}

--- a/cmd/microcloud/ask.go
+++ b/cmd/microcloud/ask.go
@@ -1106,6 +1106,10 @@ func (c *initConfig) askOVNNetwork(sh *service.Handler) error {
 	}
 
 	if warningMessage != "" {
+		// Be concrete and notify the user that we cannot configure MicroOVN at this stage.
+		tui.PrintWarning("Cannot configure MicroOVN")
+
+		// Ask to continue and print a second warning here (the actual warning message) which contains some more reasoning.
 		question := "Continue anyway?"
 		wantsContinue, err := c.asker.AskBoolWarn(warningMessage, question, true)
 		if err != nil {


### PR DESCRIPTION
This PR aims to help users understanding when MicroOVN cannot be configured.

An additional warning message is printed which explicitly mentions MicroOVN.
Also the default answer is changed from `true` to `false` so users rather stop the setup instead of falling back silently to FAN networking:

<img width="1362" height="101" alt="Screenshot from 2026-06-09 10-58-46" src="https://github.com/user-attachments/assets/1615d6fe-a74d-4c4c-a5b3-7327c130977e" />
