### PR TITLE
doc/conf.py: add to linkcheck_ignore

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -140,6 +140,8 @@ linkcheck_ignore = [
     r'https://.*\.sourceforge\.(net|io)/.*',
     # These links often fail due to infra issues or protection measures 
     r'https://ubuntu\.com.*',
+    r'https://canonical\.com.*',
+    r'https://snapcraft\.io.*',
     # Ignore so that we can link change log in release notes before a release is ready
     r'https://github\.com/canonical/microcloud/compare.*',
 ]


### PR DESCRIPTION
Link checks of `canonical.com` and `snapcraft.io` frequently fail, possibly due to protection measures. This PR adds them to the ignore list.

For reference, the LXD ignore list already includes `snapcraft.io` as well as subdomains of `canonical.com`.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.