### PR TITLE
doc: update MicroCeph docs URL

### DIFF
--- a/doc/.sphinx/_integration/add_config.py
+++ b/doc/.sphinx/_integration/add_config.py
@@ -15,7 +15,7 @@ if project == "LXD":
     html_js_files = globals().get('html_js_files', []) + ['js/overwrite_microcloud_links.js']
     tags.add('integrated')
 elif project == "MicroCeph":
-    html_baseurl = "https://documentation.ubuntu.com/microceph/latest/"
+    html_baseurl = "https://canonical.com/ceph/docs/latest/"
     # Override default header templates
     templates_path = globals().get('templates_path', []) + ["_templates"]
     # Override default header styles

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -271,7 +271,7 @@ notfound_context = {
 if ('SINGLE_BUILD' in os.environ and os.environ['SINGLE_BUILD'] == 'True'):
     intersphinx_mapping = {
         'lxd': ('https://canonical.com/lxd/docs/latest/', None),
-        'microceph': ('https://documentation.ubuntu.com/microceph/latest/', None),
+        'microceph': ('https://canonical.com/ceph/docs/latest/', None),
         'microovn': ('https://ubuntu.com/docs/microovn/latest/', None),
     }
 elif ('READTHEDOCS' in os.environ) and (os.environ['READTHEDOCS'] == 'True'):


### PR DESCRIPTION
MicroCeph docs have moved to https://canonical.com/ceph/docs/.