### PR TITLE
doc: add Google tag manager to integrated docs

### DIFF
--- a/doc/.sphinx/_integration/lxd.html
+++ b/doc/.sphinx/_integration/lxd.html
@@ -1,5 +1,7 @@
 <header id="header" class="p-navigation">
 
+  {% include "google-tag.html" %}
+
   <div class="p-navigation__nav" role="menubar">
 
     <ul class="p-navigation__links" role="menu">

--- a/doc/.sphinx/_integration/microceph.html
+++ b/doc/.sphinx/_integration/microceph.html
@@ -1,5 +1,7 @@
 <header id="header" class="p-navigation">
 
+  {% include "google-tag.html" %}
+
   <div class="p-navigation__nav" role="menubar">
 
     <ul class="p-navigation__links" role="menu">

--- a/doc/.sphinx/_integration/microovn.html
+++ b/doc/.sphinx/_integration/microovn.html
@@ -1,5 +1,7 @@
 <header id="header" class="p-navigation">
 
+  {% include "google-tag.html" %}
+
   <div class="p-navigation__nav" role="menubar">
 
     <ul class="p-navigation__links" role="menu">

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -96,14 +96,21 @@ integrate:
 	mkdir -p integration/microcloud/_templates/ integration/microcloud/_static
 	mkdir -p integration/microceph/docs/_templates integration/microceph/docs/_static
 	
-	# Copy the header HTML and CSS files for the doc sets  
+	# Copy the header HTML, CSS files, and Google Tag Manager for the doc sets
 	cp .sphinx/_integration/microcloud.html integration/microcloud/_templates/header.html
+	cp _templates/google-tag.html integration/microcloud/_templates/
 	cp .sphinx/_integration/override-header.css integration/microcloud/_static/
+
 	cp .sphinx/_integration/lxd.html integration/lxd/doc/_templates/header.html
+	cp _templates/google-tag.html integration/lxd/doc/_templates/
 	cp .sphinx/_integration/override-header.css integration/lxd/doc/_static/
+
 	cp .sphinx/_integration/microceph.html integration/microceph/docs/_templates/header.html
+	cp _templates/google-tag.html integration/microceph/docs/_templates/
 	cp .sphinx/_integration/override-header.css integration/microceph/docs/_static/
+
 	cp .sphinx/_integration/microovn.html integration/microovn/docs/.sphinx/_templates/header.html
+	cp _templates/google-tag.html integration/microovn/docs/.sphinx/_templates/
 	cp .sphinx/_integration/header.css integration/microovn/docs/.sphinx/_static/
 
 	# Add information about where to find the tags/docs to the doc sets


### PR DESCRIPTION
Currently, Google Analytics is only enabled for the MicroCloud portion of the integrated docs set. This PR enables Google Analytics for the LXD, MicroCeph, and MicroOVN portions:

1. Updates the docs Makefile to copy the Google tag manager script into the `_templates` directories of the cloned LXD, MicroCeph, and MicroOVN repos.
2. Updates the header files for each of those products to include the snippet that includes the tag manager script.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.