### PR TITLE
doc: restore "edit this page" button, update RTD project

### DIFF
--- a/doc/_static/js/overwrite_links.js
+++ b/doc/_static/js/overwrite_links.js
@@ -1,5 +1,5 @@
  // Replace oldDomain with newDomain
- const microcloud_oldDomain = 'canonical-microcloud-documentation.readthedocs-hosted.com';
+ const microcloud_oldDomain = 'canonical-microcloud.readthedocs-hosted.com';
  const microcloud_newDomain = 'canonical.com/microcloud/docs';
 
  function microcloud_escapeRegExp(value) {

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -77,9 +77,9 @@ html_context = {
 html_extra_path = ['_extra']
 
 # Enables the pencil icon to edit pages on GitHub, shown at the top of each page
-# html_theme_options = {
-#     'source_edit_link': html_context['github_url']
-# }
+html_theme_options = {
+    'source_edit_link': html_context['github_url']
+}
 
 #######################
 # Sitemap configuration: https://sphinx-sitemap.readthedocs.io/


### PR DESCRIPTION
This PR further advances the docs domain migration to `canonical.com/microcloud/docs`:

- Restores the "edit this page" button
- Updates the RTD project URL

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.