### PR TITLE
doc: fix how html, css is added to MicroCeph (v2-edge)

### DIFF
--- a/doc/.sphinx/_integration/add_config.py
+++ b/doc/.sphinx/_integration/add_config.py
@@ -15,8 +15,6 @@ if project == "LXD":
     tags.add('integrated')
 elif project == "MicroCeph":
     html_baseurl = "https://documentation.ubuntu.com/microceph/v19.2.0-squid/"
-    # Override default header templates
-    templates_path = globals().get('templates_path', []) + ["_templates"]
     # Override default header styles
     html_static_path = globals().get('html_static_path', []) + ["_static"]
     html_css_files = globals().get('html_css_files', []) + ['override-header.css']

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -94,15 +94,15 @@ integrate:
 
 	# Create a directory for files to override in MicroCloud docs
 	mkdir -p integration/microcloud/_templates/ integration/microcloud/_static
-	mkdir -p integration/microceph/docs/_templates integration/microceph/docs/_static
+	mkdir -p integration/microceph/docs/_static
 	
 	# Copy the header HTML and CSS files for the doc sets  
 	cp .sphinx/_integration/microcloud.html integration/microcloud/_templates/header.html
 	cp .sphinx/_integration/override-header.css integration/microcloud/_static/
 	cp .sphinx/_integration/lxd.html integration/lxd/doc/_templates/header.html
 	cp .sphinx/_integration/override-header.css integration/lxd/doc/_static/
-	cp .sphinx/_integration/microceph.html integration/microceph/docs/_templates/header.html
-	cp .sphinx/_integration/override-header.css integration/microceph/docs/_static/
+	cp .sphinx/_integration/microceph.html integration/microceph/docs/.sphinx/_templates/header.html
+	cp .sphinx/_integration/override-header.css integration/microceph/docs/.sphinx/_static/
 	cp .sphinx/_integration/microovn.html integration/microovn/docs/.sphinx/_templates/header.html
 	cp .sphinx/_integration/header.css integration/microovn/docs/.sphinx/_static/
 


### PR DESCRIPTION
When on the MicroCeph section of the `v2-edge` docs, the top navigation menu currently only shows the MicroCeph navigation links rather than the integrated docs header.

To fix this, this PR updates the docs `Makefile` to overwrite the MicroCeph `header.html` file with the integrated header file in the MicroCloud docs (`.sphinx/_integration/microceph.html`). Based on this change, this PR also removes an unnecessary `mkdir` rule from the Makefile and removes unnecessary settings from the `add_config.py` settings for MicroCeph.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.