### PR TITLE
doc: add Google tag manager to integrated docs (v2-edge)

### DIFF
--- a/doc/.sphinx/_integration/add_config.py
+++ b/doc/.sphinx/_integration/add_config.py
@@ -17,7 +17,8 @@ elif project == "MicroCeph":
     html_baseurl = "https://documentation.ubuntu.com/microceph/v19.2.0-squid/"
     # Override default header styles
     html_static_path = globals().get('html_static_path', []) + ["_static"]
-    html_css_files = globals().get('html_css_files', []) + ['override-header.css']
+    html_css_files = globals().get('html_css_files', []) + ['override-header.css', 'https://assets.ubuntu.com/v1/d86746ef-cookie_banner.css']
+    html_js_files = globals().get('html_js_files', []) + ['https://assets.ubuntu.com/v1/287a5e8f-bundle.js']
     # Add "integrated" to the list of custom tags
     tags.add('integrated')
 elif project == "MicroOVN":

--- a/doc/.sphinx/_integration/lxd.html
+++ b/doc/.sphinx/_integration/lxd.html
@@ -1,5 +1,7 @@
 <header id="header" class="p-navigation">
 
+  {% include "google-tag.html" %}
+
   <div class="p-navigation__nav" role="menubar">
 
     <ul class="p-navigation__links" role="menu">

--- a/doc/.sphinx/_integration/microceph.html
+++ b/doc/.sphinx/_integration/microceph.html
@@ -1,5 +1,7 @@
 <header id="header" class="p-navigation">
 
+  {% include "google-tag.html" %}
+
   <div class="p-navigation__nav" role="menubar">
 
     <ul class="p-navigation__links" role="menu">

