### PR TITLE
demos/terraform: Improve MicroCloud resource naming

### DIFF
--- a/demos/terraform/main.tf
+++ b/demos/terraform/main.tf
@@ -45,7 +45,7 @@ locals {
   }
 }
 
-resource "lxd_network" "microbr0" {
+resource "lxd_network" "microbr" {
   name = var.network_name
 
   config = {
@@ -122,7 +122,7 @@ resource "lxd_instance" "microcloud" {
     type = "nic"
     properties = {
       nictype = "bridged"
-      parent  = lxd_network.microbr0.name
+      parent  = lxd_network.microbr.name
     }
   }
 
@@ -203,7 +203,7 @@ resource "lxd_instance" "microcloud" {
 
   depends_on = [
     data.lxd_network.lookup_bridge,
-    lxd_network.microbr0,
+    lxd_network.microbr,
     lxd_volume.local_disk,
     lxd_volume.ceph_disk
   ]

--- a/demos/terraform/main.tf
+++ b/demos/terraform/main.tf
@@ -32,17 +32,14 @@ locals {
 
   systems = [
     for i, name in var.vm_names : {
-      name     = name
-      ip       = cidrhost(local.lookup_subnet, var.ip_base_offset + (i * var.ip_increment))
-      has_ceph = contains(var.ceph_nodes, name)
+      name        = name
+      ip          = cidrhost(local.lookup_subnet, var.ip_base_offset + (i * var.ip_increment))
+      has_ceph    = contains(var.ceph_nodes, name)
+      disk_number = var.disk_number_start + i
     }
   ]
 
-  ceph_disk_mapping = {
-    for i, system in local.systems : i => length([
-      for j, s in local.systems : j if j < i && s.has_ceph
-    ]) if system.has_ceph
-  }
+  ceph_systems = [for s in local.systems : s if s.has_ceph]
 }
 
 resource "lxd_network" "microbr" {
@@ -57,8 +54,8 @@ resource "lxd_network" "microbr" {
 }
 
 resource "lxd_volume" "local_disk" {
-  count        = var.vm_count
-  name         = "${var.local_disk_name_prefix}${count.index + 1}"
+  count        = length(local.systems)
+  name         = "${var.local_disk_name_prefix}${local.systems[count.index].disk_number}"
   pool         = var.storage_pool
   type         = "custom"
   content_type = "block"
@@ -68,8 +65,8 @@ resource "lxd_volume" "local_disk" {
 }
 
 resource "lxd_volume" "ceph_disk" {
-  count        = length([for system in local.systems : system if system.has_ceph])
-  name         = "${var.ceph_disk_name_prefix}${count.index + 1}"
+  count        = length(local.ceph_systems)
+  name         = "${var.ceph_disk_name_prefix}${local.ceph_systems[count.index].disk_number}"
   pool         = var.storage_pool
   type         = "custom"
   content_type = "block"
@@ -79,7 +76,7 @@ resource "lxd_volume" "ceph_disk" {
 }
 
 resource "lxd_instance" "microcloud" {
-  count            = var.vm_count
+  count            = length(local.systems)
   name             = var.vm_names[count.index]
   image            = var.ubuntu_image
   type             = "virtual-machine"
@@ -142,7 +139,7 @@ resource "lxd_instance" "microcloud" {
       type = "disk"
       properties = {
         pool   = var.storage_pool
-        source = lxd_volume.ceph_disk[local.ceph_disk_mapping[count.index]].name
+        source = lxd_volume.ceph_disk[index(local.ceph_systems[*].name, local.systems[count.index].name)].name
       }
     }
   }

--- a/demos/terraform/terraform.tfvars.example
+++ b/demos/terraform/terraform.tfvars.example
@@ -22,7 +22,6 @@ lookup_timeout = 300
 instance_create_timeout = "25m"
 
 # VM Configuration
-vm_count = 4
 vm_names = ["micro1", "micro2", "micro3", "micro4"]
 ceph_nodes = ["micro1", "micro2", "micro3"]
 
@@ -46,6 +45,7 @@ ip_increment = 10
 # Disk Name Configuration
 local_disk_name_prefix = "local"
 ceph_disk_name_prefix = "remote"
+disk_number_start = 1
 
 # MicroCloud Configuration
 initiator = "micro1"

--- a/demos/terraform/variables.tf
+++ b/demos/terraform/variables.tf
@@ -148,13 +148,6 @@ variable "lookup_bridge" {
   default     = "lxdbr0"
 }
 
-
-variable "vm_count" {
-  description = "Number of VMs to create"
-  type        = number
-  default     = 4
-}
-
 variable "ip_base_offset" {
   description = "Base IP address offset for the first VM"
   type        = number
@@ -177,6 +170,12 @@ variable "ceph_disk_name_prefix" {
   description = "Prefix for Ceph disk volume names"
   type        = string
   default     = "remote"
+}
+
+variable "disk_number_start" {
+  description = "Starting number for disk names (e.g., 1 for local1/remote1, 5 for local5/remote5)"
+  type        = number
+  default     = 1
 }
 
 variable "initiator" {


### PR DESCRIPTION
This PR avoids hardcoding the bridge variable name to `microbr0`, so deployments can use different network names such as `microbr1` when needed.
It also supports custom VM numbering (for example `micro5`, `micro6`, `micro7`, `micro8`) with matching disk naming (i.e. `local7`, `remote7`...), making the demo reusable in environments where lower indexes are already occupied for multiple MicroCloud deployments on the same host.


## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.