### PR TITLE
doc: update microovn url, microceph variable

### DIFF
--- a/doc/.sphinx/_integration/add_config.py
+++ b/doc/.sphinx/_integration/add_config.py
@@ -23,6 +23,6 @@ elif project == "MicroCeph":
     # Add "integrated" to the list of custom tags
     tags.add('integrated')
 elif project == "MicroOVN":
-    html_baseurl = "https://canonical-microovn.readthedocs-hosted.com/en/latest/"
+    html_baseurl = "https://ubuntu.com/docs/microovn/latest/"
     custom_tags.append('integrated')
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -118,7 +118,7 @@ integrate:
 html: integrate install
 	mkdir -p $(current_dir)/_build
 	cd integration/lxd/doc/ && $(MAKE) html BUILDDIR=$(current_dir)/_build/lxd
-	cd integration/microceph/docs/ && $(MAKE) html BUILDDIR=$(current_dir)/_build/microceph
+	cd integration/microceph/docs/ && $(MAKE) html DOCS_BUILDDIR=$(current_dir)/_build/microceph
 	cd integration/microovn/docs/ && $(MAKE) html BUILDDIR=$(current_dir)/_build/microovn
 	. $(DOCS_VENV); $(SPHINX_BUILD) -W --keep-going -b dirhtml "$(DOCS_SOURCEDIR)" "$(current_dir)/_build" -w $(SPHINX_DIR)/warnings.txt $(SPHINX_OPTS)
 
@@ -126,7 +126,7 @@ html: integrate install
 # This target is used by the Read the Docs build.
 html-rtd: install
 	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -C integration/lxd/doc/ html-rtd BUILDDIR=$(READTHEDOCS_OUTPUT)/html/lxd
-	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -C integration/microceph/docs/ html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microceph
+	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -C integration/microceph/docs/ html DOCS_BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microceph
 	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -C integration/microovn/docs/ html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microovn
 	. $(DOCS_VENV); PATH_PREFIX=$(PATH_PREFIX) $(SPHINX_BUILD) -W --keep-going -b dirhtml "$(DOCS_SOURCEDIR)" "$(READTHEDOCS_OUTPUT)/html" -w $(SPHINX_DIR)/warnings.txt $(SPHINX_OPTS)
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -267,7 +267,7 @@ if ('SINGLE_BUILD' in os.environ and os.environ['SINGLE_BUILD'] == 'True'):
     intersphinx_mapping = {
         'lxd': ('https://canonical.com/lxd/docs/latest/', None),
         'microceph': ('https://documentation.ubuntu.com/canonical-microceph/latest/', None),
-        'microovn': ('https://canonical-microovn.readthedocs-hosted.com/en/latest/', None),
+        'microovn': ('https://ubuntu.com/docs/microovn/latest/', None),
     }
 elif ('READTHEDOCS' in os.environ) and (os.environ['READTHEDOCS'] == 'True'):
     intersphinx_mapping = {


### PR DESCRIPTION
- Updates MicroOVN docs URL following the move to ubuntu.com/docs/microovn.
- Updates the MicroCeph build directory variable after `BUILDDIR` was changed to `DOCS_BUILDDIR` in https://github.com/canonical/microceph/pull/794.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.