### PR TITLE
Backport MicroCloud 3 release notes to MicroCloud 2 docs (v2-edge)

### DIFF
--- a/doc/reference/release-notes/index.md
+++ b/doc/reference/release-notes/index.md
@@ -25,8 +25,8 @@ For full instructions on updating or upgrading MicroCloud, refer to {ref}`howto-
 
 ```{toctree}
 :titlesonly:
-MicroCloud 3.2 <https://documentation.ubuntu.com/microcloud/latest/reference/release-notes/release-notes-3.2/>
-MicroCloud 3.1 <https://documentation.ubuntu.com/microcloud/latest/reference/release-notes/release-notes-3.1/>
+MicroCloud 3.2 </reference/release-notes/release-notes-3.2>
+MicroCloud 3.1 </reference/release-notes/release-notes-3.1>
 MicroCloud 2.1.3 LTS </reference/release-notes/release-notes-2.1.3>
 MicroCloud 2.1.2 LTS <https://discourse.ubuntu.com/t/microcloud-2-1-2-lts-has-been-released/73771/2>
 MicroCloud 2.1.1 LTS <https://discourse.ubuntu.com/t/microcloud-2-1-2-lts-has-been-released/73771>

--- a/doc/reference/release-notes/release-notes-3.1.md
+++ b/doc/reference/release-notes/release-notes-3.1.md
@@ -29,7 +29,7 @@ how to enroll a MicroCloud cluster.
 
 ### Temporary UI access link
 
-It's fast to deploy a MicroCloud and gain the ability to spawn resources with it from the command line.
+It's fast to deploy a MicroCloud and gain the ability to spawn resources from the command line.
 To provide the same experience when {ref}`using the UI <howto-ui>`, we added a new question to the end of the
 interactive `microcloud init` questionnaire:
 
@@ -37,7 +37,7 @@ interactive `microcloud init` questionnaire:
 
 If you answer `yes` (default), MicroCloud creates a temporary UI access link that allows you to immediately enter
 the LXD UI after MicroCloud is installed.
-The temporary access lasts for 24 hours and is intended to perform further setups (such as configuring permanent access).
+The temporary access lasts for 24 hours and is intended to allow you to perform further setup (such as configuring permanent access).
 
 This requires a 6+ version of LXD, which is currently a feature track (non-LTS).
 

