### PR TITLE
Github: Add and replace snap build job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -300,20 +300,13 @@ jobs:
       python-version: '3.12'
 
   snap:
-    name: Trigger snap edge build
+    name: Trigger snap build
     runs-on: ubuntu-24.04
     needs: [code-tests, system-tests-core, system-tests-upgrade, doc-tests]
     if: ${{ github.repository_owner == 'canonical' && github.event_name == 'push' && github.actor != 'dependabot[bot]' }}
     env:
       SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-      PACKAGE: "microcloud"
-      REPO: "git+ssh://lxdbot@git.launchpad.net/~microcloud-snap/microcloud"
-      BRANCH: >-
-        ${{ fromJson('{
-          "main": "latest-edge",
-          "v2-edge": "v2-edge",
-          "v1-edge": "v1-edge",
-        }')[github.ref_name] }}
+      LATEST_MAJOR_VERSION: 3
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -324,19 +317,84 @@ jobs:
       #      available through the SSH_AUTH_SOCK environment variable.
       - uses: canonical/lxd-pkg-snap/.github/actions/lp-snap-build@latest-edge # zizmor: ignore[unpinned-uses]
         with:
+          repo: "git+ssh://lxdbot@git.launchpad.net/~microcloud-snap/microcloud"
           ssh-key: ${{ secrets.LAUNCHPAD_LXD_BOT_KEY }} # zizmor: ignore[secrets-outside-env]
 
       - name: Trigger Launchpad snap build
         run: |
           set -eux
-          echo "${PATH}"
+          set -o pipefail
+
+          # Record current commit hash.
           localRev="$(git rev-parse HEAD)"
-          cd ~/"${PACKAGE}-pkg-snap-lp"
-          lxd-snapcraft -package "${PACKAGE}" -set-version "git-${localRev:0:7}" -set-source-commit "${localRev}"
+
+          # Extract a strict major.minor[.patch] version.
+          version="$(sed -nE 's/^const RawVersion = "([0-9]+\.[0-9]+(\.[0-9]+)?)"$/\1/p' "${GITHUB_WORKSPACE}/version/version.go")"
+
+          if [ -z "${version}" ]; then
+            echo "ERROR: Invalid version format in version/version.go. Expected format: n.n or n.n.n" >&2
+            exit 1
+          fi
+
+          # Code branch                              Launchpad branch
+          # main                                  -> latest-edge
+          # vX-edge                               -> vX-edge
+          # release-${LATEST_MAJOR_VERSION}.Y(.Z) -> latest-candidate
+          # release-X.Y(.Z)                       -> vX-candidate
+          if [ "${GITHUB_REF_NAME}" = "main" ]; then
+            BRANCH="latest-edge"
+          elif [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+-edge$ ]]; then
+            BRANCH="${GITHUB_REF_NAME}"
+          elif [[ "${GITHUB_REF_NAME}" =~ ^release-${LATEST_MAJOR_VERSION}\.[0-9]+(\.[0-9]+)?$ ]]; then
+            BRANCH="latest-candidate"
+          elif [[ "${GITHUB_REF_NAME}" =~ ^release-([0-9]+)\.[0-9]+(\.[0-9]+)?$ ]]; then
+            BRANCH="v${BASH_REMATCH[1]}-candidate"
+          else
+            echo "ERROR: Unsupported GITHUB_REF_NAME pattern: ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+
+          # Determine snap version and grade based on edge or candidate.
+          grade="devel"
+          if [[ "${BRANCH}" == *"-candidate" ]]; then
+            versionString="${version}-${localRev:0:7}"
+            grade="stable"
+          else
+            versionString="git-${localRev:0:7}"
+          fi
+
+          cd "${GITHUB_WORKSPACE}/snap"
+
+          # Fail unless exactly one `version: git` line exists, then replace it.
+          match_count="$(grep -cxF 'version: git' snapcraft.yaml || true)"
+          if [ "${match_count}" -ne 1 ]; then
+            echo "ERROR: Expected exactly one 'version: git' line in snapcraft.yaml, found ${match_count}" >&2
+            exit 1
+          fi
+
+          sed -i -e "s/^version: git$/version: ${versionString}/" snapcraft.yaml
+
+          if [ "${grade}" = "stable" ]; then
+            # Fail unless exactly one `grade: devel` line exists, then replace it.
+            match_count="$(grep -cxF 'grade: devel' snapcraft.yaml || true)"
+            if [ "${match_count}" -ne 1 ]; then
+              echo "ERROR: Expected exactly one 'grade: devel' line in snapcraft.yaml, found ${match_count}" >&2
+              exit 1
+            fi
+
+            sed -i -e "s/^grade: devel$/grade: stable/" snapcraft.yaml
+          fi
+
           git add snapcraft.yaml
-          git commit --quiet -s --allow-empty -m "Automatic upstream build (${BRANCH})" -m "Upstream commit: ${localRev}"
+          git commit --quiet -s -m "Automatic upstream build (${BRANCH})" -m "Upstream commit: ${localRev} (version: ${versionString})"
           git show
-          git push --quiet
+
+          # Pack all objects and generate a bitmap index
+          # right before the push so that pack generation benefits from full bitmap coverage.
+          git config --local pack.useBitmaps true
+          git gc --prune=now
+
+          git push --quiet --force launchpad HEAD:"${BRANCH}"
 
           # Unload the SSH key from the agent now that the push is done, to
           # prevent accidental usage in any subsequent steps within this job.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -300,20 +300,13 @@ jobs:
       python-version: '3.12'
 
   snap:
-    name: Trigger snap edge build
+    name: Trigger snap build
     runs-on: ubuntu-24.04
     needs: [code-tests, system-tests-core, system-tests-upgrade, doc-tests]
     if: ${{ github.repository_owner == 'canonical' && github.event_name == 'push' && github.actor != 'dependabot[bot]' }}
     env:
       SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-      PACKAGE: "microcloud"
-      REPO: "git+ssh://lxdbot@git.launchpad.net/~microcloud-snap/microcloud"
-      BRANCH: >-
-        ${{ fromJson('{
-          "main": "latest-edge",
-          "v2-edge": "v2-edge",
-          "v1-edge": "v1-edge",
-        }')[github.ref_name] }}
+      LATEST_MAJOR_VERSION: 3
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -322,21 +315,86 @@ jobs:
 
       # XXX: from this point onwards in this **specific job**, the private SSH key is
       #      available through the SSH_AUTH_SOCK environment variable.
-      - uses: canonical/lxd-pkg-snap/.github/actions/lp-snap-build@latest-edge # zizmor: ignore[unpinned-uses]
+      - uses: canonical/lxd/.github/actions/lp-snap-build@main # zizmor: ignore[unpinned-uses]
         with:
+          repo: "git+ssh://lxdbot@git.launchpad.net/~microcloud-snap/microcloud"
           ssh-key: ${{ secrets.LAUNCHPAD_LXD_BOT_KEY }} # zizmor: ignore[secrets-outside-env]
 
       - name: Trigger Launchpad snap build
         run: |
           set -eux
-          echo "${PATH}"
+          set -o pipefail
+
+          # Record current commit hash.
           localRev="$(git rev-parse HEAD)"
-          cd ~/"${PACKAGE}-pkg-snap-lp"
-          lxd-snapcraft -package "${PACKAGE}" -set-version "git-${localRev:0:7}" -set-source-commit "${localRev}"
+
+          # Extract a strict major.minor[.patch] version.
+          version="$(sed -nE 's/^const RawVersion = "([0-9]+\.[0-9]+(\.[0-9]+)?)"$/\1/p' "${GITHUB_WORKSPACE}/version/version.go")"
+
+          if [ -z "${version}" ]; then
+            echo "ERROR: Invalid version format in version/version.go. Expected format: n.n or n.n.n" >&2
+            exit 1
+          fi
+
+          # Code branch                              Launchpad branch
+          # main                                  -> latest-edge
+          # vX-edge                               -> vX-edge
+          # release-${LATEST_MAJOR_VERSION}.Y(.Z) -> latest-candidate
+          # release-X.Y(.Z)                       -> vX-candidate
+          if [ "${GITHUB_REF_NAME}" = "main" ]; then
+            BRANCH="latest-edge"
+          elif [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+-edge$ ]]; then
+            BRANCH="${GITHUB_REF_NAME}"
+          elif [[ "${GITHUB_REF_NAME}" =~ ^release-${LATEST_MAJOR_VERSION}\.[0-9]+(\.[0-9]+)?$ ]]; then
+            BRANCH="latest-candidate"
+          elif [[ "${GITHUB_REF_NAME}" =~ ^release-([0-9]+)\.[0-9]+(\.[0-9]+)?$ ]]; then
+            BRANCH="v${BASH_REMATCH[1]}-candidate"
+          else
+            echo "ERROR: Unsupported GITHUB_REF_NAME pattern: ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+
+          # Determine snap version and grade based on edge or candidate.
+          grade="devel"
+          if [[ "${BRANCH}" == *"-candidate" ]]; then
+            versionString="${version}-${localRev:0:7}"
+            grade="stable"
+          else
+            versionString="git-${localRev:0:7}"
+          fi
+
+          cd "${GITHUB_WORKSPACE}/snap"
+
+          # Fail unless exactly one `version: git` line exists, then replace it.
+          match_count="$(grep -cxF 'version: git' snapcraft.yaml || true)"
+          if [ "${match_count}" -ne 1 ]; then
+            echo "ERROR: Expected exactly one 'version: git' line in snapcraft.yaml, found ${match_count}" >&2
+            exit 1
+          fi
+
+          sed -i -e "s/^version: git$/version: ${versionString}/" snapcraft.yaml
+
+          if [ "${grade}" = "stable" ]; then
+            # Fail unless exactly one `grade: devel` line exists, then replace it.
+            match_count="$(grep -cxF 'grade: devel' snapcraft.yaml || true)"
+            if [ "${match_count}" -ne 1 ]; then
+              echo "ERROR: Expected exactly one 'grade: devel' line in snapcraft.yaml, found ${match_count}" >&2
+              exit 1
+            fi
+
+            sed -i -e "s/^grade: devel$/grade: stable/" snapcraft.yaml
+          fi
+
           git add snapcraft.yaml
-          git commit --quiet -s --allow-empty -m "Automatic upstream build (${BRANCH})" -m "Upstream commit: ${localRev}"
+          git commit --quiet -s -m "Automatic upstream build (${BRANCH})" -m "Upstream commit: ${localRev} (version: ${versionString})"
           git show
-          git push --quiet
+
+          # Pack all objects and generate a bitmap index
+          # right before the push so that pack generation benefits from full bitmap coverage.
+          git config --local pack.useBitmaps true
+          git gc --prune=now
+
+          git push --quiet --force launchpad HEAD:"${BRANCH}"
 
           # Unload the SSH key from the agent now that the push is done, to
           # prevent accidental usage in any subsequent steps within this job.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,134 @@
+name: microcloud
+base: core24
+assumes:
+ - snapd2.59
+version: git
+grade: devel
+license: AGPL-3.0-only
+
+title: MicroCloud
+summary: Deploy a low-touch, open source cloud platform in minutes with MicroCloud.
+description: |-
+  MicroCloud creates a lightweight cluster of machines that operates as a scalable private cloud. It combines LXD for virtualization, MicroCeph for distributed storage, and MicroOVN for networking—all automatically configured by the **MicroCloud snap** for reproducible, scalable deployments.
+
+  With MicroCloud, you can eliminate the complexity of manual setup and quickly benefit from high availability, streamlined security updates, and fine-grained access control for multi-tenancy. Cluster members can run full virtual machines or lightweight system containers with bare-metal performance. Manage it through your choice of client interfaces, including a graphical UI and CLI.
+
+  MicroCloud is designed for small-scale private clouds and hybrid cloud extensions. Its efficiency and simplicity also make it an excellent choice for edge computing, test labs, and other resource-constrained use cases.
+
+  **MicroCloud supports single-node deployments, but at least 3 nodes are recommended for high availability.**
+
+  Once the simple bootstrapping is completed, users can launch, run and manage their workloads, and otherwise utilize regular LXD functionalities.
+
+  To get started, LXD, MicroCeph, MicroOVN and MicroCloud snaps are needed. Users can install them at once with the command:
+
+  `snap install lxd microceph microcloud microovn`
+
+  The bootstrapping process starts with running
+
+  `microcloud init` on the initiating member
+  and `microcloud join` on the joining members if you're using more than one system.
+
+  Following the simple CLI prompts, a working MicroCloud will be ready within minutes.
+
+contact: lxd@lists.canonical.com
+issues: https://github.com/canonical/microcloud/issues
+source-code: https://github.com/canonical/microcloud
+website:
+  - https://canonical.com/microcloud
+  - https://documentation.ubuntu.com/microcloud/latest/microcloud/
+confinement: strict
+
+apps:
+  # Service
+  daemon:
+    command: commands/daemon.start
+    daemon: simple
+    plugs:
+      - lxd
+      - microceph
+      - microovn
+      - network
+      - network-bind
+
+  # Commands
+  microcloud:
+    command: commands/microcloud
+    plugs:
+      - network
+
+parts:
+  dqlite:
+    source: https://github.com/canonical/dqlite
+    source-branch: main
+    source-depth: 1
+    source-type: git
+    plugin: autotools
+    autotools-configure-parameters:
+      - --prefix=
+      - --enable-build-raft
+    stage-packages:
+      - liblz4-1
+      - libsqlite3-0
+      - libuv1
+    build-packages:
+      - liblz4-dev
+      - libsqlite3-dev
+      - libuv1-dev
+      - pkg-config
+    organize:
+      usr/lib/: lib/
+    prime:
+      - lib/libdqlite*so*
+      - lib/*/libuv*
+      #- lib/*/liblz4.so*  # use liblz4.so from the base snap
+
+  microcloud:
+    source: .
+    after:
+      - dqlite
+    build-snaps:
+      - go
+    plugin: nil
+    override-pull: |
+      craftctl default
+      set -ex
+
+      # Download the dependencies
+      go get -v -tags=agent ./...
+    override-build: |
+      set -ex
+
+      # Setup build environment
+      export CGO_CFLAGS="-I${CRAFT_STAGE}/include/ -I${CRAFT_STAGE}/usr/local/include/"
+      export CGO_LDFLAGS="-L${CRAFT_STAGE}/lib/ -L${CRAFT_STAGE}/usr/local/lib/"
+      export CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
+
+      # Build the binaries
+      go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/microcloud" -tags=agent ./cmd/microcloud
+      go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/microcloudd" -tags=agent,libsqlite3 ./cmd/microcloudd
+
+      # Workaround for https://bugs.launchpad.net/ubuntu/+source/vim/+bug/1968912
+      mkdir -p "${CRAFT_PART_INSTALL}/usr/share/vim/vim91"
+      touch "${CRAFT_PART_INSTALL}/usr/share/vim/vim91/defaults.vim"
+    prime:
+      - bin/microcloud
+      - bin/microcloudd
+      - usr/share/vim/vim91/defaults.vim
+
+  strip:
+    after:
+      - dqlite
+      - microcloud
+    plugin: nil
+    override-prime: |
+      set -x
+
+      # Strip binaries
+      find "${CRAFT_PRIME}"/bin -type f -exec strip -s {} +
+
+      # Strip libraries
+      find "${CRAFT_PRIME}"/lib -type f -exec strip -s {} +
+
+  wrappers:
+    plugin: dump
+    source: snapcraft/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,134 @@
+name: microcloud
+base: core24
+assumes:
+ - snapd2.59
+version: git
+grade: devel
+license: AGPL-3.0-only
+
+title: MicroCloud
+summary: Deploy a low-touch, open source cloud platform in minutes with MicroCloud.
+description: |-
+  MicroCloud creates a lightweight cluster of machines that operates as a scalable private cloud. It combines LXD for virtualization, MicroCeph for distributed storage, and MicroOVN for networking—all automatically configured by the **MicroCloud snap** for reproducible, scalable deployments.
+
+  With MicroCloud, you can eliminate the complexity of manual setup and quickly benefit from high availability, streamlined security updates, and fine-grained access control for multi-tenancy. Cluster members can run full virtual machines or lightweight system containers with bare-metal performance. Manage it through your choice of client interfaces, including a graphical UI and CLI.
+
+  MicroCloud is designed for small-scale private clouds and hybrid cloud extensions. Its efficiency and simplicity also make it an excellent choice for edge computing, test labs, and other resource-constrained use cases.
+
+  **MicroCloud supports single-node deployments, but at least 3 nodes are recommended for high availability.**
+
+  Once the simple bootstrapping is completed, users can launch, run and manage their workloads, and otherwise utilize regular LXD functionalities.
+
+  To get started, LXD, MicroCeph, MicroOVN and MicroCloud snaps are needed. Users can install them at once with the command:
+
+  `snap install lxd microceph microcloud microovn`
+
+  The bootstrapping process starts with running
+
+  `microcloud init` on the initiating member
+  and `microcloud join` on the joining members if you're using more than one system.
+
+  Following the simple CLI prompts, a working MicroCloud will be ready within minutes.
+
+contact: lxd@lists.canonical.com
+issues: https://github.com/canonical/microcloud/issues
+source-code: https://github.com/canonical/microcloud
+website:
+  - https://canonical.com/microcloud
+  - https://canonical.com/microcloud/docs/latest/
+confinement: strict
+
+apps:
+  # Service
+  daemon:
+    command: commands/daemon.start
+    daemon: simple
+    plugs:
+      - lxd
+      - microceph
+      - microovn
+      - network
+      - network-bind
+
+  # Commands
+  microcloud:
+    command: commands/microcloud
+    plugs:
+      - network
+
+parts:
+  dqlite:
+    source: https://github.com/canonical/dqlite
+    source-branch: main
+    source-depth: 1
+    source-type: git
+    plugin: autotools
+    autotools-configure-parameters:
+      - --prefix=
+      - --enable-build-raft
+    stage-packages:
+      - liblz4-1
+      - libsqlite3-0
+      - libuv1
+    build-packages:
+      - liblz4-dev
+      - libsqlite3-dev
+      - libuv1-dev
+      - pkg-config
+    organize:
+      usr/lib/: lib/
+    prime:
+      - lib/libdqlite*so*
+      - lib/*/libuv*
+      #- lib/*/liblz4.so*  # use liblz4.so from the base snap
+
+  microcloud:
+    source: .
+    after:
+      - dqlite
+    build-snaps:
+      - go
+    plugin: nil
+    override-pull: |
+      craftctl default
+      set -ex
+
+      # Download the dependencies
+      go get -v -tags=agent ./...
+    override-build: |
+      set -ex
+
+      # Setup build environment
+      export CGO_CFLAGS="-I${CRAFT_STAGE}/include/ -I${CRAFT_STAGE}/usr/local/include/"
+      export CGO_LDFLAGS="-L${CRAFT_STAGE}/lib/ -L${CRAFT_STAGE}/usr/local/lib/"
+      export CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
+
+      # Build the binaries
+      go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/microcloud" -tags=agent ./cmd/microcloud
+      go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/microcloudd" -tags=agent,libsqlite3 ./cmd/microcloudd
+
+      # Workaround for https://bugs.launchpad.net/ubuntu/+source/vim/+bug/1968912
+      mkdir -p "${CRAFT_PART_INSTALL}/usr/share/vim/vim91"
+      touch "${CRAFT_PART_INSTALL}/usr/share/vim/vim91/defaults.vim"
+    prime:
+      - bin/microcloud
+      - bin/microcloudd
+      - usr/share/vim/vim91/defaults.vim
+
+  strip:
+    after:
+      - dqlite
+      - microcloud
+    plugin: nil
+    override-prime: |
+      set -x
+
+      # Strip binaries
+      find "${CRAFT_PRIME}"/bin -type f -exec strip -s {} +
+
+      # Strip libraries
+      find "${CRAFT_PRIME}"/lib -type f -exec strip -s {} +
+
+  wrappers:
+    plugin: dump
+    source: snapcraft/

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -1,0 +1,13 @@
+#!/bin/sh
+export DQLITE_SOCKET="@snap.${SNAP_INSTANCE_NAME}.dqlite"
+
+MICROCLOUDD="microcloudd"
+if [ -x "${SNAP_COMMON}/microcloudd.debug" ]; then
+    MICROCLOUDD="${SNAP_COMMON}/microcloudd.debug"
+    echo "==> WARNING: Using a custom debug MicroCloud binary!"
+    GOCOVERDIR="${SNAP_COMMON}/data/cover"
+    export GOCOVERDIR
+    mkdir -p "${GOCOVERDIR}"
+fi
+
+exec "${MICROCLOUDD}" --state-dir "${SNAP_COMMON}/state"

--- a/snapcraft/commands/microcloud
+++ b/snapcraft/commands/microcloud
@@ -1,0 +1,20 @@
+#!/bin/sh
+MICROCLOUD="microcloud"
+if [ -x "${SNAP_COMMON}/microcloud.debug" ]; then
+    MICROCLOUD="${SNAP_COMMON}/microcloud.debug"
+    GOCOVERDIR="${SNAP_COMMON}/data/cover"
+    export GOCOVERDIR
+    mkdir -p "${GOCOVERDIR}"
+fi
+
+# Change the location of $VIMRUNTIME root to be able to define the defaults.vim file.
+# This is to prevent seeing the message 'E1187: Failed to source defaults.vim'
+# which is caused by not having the 'vim-runtime' package.
+# Also see https://bugs.launchpad.net/ubuntu/+source/vim/+bug/1968912.
+export VIMRUNTIME="${SNAP}/usr/share/vim/vim91"
+export EDITOR="vim.tiny -Z --clean"
+
+# Run the CLI from an accessible directory which allows reads.
+# When launching VIM it tries to access the $PWD regardless of the --clean setting.
+cd "$SNAP_USER_DATA" || exit
+exec "${MICROCLOUD}" --state-dir "${SNAP_COMMON}/state" "$@"


### PR DESCRIPTION
Migrates the build job from github.com/canonical/microcloud-pkg-snap. Aligns with the build job from LXD.

To stay in line with LXD, I would propose using the same format for `release-*` branches even though MicroCloud uses `vX-edge` scheme for the version branches.