### PR TITLE
Test: Wait for stable members during upgrade

### DIFF
--- a/test/suites/upgrade.sh
+++ b/test/suites/upgrade.sh
@@ -175,9 +175,8 @@ ceph:
     # Second upgrade MicroOVN.
     for m in micro01 micro02 micro03; do
       lxc exec "${m}" -- snap refresh microovn --channel "${microovn_target}"
-    done
 
-    for m in micro01 micro02 micro03; do
+      # Before proceeding with the next member, wait for ${m} to stabilize.
       retries=0
       while true; do
         if [ "${retries}" -gt 60 ]; then


### PR DESCRIPTION
Instead of upgrading all at once and waiting for the members to stabilize at the end, upgrade one by one (as mentioned in the docs) and wait until the member stabilizes before proceeding with the next one.

I suspect the change fixing intermittent errors like https://github.com/canonical/microcloud/actions/runs/31585772271/job/94120471038.