### PR TITLE
doc: prevent indexing of integrated docs

### DIFF
--- a/doc/.sphinx/_integration/add_config.py
+++ b/doc/.sphinx/_integration/add_config.py
@@ -14,6 +14,8 @@ if project == "LXD":
     html_css_files = globals().get('html_css_files', []) + ['override-header.css']
     html_js_files = globals().get('html_js_files', []) + ['js/overwrite_microcloud_links.js']
     tags.add('integrated')
+    # Prevent indexing of integrated docs
+    html_context['seo_noindex'] = True
 elif project == "MicroCeph":
     html_baseurl = "https://documentation.ubuntu.com/microceph/latest/"
     # Override default header templates
@@ -25,9 +27,13 @@ elif project == "MicroCeph":
     html_js_files = globals().get('html_js_files', []) + ['overwrite_microcloud_links.js']
     # Add "integrated" to the list of custom tags
     tags.add('integrated')
+    # Prevent indexing of integrated docs
+    html_context['seo_noindex'] = True
 elif project == "MicroOVN":
     html_baseurl = "https://ubuntu.com/docs/microovn/latest/"
     tags.add('integrated')
     html_static_path = globals().get('html_static_path', []) + ["_static"]
     # Add js to overwrite MicroCloud links
     html_js_files = globals().get('html_js_files', []) + ['overwrite_microcloud_links.js']
+    # Prevent indexing of integrated docs
+    html_context['seo_noindex'] = True

--- a/doc/.sphinx/_integration/microceph-base.html
+++ b/doc/.sphinx/_integration/microceph-base.html
@@ -1,0 +1,9 @@
+{% extends "!base.html" %}
+
+{% block extrahead %}
+  {{ super() }}
+  {% if seo_noindex %}
+  {# Prevent indexing of integrated docs. #}
+  <meta name="robots" content="noindex">
+  {% endif %}
+{% endblock %}

--- a/doc/.sphinx/_integration/microovn-extrahead.html
+++ b/doc/.sphinx/_integration/microovn-extrahead.html
@@ -1,0 +1,7 @@
+{% block extrahead %}
+  {{ super() }}
+  {% if seo_noindex %}
+  {# Prevent indexing of integrated docs. #}
+  <meta name="robots" content="noindex">
+  {% endif %}
+{% endblock %}

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -157,6 +157,10 @@ integrate: integrate-precheck
 	cp _templates/google-tag.html integration/microovn/docs/.sphinx/_templates/
 	cp .sphinx/_integration/header.css integration/microovn/docs/.sphinx/_static/
 
+	# Set up `noindex` tags for MicroCeph and MicroOVN pages
+	cp .sphinx/_integration/microceph-base.html integration/microceph/docs/_templates/base.html
+	cat .sphinx/_integration/microovn-extrahead.html >> integration/microovn/docs/.sphinx/_templates/base.html
+
 	# Add information about where to find the tags/docs to the doc sets
 	cat .sphinx/_integration/add_config.py >> integration/lxd/doc/conf.py
 	cat .sphinx/_integration/add_config.py >> integration/microceph/docs/conf.py

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -112,6 +112,12 @@ integrate-pull:
 # - MicroOVN tag: The integrated docs use the circle of friends logo by
 #   overwriting the MicroOVN logo. Check that the MicroOVN logo is located where
 #   expected.
+# - SEO noindex tags:
+#     - LXD: verify upstream `base.html`, with `seo_noindex` check and `noindex`
+#       tag
+#     - MicroCeph: verify that there is no `base.html` file in the upstream docs
+#     - MicroOVN: verify upstream base.html file, that extends furo and does not
+#       already have an extrahead block
 integrate-precheck: integrate-pull
 	@echo "Running integration prechecks ..."
 
@@ -134,6 +140,25 @@ integrate-precheck: integrate-pull
 	@echo "Checking for MicroOVN tag ..."
 	@test -f integration/microovn/docs/.sphinx/_static/microovn.png || \
 		{ echo "ERROR: MicroOVN tag not found. Update the integration."; exit 1; }
+
+	@echo "Checking noindex tag setup ..."
+	@echo "- Checking LXD noindex setup..."
+	@test -f integration/lxd/doc/_templates/base.html || \
+		{ echo "ERROR: No base.html file in LXD docs. Update the noindex integration."; exit 1; }
+	@grep -q 'seo_noindex' integration/lxd/doc/_templates/base.html || \
+		{ echo "ERROR: LXD's base.html does not check seo_noindex. Update the noindex integration."; exit 1; }
+	@grep -q 'content="noindex"' integration/lxd/doc/_templates/base.html || \
+		{ echo "ERROR: LXD's base.html does not contain the noindex tag. Update the noindex integration."; exit 1; }
+	@echo "- Checking MicroCeph noindex setup..."
+	@test ! -f integration/microceph/docs/_templates/base.html || \
+		{ echo "ERROR: MicroCeph docs now include base.html. Update the noindex integration."; exit 1; }
+	@echo "- Checking MicroOVN noindex setup..."
+	@test -f integration/microovn/docs/.sphinx/_templates/base.html || \
+		{ echo "ERROR: No base.html file in MicroOVN docs. Update the noindex integration."; exit 1; }
+	@grep -q 'extends "furo/base.html"' integration/microovn/docs/.sphinx/_templates/base.html || \
+		{ echo "ERROR: MicroOVN base.html no longer extends furo/base.html. Update the noindex integration."; exit 1; }
+	@! grep -q 'extrahead' integration/microovn/docs/.sphinx/_templates/base.html || \
+		{ echo "ERROR: MicroOVN base.html defines extrahead block. Update the noindex integration."; exit 1; }
 
 integrate: integrate-precheck
 	# Create a directory for files to override in MicroCloud docs


### PR DESCRIPTION
- Updates `add_config.py` to add `seo_noindex` context to the LXD, MicroCeph, and MicroOVN docs.
- Sets up base.html file to add to the cloned MicroCeph docs
- Sets up extrahead block to append to the cloned MicroOVN docs

Note that the LXD upstream docs already have a check for `seo_noindex`, so setting `html['seo_noindex'] = True` is sufficient to add the noindex tags.

Documentation on the `extrahead` block and `super()` is available here: https://www.sphinx-doc.org/en/master/development/html_themes/templating.html.

For comparison, `noindex` tags were added to the older LXD docs versions in https://github.com/canonical/lxd/pull/17984.