### PR TITLE
doc: fix paths on 404 pages

### DIFF
--- a/doc/.sphinx/_integration/microcloud.html
+++ b/doc/.sphinx/_integration/microcloud.html
@@ -7,7 +7,11 @@
     <ul class="p-navigation__links" role="menu">
 
       <li class="active">
+        {% if pagename == "404" %}
+        <a class="p-logo" href="{{ nav404_prefix }}" aria-current="page">
+        {% else %}
         <a class="p-logo" href="{{ pathto(root_doc) }}" aria-current="page">
+        {% endif %}
           <img src="{{ pathto(product_tag,1) }}" alt="Logo" class="p-logo-image">
           <div class="p-logo-text p-heading--4">{{ project }}
           </div>
@@ -15,24 +19,39 @@
       </li>
 
       <li>
+        {% if pagename == "404" %}
+        <a class="p-logo" href="{{ nav404_prefix }}{{ lxd_path }}/" aria-current="page">
+          <img src="{{ nav404_prefix }}{{ lxd_tag }}" alt="Logo" class="p-logo-image">
+        {% else %}
         <a class="p-logo" href="{{ pathto(root_doc) if pathto(root_doc) != '#' }}{{ lxd_path }}/" aria-current="page">
           <img src="{{ pathto(root_doc) if pathto(root_doc) != '#' }}{{ lxd_tag }}" alt="Logo" class="p-logo-image">
+        {% endif %}
           <div class="p-logo-text p-heading--4">LXD
           </div>
         </a>
       </li>
 
       <li>
+        {% if pagename == "404" %}
+        <a class="p-logo" href="{{ nav404_prefix }}{{ microceph_path }}/" aria-current="page">
+          <img src="{{ nav404_prefix }}{{ microceph_tag }}" alt="Logo" class="p-logo-image">
+        {% else %}
         <a class="p-logo" href="{{ pathto(root_doc) if pathto(root_doc) != '#' }}{{ microceph_path }}/" aria-current="page">
           <img src="{{ pathto(root_doc) if pathto(root_doc) != '#' }}{{ microceph_tag }}" alt="Logo" class="p-logo-image">
+        {% endif %}
           <div class="p-logo-text p-heading--4">MicroCeph
           </div>
         </a>
       </li>
 
       <li>
+        {% if pagename == "404" %}
+        <a class="p-logo" href="{{ nav404_prefix }}{{ microovn_path }}/" aria-current="page">
+          <img src="{{ nav404_prefix }}{{ microovn_tag }}" alt="Logo" class="p-logo-image">
+        {% else %}
         <a class="p-logo" href="{{ pathto(root_doc) if pathto(root_doc) != '#' }}{{ microovn_path }}/" aria-current="page">
           <img src="{{ pathto(root_doc) if pathto(root_doc) != '#' }}{{ microovn_tag }}" alt="Logo" class="p-logo-image">
+        {% endif %}
           <div class="p-logo-text p-heading--4">MicroOVN
           </div>
         </a>

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -141,6 +141,11 @@ html: integrate install
 	cd integration/microceph/docs/ && $(MAKE) html DOCS_BUILDDIR=$(current_dir)/_build/microceph
 	cd integration/microovn/docs/ && $(MAKE) html BUILDDIR=$(current_dir)/_build/microovn
 	. $(DOCS_VENV); $(SPHINX_BUILD) -W --keep-going -b dirhtml "$(DOCS_SOURCEDIR)" "$(current_dir)/_build" -w $(SPHINX_DIR)/warnings.txt $(SPHINX_OPTS)
+	@echo "Checking 404 page setup ..."
+	@grep -q '<a href="#"><div class="brand">' "$(LOCAL_404_FILE)" || \
+		{ echo "ERROR: brand pattern not found in $(LOCAL_404_FILE). Update the 404 page customization."; exit 1; }
+	@grep -q '<a class="sidebar-brand" href="#">' "$(LOCAL_404_FILE)" || \
+		{ echo "ERROR: sidebar-brand pattern not found in $(LOCAL_404_FILE). Update the 404 page customization."; exit 1; }
 	sed -e 's|<a href="#"><div class="brand">|<a href="$(NAV_404_HREF)"><div class="brand">|' \
 		-e 's|<a class="sidebar-brand" href="#">|<a class="sidebar-brand" href="$(NAV_404_HREF)">|' \
 		"$(LOCAL_404_FILE)" > "$(LOCAL_404_FILE).tmp" && mv "$(LOCAL_404_FILE).tmp" "$(LOCAL_404_FILE)"
@@ -152,6 +157,11 @@ html-rtd: install
 	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -C integration/microceph/docs/ html DOCS_BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microceph
 	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -C integration/microovn/docs/ html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microovn
 	. $(DOCS_VENV); PATH_PREFIX=$(PATH_PREFIX) $(SPHINX_BUILD) -W --keep-going -b dirhtml "$(DOCS_SOURCEDIR)" "$(READTHEDOCS_OUTPUT)/html" -w $(SPHINX_DIR)/warnings.txt $(SPHINX_OPTS)
