### PR TITLE
Doc: Clarify how to configure CephFS vols as image/backup store

### DIFF
--- a/doc/how-to/initialize.md
+++ b/doc/how-to/initialize.md
@@ -276,18 +276,18 @@ lxc storage volume create remote-fs backups # for instances operations
 lxc storage volume create remote-fs images # for images operations
 ```
 
-Once the storage volumes are created, set them as the values for the {ref}`configuration options <lxd:server-options-misc>` of `storage.images_volume` and `storage.backups_volume`. This example syntax uses `remote-fs` as the storage pool, along with volumes named `images` and `backup`:
+Once the storage volumes are created, set them as the values for the `storage.images_volume` and `storage.backups_volume` {ref}`configuration options <lxd:server-options-misc>`.
+This example syntax uses `remote-fs` as the storage pool, along with volumes named `images` and `backups`.
+Repeat these steps for each cluster member:
 
 ```bash
-lxc config set storage.images_volume=remote-fs/images
-lxc config set storage.backups_volume=remote-fs/backups
+lxc config set storage.images_volume=remote-fs/images --target <cluster member>
+lxc config set storage.backups_volume=remote-fs/backups --target <cluster member>
 ```
 
 To view the set values, run:
 
 ```bash
-lxc config get storage.backups_volume
-lxc config get storage.images_volume
+lxc config get storage.backups_volume --target <cluster member>
+lxc config get storage.images_volume --target <cluster member>
 ```
-
-Repeat these steps on each cluster member.


### PR DESCRIPTION
Fixes https://github.com/canonical/microcloud/issues/1417.

A user might not be aware that it's crucial to set the config per cluster member. So instead of mentioning it at the bottom, use the `--target` key specifically.

Otherwise a user would need to know that he needs to go to each cluster member to set the config key.