--- a/doc/reference/release-notes/release-notes-3.1.md
+++ b/doc/reference/release-notes/release-notes-3.1.md
@@ -1,0 +1,63 @@
+---
+myst:
+  html_meta:
+    description: Release notes for MicroCloud 3.1, including highlights about new features, bugfixes, and other updates from the MicroCloud project.
+---
+
+(ref-release-notes-3.1)=
+# MicroCloud 3.1 release notes
+
+This is a {ref}`feature release <ref-releases-microcloud-feature>` and is not recommended for production use.
+It's the first feature release of the new track 3.
+
+(ref-release-notes-3.1-highlights)=
+## Highlights
+
+This section highlights new and improved features in this release.
+
+### Cluster Manager
+
+Cluster Manager allows you to manage and monitor multiple MicroCloud clusters in a single application.
+Starting with this release, a MicroCloud can be connected to an existing deployment of Cluster Manager.
+
+Check {ref}`howto-cluster-manager` to deploy Cluster Manager.
+The {ref}`howto-cluster-manager-requirements` section lists the requirements to get started.
+See the {ref}`ref-cluster-manager-architecture` page for an in-depth view of the core components.
+
+If you already have a Cluster Manager deployment, see {ref}`howto-cluster-manager-enroll` to learn
+how to enroll a MicroCloud cluster.
+
+### Temporary UI access link
+
+It's fast to deploy a MicroCloud and gain the ability to spawn resources with it from the command line.
+To provide the same experience when {ref}`using the UI <howto-ui>`, we added a new question to the end of the
+interactive `microcloud init` questionnaire:
+
+`Would you like to create an initial UI access link? (yes/no) [default=yes]:`
+
+If you answer `yes` (default), MicroCloud creates a temporary UI access link that allows you to immediately enter
+the LXD UI after MicroCloud is installed.
+The temporary access lasts for 24 hours and is intended to perform further setups (such as configuring permanent access).
+
+This requires a 6+ version of LXD, which is currently a feature track (non-LTS).
+
+### MicroOVN 26.03 support (experimental)
+
+MicroCloud 3.1 can use MicroOVN 26.03, which is a feature release currently available through their `latest/edge` channel. Using this instead of the MicroOVN 24.03 LTS release (snap channel `24.03/stable`) allows us to test the latest features before the 26.03 release is published as the next LTS.
+
+Make sure you have the `core26` snap installed before trying to install MicroOVN from `latest/edge`:
+
+```bash
+snap install core26 --channel="latest/edge"
+snap install microovn --channel="latest/edge" --cohort="+"
+```
+
+## Upgrading to the new version
+
+If you are currently running MicroCloud 2 LTS, be aware that upgrading to track 3 is not yet recommended or supported for production clusters.
+See the {ref}`howto-upgrade-microcloud` guide for information on how to switch the MicroCloud track.
+
+(ref-release-notes-3.1-changelog)=
+## Change log
+
+View the [complete list of all changes in this release](https://github.com/canonical/microcloud/compare/2.1.0...3.1).

--- a/doc/reference/release-notes/release-notes-3.2.md
+++ b/doc/reference/release-notes/release-notes-3.2.md
@@ -1,0 +1,33 @@
+---
+myst:
+  html_meta:
+    description: Release notes for MicroCloud 3.2, including highlights about new features, bugfixes, and other updates from the MicroCloud project.
+---
+
+(ref-release-notes-3.2)=
+# MicroCloud 3.2 release notes
+
+This is a {ref}`feature release <ref-releases-microcloud-feature>` and is not recommended for production use.
+It's the second feature release of track 3.
+
+(ref-release-notes-3.2-highlights)=
+## Highlights
+
+This section highlights new and improved features in this release.
+
+### LXD 6.8 support
+
+{ref}`LXD 6.8 <lxd:ref-release-notes-6.8>` changed many of its API endpoints to be asynchronous (such as storage and network creation).
+MicroCloud 3.2 accommodates those changes when creating resources in LXD.
+
+## Upgrading to the new version
+
+If you are currently running MicroCloud 2 LTS, be aware that upgrading to track 3 is not yet recommended or supported for production clusters.
+See the {ref}`howto-upgrade` guide for information on how to switch the MicroCloud track.
+
+If you are currently using an earlier release of MicroCloud 3, refer to the {ref}`howto-update` guide for information on how to retrieve and use the latest release on the same track.
+
+(ref-release-notes-3.2-changelog)=
+## Change log
+
+View the [complete list of all changes in this release](https://github.com/canonical/microcloud/compare/3.1...3.2).


### PR DESCRIPTION
This PR:

- backports the release notes for MicroCloud 3.1 and MicroCloud 3.2 to the documentation for MicroCloud 2 (from PRs https://github.com/canonical/microcloud/pull/1274, https://github.com/canonical/microcloud/pull/1343, and https://github.com/canonical/microcloud/pull/1345), and
- updates the MicroCloud 2 release notes TOC to use the pages, rather than links out to MicroCloud 3 (`latest`) docs.

Motivation: if a user is viewing the `default` version of the docs and navigates to the 3.1 or 3.2 release notes, then the user jumps to the `latest` version. If the user then uses the version selector flyout menu to navigate back to `default`, the user lands on a 404 page.

We could, alternatively, put in place a redirect for the `/reference/release-notes/release-notes-3.{1|2}/` path back to `latest`, but if that additional step of adding a redirect is required anyway, it seems simpler to backport the MicroCloud 3 release notes. This also ensures that users do not unintentionally switch from the `default` to `latest` docs versions.