+	@echo "Checking 404 page setup ..."
+	@grep -q '<a href="#"><div class="brand">' "$(RTD_404_FILE)" || \
+		{ echo "ERROR: brand pattern not found in $(RTD_404_FILE). Update the 404 page customization."; exit 1; }
+	@grep -q '<a class="sidebar-brand" href="#">' "$(RTD_404_FILE)" || \
+		{ echo "ERROR: sidebar-brand pattern not found in $(RTD_404_FILE). Update the 404 page customization."; exit 1; }
 	sed -e 's|<a href="#"><div class="brand">|<a href="$(NAV_404_HREF)"><div class="brand">|' \
 		-e 's|<a class="sidebar-brand" href="#">|<a class="sidebar-brand" href="$(NAV_404_HREF)">|' \
 		"$(RTD_404_FILE)" > "$(RTD_404_FILE).tmp" && mv "$(RTD_404_FILE).tmp" "$(RTD_404_FILE)"

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -20,7 +20,13 @@ VALE_DIR         ?= $(DOCS_VENVDIR)/lib/python*/site-packages/vale
 VALE_CONFIG      ?= $(SPHINX_DIR)/vale.ini
 PA11Y_CMD        ?= $(SPHINX_DIR)/node_modules/pa11y/bin/pa11y.js --config $(SPHINX_DIR)/pa11y.json
 CHECK_PATH       ?= $(filter-out $(DOCS_VENVDIR),$(wildcard *))
+
+# Integration setup
 INTEGRATION_DIR ?= integration
+# 404 page customization
+LOCAL_404_FILE ?= $(DOCS_BUILDDIR)/404/index.html
+RTD_404_FILE ?= $(READTHEDOCS_OUTPUT)/html/404/index.html
+NAV_404_HREF ?= /microcloud/docs/$(or $(READTHEDOCS_VERSION),local)/
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -135,6 +141,9 @@ html: integrate install
 	cd integration/microceph/docs/ && $(MAKE) html DOCS_BUILDDIR=$(current_dir)/_build/microceph
 	cd integration/microovn/docs/ && $(MAKE) html BUILDDIR=$(current_dir)/_build/microovn
 	. $(DOCS_VENV); $(SPHINX_BUILD) -W --keep-going -b dirhtml "$(DOCS_SOURCEDIR)" "$(current_dir)/_build" -w $(SPHINX_DIR)/warnings.txt $(SPHINX_OPTS)
+	sed -e 's|<a href="#"><div class="brand">|<a href="$(NAV_404_HREF)"><div class="brand">|' \
+		-e 's|<a class="sidebar-brand" href="#">|<a class="sidebar-brand" href="$(NAV_404_HREF)">|' \
+		"$(LOCAL_404_FILE)" > "$(LOCAL_404_FILE).tmp" && mv "$(LOCAL_404_FILE).tmp" "$(LOCAL_404_FILE)"
 
 # `html-rtd` builds the integrated docs, with the correct paths for Read the Docs.
 # This target is used by the Read the Docs build.
@@ -143,6 +152,9 @@ html-rtd: install
 	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -C integration/microceph/docs/ html DOCS_BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microceph
 	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -C integration/microovn/docs/ html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microovn
 	. $(DOCS_VENV); PATH_PREFIX=$(PATH_PREFIX) $(SPHINX_BUILD) -W --keep-going -b dirhtml "$(DOCS_SOURCEDIR)" "$(READTHEDOCS_OUTPUT)/html" -w $(SPHINX_DIR)/warnings.txt $(SPHINX_OPTS)
+	sed -e 's|<a href="#"><div class="brand">|<a href="$(NAV_404_HREF)"><div class="brand">|' \
+		-e 's|<a class="sidebar-brand" href="#">|<a class="sidebar-brand" href="$(NAV_404_HREF)">|' \
+		"$(RTD_404_FILE)" > "$(RTD_404_FILE).tmp" && mv "$(RTD_404_FILE).tmp" "$(RTD_404_FILE)"
 
 epub: install
 	. $(DOCS_VENV); $(SPHINX_BUILD) -b epub "$(DOCS_SOURCEDIR)" "$(DOCS_BUILDDIR)" -w $(SPHINX_DIR)/warnings.txt $(SPHINX_OPTS)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,6 +9,7 @@ import yaml
 import sys
 from git import Repo
 import re
+from urllib.parse import urlparse
 
 sys.path.append('./')
 sys.path.append('.sphinx/')
@@ -72,6 +73,9 @@ html_context = {
     'display_contributors': False,
 
     'sequential_nav': 'both',
+
+    # Prefix for top navigation menu URLs on 404 pages
+    'nav404_prefix': urlparse(html_baseurl).path,
 }
 
 html_extra_path = ['_extra']


### PR DESCRIPTION
With the exception of the MicroCloud logo, the relative paths are not resolving correctly for href links and logo static files in the top navigation menu on 404 pages, nor are the resolving correctly for two "brand" href links (one in the sidebar and the other at the top of the page). Issues include:

- MicroCloud links in the top navigation menu, at the top of the page, and in the sidebar resolve to "#", which means that these links cannot be used to navigate back to the docs homepage.
- LXD, MicroCeph, and MicroOVN href links and static file paths in the to navigation menu resolve to the product (e.g. `lxd/`) or the tag path (e.g. `lxd/_static/lxd_tag.png`), which appends those paths to the end of the URL that lands on a 404 page (e.g.  on `canonical.com/microcloud/docs/latest/bad-url/`, the LXD link goes to `canonical.com/microcloud/docs/latest/bad-url/lxd/`. As a result, the logos are not loading and the links cannot be used to navigate to the LXD, etc. docs subsets.

To resolve this issue, this commit:

- Adds `nav404_prefix` to `html_context` and sets it to the path portion of `html_baseurl`. This makes the base path available in HTML templates.
- Updates the MicroCloud header template with if-else statements, to use `nav404_prefix` on 404 pages. Note that only the MicroCloud header (`microcloud.html`) needed to be updated, since 404 pages across the integrated docs use the MicroCloud template (rather than to the LXD, MicroCeph, and MicroOVN subsets). This hard-codes the correct path into the 404 page generated by Sphinx.
- Updates the Makefile to replace `"#"` in the "brand" href links with the correct `/microcloud/docs/{version}` path.

Note that the Makefile update depends on the current docs URL pattern (`https://canonical.com/microcloud/docs/{version}/` and will require a manual update if the docs move to a new URL pattern.
