### PR TITLE
Trivy: Drop EOL MicroCloud 1 and align with LXD

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -83,9 +83,6 @@ jobs:
           - channel: "2/stable"
             branch: "v2-edge"
             version: "2"
-          - channel: "1/stable"
-            branch: "v1-edge"
-            version: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -76,18 +76,14 @@ jobs:
     if: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ) && github.ref_name == 'main' && github.repository_owner == 'canonical' }}
     strategy:
       matrix:
-        include:
-          - channel: "3/edge"
-            branch: "main"
-            version: "3"
-          - channel: "2/stable"
-            branch: "v2-edge"
-            version: "2"
+        version:
+          - "latest"
+          - "2"
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ matrix.branch }}
+          ref: ${{ (matrix.version == 'latest' && 'main') || format('v{0}-edge', matrix.version) }}
           persist-credentials: false
 
       - name: Resolve branch HEAD SHA
@@ -137,4 +133,4 @@ jobs:
         with:
           sarif_file: ${{ matrix.version }}-stable.sarif
           sha: ${{ steps.branch-sha.outputs.sha }}
-          ref: refs/heads/${{ matrix.branch }}
+          ref: refs/heads/${{ (matrix.version == 'latest' && 'main') || format('v{0}-edge', matrix.version) }}

--- a/test/e2e/reboot.local-lxd-vm
+++ b/test/e2e/reboot.local-lxd-vm
@@ -33,14 +33,3 @@ lxc exec "${MEMBER}" -- timeout 90 systemctl is-system-running --wait --quiet ||
 sleep 5
 lxc exec "${MEMBER}" --env TEST_CONSOLE=0 -- microcloud waitready --timeout=90 || true
 echo " DONE"
-
-# Temporary fix to deal with https://github.com/canonical/microovn/pull/249.
-#
-# First try to find the cluster member which joined last and restart its ovn-northd service.
-# We can identify it based on its appearance in Microcluster's `core_cluster_members` table.
-# The CLI's `microovn cluster list` cannot be used as the result is sorted.
-# MicroCloud doesn't guarantee any order in which members are joined and doesn't sort them by name (as they are internally stored inside a map).
-last_member="$(lxc exec "${MEMBER}" -- microovn cluster sql 'SELECT name FROM core_cluster_members ORDER BY ID DESC LIMIT 1' | awk -F" " '/micro/ { print $2 }')"
-
-# Second restart ovn-northd on this member.
-lxc exec "${last_member}" -- systemctl restart snap.microovn.ovn-northd.service


### PR DESCRIPTION
Also revert a commit which was initially put in to address an already fixed bug in MicroOVN.