### PR TITLE
doc: update microovn 24.03 url (v2-edge)

### DIFF
--- a/doc/.sphinx/_integration/add_config.py
+++ b/doc/.sphinx/_integration/add_config.py
@@ -23,6 +23,6 @@ elif project == "MicroCeph":
     # Add "integrated" to the list of custom tags
     tags.add('integrated')
 elif project == "MicroOVN":
-    html_baseurl = "https://canonical-microovn.readthedocs-hosted.com/en/24.03/"
+    html_baseurl = "https://ubuntu.com/docs/microovn/24.03/"
     custom_tags.append('integrated')
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -261,7 +261,7 @@ if ('SINGLE_BUILD' in os.environ and os.environ['SINGLE_BUILD'] == 'True'):
     intersphinx_mapping = {
         'lxd': ('https://documentation.ubuntu.com/lxd/stable-5.21/', None),
         'microceph': ('https://documentation.ubuntu.com/canonical-microceph/v19.2.0-squid/', None),
-        'microovn': ('https://canonical-microovn.readthedocs-hosted.com/en/24.03/', None),
+        'microovn': ('https://ubuntu.com/docs/microovn/24.03/', None),
     }
 elif ('READTHEDOCS' in os.environ) and (os.environ['READTHEDOCS'] == 'True'):
     intersphinx_mapping = {


### PR DESCRIPTION
MicroOVN docs have moved to ubuntu.com/docs/microovn. This update is similar to PR #1442, but uses the URL for MicroOVN 24.03.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.