### PR TITLE
demos/terraform: Remove incompatible secure boot option

### DIFF
--- a/demos/terraform/main.tf
+++ b/demos/terraform/main.tf
@@ -90,7 +90,6 @@ resource "lxd_instance" "microcloud" {
   }
 
   config = {
-    "security.secureboot" = "false"
     "cloud-init.user-data" = templatefile("${path.module}/cloud-init.yaml.tpl", {
       hostname             = var.vm_names[count.index]
       lookup_interface     = var.lookup_interface


### PR DESCRIPTION
## Checklist
Removed `security.secureboot` from `main.tf` since it is not compatible with [LXD 6.8](https://canonical.com/lxd/docs/latest/reference/instance_options/#instance-boot:boot.mode) 

- [x] I have read the [contributing guidelines](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.