### PR TITLE
Github: Add dependabot checks for `doc/requirements.txt`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,23 @@ updates:
         patterns:
           - "*"
 
+  - package-ecosystem: "pip"
+    directory: "/doc"
+    ignore:
+      # Pinned intentionally: myst-parser v5.0.0 causes version conflicts.
+      - dependency-name: "myst-parser"
+        versions: [">=5.0.0"]
+    labels: []
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    cooldown:
+      default-days: 7
+    groups:
+      pip:
+        patterns:
+          - "*"
+
   - package-ecosystem: "github-actions"
     directories:
       - "/"
@@ -53,5 +70,22 @@ updates:
       default-days: 7
     groups:
       gomod:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/doc"
+    ignore:
+      # Pinned intentionally: myst-parser v5.0.0 causes version conflicts.
+      - dependency-name: "myst-parser"
+        versions: [">=5.0.0"]
+    labels: []
+    schedule:
+      interval: "weekly"
+    target-branch: "v2-edge"
+    cooldown:
+      default-days: 7
+    groups:
+      pip:
         patterns:
           - "*"


### PR DESCRIPTION
Similar to https://github.com/canonical/lxd/commit/f69ed17ba65221a62ea6536aa63f55185971ca44. Should address some of the code scanning alerts like https://github.com/canonical/microcloud/security/code-scanning/505.