### PR TITLE
doc: update MicroCloud docs URLs (v2-edge)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,4 +104,4 @@ In addition to the sign-off requirement, contributors must also cryptographicall
 
 ## More information
 
-For more information, see [How to contribute to MicroCloud](https://documentation.ubuntu.com/microcloud/latest/microcloud/how-to/contribute/) in the documentation.
+For more information, see [How to contribute to MicroCloud](https://canonical.com/microcloud/docs/latest/how-to/contribute/) in the documentation.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ MicroCloud is designed for small-scale private clouds and hybrid cloud extension
 
 MicroCloud can be deployed on machines running Ubuntu 22.04 or newer. A MicroCloud cluster can consist of a single cluster member for a testing deployment, and requires a minimum of 3 cluster members for a production deployment.
 
-See: [Pre-deployment requirements](https://documentation.ubuntu.com/microcloud/latest/microcloud/how-to/install/#pre-deployment-requirements) in the MicroCloud documentation for a full list of requirements.
+See: [Pre-deployment requirements](https://canonical.com/microcloud/docs/latest/how-to/install/#pre-deployment-requirements) in the MicroCloud documentation for a full list of requirements.
 
 
 ## **How to get started**
@@ -46,13 +46,13 @@ microcloud join
 
 Following the CLI prompts, a working MicroCloud will be ready within minutes.
 
-The MicroCloud snap drives three other snaps ([LXD](https://documentation.ubuntu.com/microcloud/latest/lxd/), [MicroCeph](https://documentation.ubuntu.com/microcloud/latest/microceph/), and [MicroOVN](https://documentation.ubuntu.com/microcloud/latest/microovn/)), enabling automated deployment of a highly available LXD cluster for compute, with Ceph as the storage driver and OVN as the managed network.
+The MicroCloud snap drives three other snaps ([LXD](https://canonical.com/microcloud/docs/latest/lxd/), [MicroCeph](https://canonical.com/microcloud/docs/latest/microceph/), and [MicroOVN](https://canonical.com/microcloud/docs/latest/microovn/)), enabling automated deployment of a highly available LXD cluster for compute, with Ceph as the storage driver and OVN as the managed network.
 
 During initialization, MicroCloud scrapes the other servers for details and then prompts you to add disks to Ceph and configure the networking setup.
 
 At the end of this, you’ll have an OVN cluster, a Ceph cluster, and a LXD cluster. LXD itself will have been configured with both networking and storage suitable for use in a cluster.
 
-For more information, see the MicroCloud documentation for [installation](https://documentation.ubuntu.com/microcloud/latest/microcloud/how-to/install/) and [initialization](https://documentation.ubuntu.com/microcloud/latest/microcloud/how-to/initialize/). You can also [follow a tutorial](https://documentation.ubuntu.com/microcloud/latest/microcloud/tutorial/get_started/) that demonstrates the basics of MicroCloud.
+For more information, see the MicroCloud documentation for [installation](https://canonical.com/microcloud/docs/latest/how-to/install/) and [initialization](https://canonical.com/microcloud/docs/latest/how-to/initialize/). You can also [follow a tutorial](https://canonical.com/microcloud/docs/latest/tutorial/) that demonstrates the basics of MicroCloud.
 
 ## **What about networking?**
 
@@ -66,7 +66,7 @@ You can optionally add the following dedicated networks:
 
 ### **RESOURCES:**
 
-- Documentation: https://documentation.ubuntu.com/microcloud/latest/microcloud/
+- Documentation: <https://canonical.com/microcloud/docs/latest/>
 - Find the package at the Snap Store:
 
  [![Snapcraft logo](https://dashboard.snapcraft.io/site_media/appmedia/2018/04/Snapcraft-logo-bird.png)](https://snapcraft.io/microcloud)

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,5 +1,5 @@
 # MicroCloud documentation
 
-We advise you to read the [published documentation](https://documentation.ubuntu.com/microcloud/latest/microcloud/) rather than reading the documentation through GitHub. The GitHub web interface provides a basic rendering of the documentation. However, important features are missing, such as includes and cross-references.
+We advise you to read the [published documentation](https://canonical.com/microcloud/docs/latest/) rather than reading the documentation through GitHub. The GitHub web interface provides a basic rendering of the documentation. However, important features are missing, such as includes and cross-references.
 
-Compelled to contribute to the documentation? Visit the [documentation contributor guidelines](https://documentation.ubuntu.com/microcloud/latest/microcloud/how-to/contribute//#contribute-to-the-documentation).
+Compelled to contribute to the documentation? Visit the [documentation contributor guidelines](https://canonical.com/microcloud/docs/latest/how-to/contribute/#contribute-to-the-documentation).

--- a/doc/how-to/install.md
+++ b/doc/how-to/install.md
@@ -90,7 +90,7 @@ Install all required {ref}`snaps <reference-requirements-software-snaps>` on eac
 
 ```{admonition} Snap channels
 :class: note
-The snap channels shown below install the current {ref}`LTS release <ref-releases-microcloud-lts>` of MicroCloud, along with the most recent compatible releases for its components. To install the {ref}`current feature release <ref-releases-microcloud-feature>` of MicroCloud instead, refer to the [install guide for that version](https://documentation.ubuntu.com/microcloud/latest/how-to/install/).
+The snap channels shown below install the current {ref}`LTS release <ref-releases-microcloud-lts>` of MicroCloud, along with the most recent compatible releases for its components. To install the {ref}`current feature release <ref-releases-microcloud-feature>` of MicroCloud instead, refer to the [install guide for that version](https://canonical.com/microcloud/docs/latest/how-to/install/).
 ```
 
 ```bash

--- a/doc/how-to/support.md
+++ b/doc/how-to/support.md
@@ -13,7 +13,7 @@ Ask questions or engage in discussions in our [Discourse forum](https://discours
 
 ### Documentation
 
-Access the [official documentation](https://documentation.ubuntu.com/microcloud/).
+Access the [official documentation](https://canonical.com/microcloud/docs/).
 
 ### Bug reports and feature requests
 


### PR DESCRIPTION
Backports #1466 to update the MicroCloud URLs following the docs migration from documentation.ubuntu.com/microcloud to canonical.com/microcloud/docs

Amended to align with the MicroCloud 2 docs as appropriate.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.