### PR TITLE
Test: Wait in e2e test for restarted intances

### DIFF
--- a/test/e2e/run
+++ b/test/e2e/run
@@ -289,14 +289,23 @@ evacuation() {
         fi
 
         lxc cluster restore --project e2e-testing --force "${REMOTE}:${member}"
-    done
 
-    echo -n "Allow time for stopped instances to start back again "
-    for _ in $(seq 20); do
-        echo -n "."
-        sleep 1
+        echo -n "Allow time for stopped instances on ${member} to start back again and have an IPv4 address"
+        for instance in $(instanceListByMember "${member}"); do
+            attempts=0
+            while [ -z "$(getIPv4 "${instance}")" ]; do
+                echo -n "."
+                sleep 1
+                attempts=$((attempts + 1))
+                if [ "${attempts}" -ge 30 ]; then
+                    echo " FAILED"
+                    exit 1
+                fi
+            done
+        done
+
+        echo " DONE"
     done
-    echo " DONE"
 }
 
 

--- a/test/e2e/run
+++ b/test/e2e/run
@@ -202,6 +202,11 @@ instanceList() {
     lxc list --project e2e-testing -f csv -c n "${REMOTE}:"
 }
 
+instanceListByMember() {
+    local member="${1}"
+    lxc list --project e2e-testing -f csv -c n "${REMOTE}:" location="${member}"
+}
+
 clusterMembers() {
     local state="${1}"
     [ "${state}" = "ALL" ] && state=".*"


### PR DESCRIPTION
In https://github.com/canonical/microcloud/actions/runs/31585772271/job/94079902223 I saw that it sometimes might take the instances longer than the 20s which are currently in place to get an IPv4 address. 

Instead of bumping to 30s, we wait until they actually got an IP which might also speed up the test sometimes instead of always waiting 20s. But its capped at 30s max.