### PR TITLE
doc: update LXD urls (v2-edge)

### DIFF
--- a/doc/.sphinx/_integration/add_config.py
+++ b/doc/.sphinx/_integration/add_config.py
@@ -10,7 +10,7 @@ html_context['microovn_path'] = "../microovn"
 html_context['microovn_tag'] = "../microovn/_static/microovn.png"
 
 if project == "LXD":
-    html_baseurl = "https://documentation.ubuntu.com/lxd/stable-5.21/"
+    html_baseurl = "https://canonical.com/lxd/docs/v5.21/"
     html_css_files = globals().get('html_css_files', []) + ['override-header.css']
     tags.add('integrated')
 elif project == "MicroCeph":

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -259,7 +259,7 @@ notfound_context = {
 # Intersphinx setup differs for different builds to optimize use with integrated docs  
 if ('SINGLE_BUILD' in os.environ and os.environ['SINGLE_BUILD'] == 'True'):
     intersphinx_mapping = {
-        'lxd': ('https://documentation.ubuntu.com/lxd/stable-5.21/', None),
+        'lxd': ('https://canonical.com/lxd/docs/v5.21/', None),
         'microceph': ('https://documentation.ubuntu.com/canonical-microceph/v19.2.0-squid/', None),
         'microovn': ('https://ubuntu.com/docs/microovn/24.03/', None),
     }


### PR DESCRIPTION
Update LXD documentation URLs following the move to `canonical.com/lxd/docs`.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.