### PR TITLE
Add 'sudo' to snap install commands in tutorial

### DIFF
--- a/doc/tutorial/multi-member.md
+++ b/doc/tutorial/multi-member.md
@@ -266,9 +266,9 @@ Complete the following steps on each VM (`micro1`, `micro2`, `micro3`, and `micr
 1. Install the required snaps:
 
        sudo snap install lxd --channel=5.21/stable --cohort="+"
-       snap install microceph --channel=squid/stable --cohort="+"
-       snap install microovn --channel=24.03/stable --cohort="+"
-       snap install microcloud --channel=2/stable --cohort="+"
+       sudo snap install microceph --channel=squid/stable --cohort="+"
+       sudo snap install microovn --channel=24.03/stable --cohort="+"
+       sudo snap install microcloud --channel=2/stable --cohort="+"
 
    ```{note}
    The `--cohort="+"` flag in the command ensures that the same version of the snap is installed on all machines.


### PR DESCRIPTION
Alll commands need a sudo.

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-structure).
- [ ] I have checked and added or updated relevant documentation.