--- a/doc/.sphinx/_integration/microceph_footer.html
+++ b/doc/.sphinx/_integration/microceph_footer.html
@@ -1,0 +1,100 @@
+{# ru-fu: copied from Furo, with modifications as stated below. Modifications are marked 'mod:'. #}
+
+<div class="related-pages">
+  {# mod: Per-page navigation #}
+  {% if meta %}
+    {% if 'sequential_nav' in meta %}
+      {% set sequential_nav = meta.sequential_nav %}
+    {% endif %}  
+  {% endif %}
+  {# mod: Conditional wrappers to control page navigation buttons #}
+  {% if sequential_nav != "none" -%}
+    {% if next and (sequential_nav == "next" or sequential_nav == "both") -%}
+      <a class="next-page" href="{{ next.link }}">
+        <div class="page-info">
+          <div class="context">
+            <span>{{ _("Next") }}</span>
+          </div>
+          <div class="title">{{ next.title }}</div>
+        </div>
+        <svg class="furo-related-icon"><use href="#svg-arrow-right"></use></svg>
+      </a>
+    {%- endif %}
+    {% if prev and (sequential_nav == "prev" or sequential_nav == "both") -%}
+      <a class="prev-page" href="{{ prev.link }}">
+        <svg class="furo-related-icon"><use href="#svg-arrow-right"></use></svg>
+        <div class="page-info">
+          <div class="context">
+            <span>{{ _("Previous") }}</span>
+          </div>
+          {% if prev.link == pathto(master_doc) %}
+            <div class="title">{{ _("Home") }}</div>
+          {% else %}
+            <div class="title">{{ prev.title }}</div>
+          {% endif %}
+        </div>
+      </a>
+    {%- endif %}
+  {%- endif %}
+</div>
+<div class="bottom-of-page">
+  <div class="left-details">
+    {%- if show_copyright %}
+    <div class="copyright">
+      {%- if hasdoc('copyright') %}
+        {% trans path=pathto('copyright'), copyright=copyright|e -%}
+          <a href="{{ path }}">Copyright</a> &#169; {{ copyright }}
+        {%- endtrans %}
+      {%- else %}
+        {% trans copyright=copyright|e -%}
+          Copyright &#169; {{ copyright }}
+        {%- endtrans %}
+      {%- endif %}
+    </div>
+    {%- endif %}
+
+    {# mod: removed "Made with" #}
+
+    {%- if last_updated -%}
+    <div class="last-updated">
+      {% trans last_updated=last_updated|e -%}
+        Last updated on {{ last_updated }}
+      {%- endtrans -%}
+    </div>
+    {%- endif %}
+
+    {%- if show_source and has_source and sourcename %}
+    <div class="show-source">
+      <a class="muted-link" href="{{ pathto('_sources/' + sourcename, true)|e }}"
+         rel="nofollow">Show source</a>
+    </div>
+    {%- endif %}
+  </div>
+  <div class="right-details">
+
+    {# mod: replaced RTD icons with our links #}
+
+    {% if discourse %}
+    <div class="ask-discourse">
+      <a class="muted-link" href="{{ discourse }}">Ask a question on Discourse</a>
+    </div>
+    {% endif %}
+
+    {% if github_url and github_version and github_folder %}
+
+    {% if github_issues %}
+    <div class="issue-github">
+      <a class="muted-link" href="{{ github_url }}/issues/new?title=doc%3A+ADD+A+TITLE&body=DESCRIBE+THE+ISSUE%0A%0A---%0ADocument: {{ pagename }}{{ page_source_suffix }}">Open a GitHub issue for this page</a>
+    </div>
+    {% endif %}
+
+    <div class="edit-github">
+      <a class="muted-link" href="{{ github_url }}/edit/{{ github_version }}{{ github_folder }}{{ pagename }}{{ page_source_suffix }}">Edit this page on GitHub</a>
+    </div>
+    {% endif %}
+
+    <a href="" class="js-revoke-cookie-manager muted-link">Manage your tracker settings</a>
+
+    </div>
+  </div>
+</div>

--- a/doc/.sphinx/_integration/microovn.html
+++ b/doc/.sphinx/_integration/microovn.html
@@ -1,5 +1,7 @@
 <header id="header" class="p-navigation">
 
+  {% include "google-tag.html" %}
+
   <div class="p-navigation__nav" role="menubar">
 
     <ul class="p-navigation__links" role="menu">

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -108,6 +108,7 @@ integrate:
 	cp .sphinx/_integration/microceph.html integration/microceph/docs/.sphinx/_templates/header.html
 	cp _templates/google-tag.html integration/microceph/docs/.sphinx/_templates/
 	cp .sphinx/_integration/override-header.css integration/microceph/docs/.sphinx/_static/
+	cp .sphinx/_integration/microceph_footer.html integration/microceph/docs/.sphinx/_templates/footer.html
 
 	cp .sphinx/_integration/microovn.html integration/microovn/docs/.sphinx/_templates/header.html
 	cp _templates/google-tag.html integration/microovn/docs/.sphinx/_templates/

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -96,14 +96,21 @@ integrate:
 	mkdir -p integration/microcloud/_templates/ integration/microcloud/_static
 	mkdir -p integration/microceph/docs/_static
 	
-	# Copy the header HTML and CSS files for the doc sets  
+	# Copy the header HTML, CSS files, and Google Tag Manager for the doc sets
 	cp .sphinx/_integration/microcloud.html integration/microcloud/_templates/header.html
+	cp _templates/google-tag.html integration/microcloud/_templates/
 	cp .sphinx/_integration/override-header.css integration/microcloud/_static/
+
 	cp .sphinx/_integration/lxd.html integration/lxd/doc/_templates/header.html
+	cp _templates/google-tag.html integration/lxd/doc/_templates/
 	cp .sphinx/_integration/override-header.css integration/lxd/doc/_static/
+
 	cp .sphinx/_integration/microceph.html integration/microceph/docs/.sphinx/_templates/header.html
+	cp _templates/google-tag.html integration/microceph/docs/.sphinx/_templates/
 	cp .sphinx/_integration/override-header.css integration/microceph/docs/.sphinx/_static/
+
 	cp .sphinx/_integration/microovn.html integration/microovn/docs/.sphinx/_templates/header.html
+	cp _templates/google-tag.html integration/microovn/docs/.sphinx/_templates/
 	cp .sphinx/_integration/header.css integration/microovn/docs/.sphinx/_static/
 
 	# Add information about where to find the tags/docs to the doc sets


### PR DESCRIPTION
Backports #1455, with an additional commit to set up the cookie banner and button for MicroCeph.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.