### PR TITLE
doc: backport integration checks, 404 page fix, noindex tags, and MicroCeph URL update (v2-edge)

### DIFF
--- a/doc/.sphinx/_integration/add_config.py
+++ b/doc/.sphinx/_integration/add_config.py
@@ -14,6 +14,8 @@ if project == "LXD":
     html_css_files = globals().get('html_css_files', []) + ['override-header.css']
     html_js_files = globals().get('html_js_files', []) + ['js/overwrite_microcloud_links.js']
     tags.add('integrated')
+    # Prevent indexing of integrated docs
+    html_context['seo_noindex'] = True
 elif project == "MicroCeph":
     html_baseurl = "https://documentation.ubuntu.com/microceph/v19.2.0-squid/"
     # Override default header styles
@@ -28,9 +30,13 @@ elif project == "MicroCeph":
     ]
     # Add "integrated" to the list of custom tags
     tags.add('integrated')
+    # Prevent indexing of integrated docs
+    html_context['seo_noindex'] = True
 elif project == "MicroOVN":
     html_baseurl = "https://ubuntu.com/docs/microovn/24.03/"
     tags.add('integrated')
     html_static_path = globals().get('html_static_path', []) + ["_static"]
     # Add js to overwrite MicroCloud links
     html_js_files = globals().get('html_js_files', []) + ['overwrite_microcloud_links.js']
+    # Prevent indexing of integrated docs
+    html_context['seo_noindex'] = True

--- a/doc/.sphinx/_integration/add_config.py
+++ b/doc/.sphinx/_integration/add_config.py
@@ -17,7 +17,7 @@ if project == "LXD":
     # Prevent indexing of integrated docs
     html_context['seo_noindex'] = True
 elif project == "MicroCeph":
-    html_baseurl = "https://documentation.ubuntu.com/microceph/v19.2.0-squid/"
+    html_baseurl = "https://canonical.com/ceph/docs/v19.2.0-squid/"
     # Override default header styles
     html_static_path = globals().get('html_static_path', []) + ["_static"]
     html_css_files = globals().get('html_css_files', []) + [

--- a/doc/.sphinx/_integration/extrahead.html
+++ b/doc/.sphinx/_integration/extrahead.html
@@ -1,0 +1,7 @@
+{% block extrahead %}
+  {{ super() }}
+  {% if seo_noindex %}
+  {# Prevent indexing of integrated docs. #}
+  <meta name="robots" content="noindex">
+  {% endif %}
+{% endblock %}

--- a/doc/.sphinx/_integration/microcloud.html
+++ b/doc/.sphinx/_integration/microcloud.html
@@ -7,7 +7,11 @@
     <ul class="p-navigation__links" role="menu">
 
       <li class="active">
+        {% if pagename == "404" %}
+        <a class="p-logo" href="{{ nav404_prefix }}" aria-current="page">
+        {% else %}
         <a class="p-logo" href="{{ pathto(root_doc) }}" aria-current="page">
+        {% endif %}
           <img src="{{ pathto(product_tag,1) }}" alt="Logo" class="p-logo-image">
           <div class="p-logo-text p-heading--4">{{ project }}
           </div>
@@ -15,24 +19,39 @@
       </li>
 
       <li>
+        {% if pagename == "404" %}
+        <a class="p-logo" href="{{ nav404_prefix }}{{ lxd_path }}/" aria-current="page">
+          <img src="{{ nav404_prefix }}{{ lxd_tag }}" alt="Logo" class="p-logo-image">
+        {% else %}
         <a class="p-logo" href="{{ pathto(root_doc) if pathto(root_doc) != '#' }}{{ lxd_path }}/" aria-current="page">
           <img src="{{ pathto(root_doc) if pathto(root_doc) != '#' }}{{ lxd_tag }}" alt="Logo" class="p-logo-image">
+        {% endif %}
           <div class="p-logo-text p-heading--4">LXD
           </div>
         </a>
       </li>
 
       <li>
+        {% if pagename == "404" %}
+        <a class="p-logo" href="{{ nav404_prefix }}{{ microceph_path }}/" aria-current="page">
+          <img src="{{ nav404_prefix }}{{ microceph_tag }}" alt="Logo" class="p-logo-image">
+        {% else %}
         <a class="p-logo" href="{{ pathto(root_doc) if pathto(root_doc) != '#' }}{{ microceph_path }}/" aria-current="page">
           <img src="{{ pathto(root_doc) if pathto(root_doc) != '#' }}{{ microceph_tag }}" alt="Logo" class="p-logo-image">
+        {% endif %}
           <div class="p-logo-text p-heading--4">MicroCeph
           </div>
         </a>
       </li>
 
       <li>
+        {% if pagename == "404" %}
+        <a class="p-logo" href="{{ nav404_prefix }}{{ microovn_path }}/" aria-current="page">
+          <img src="{{ nav404_prefix }}{{ microovn_tag }}" alt="Logo" class="p-logo-image">
+        {% else %}
         <a class="p-logo" href="{{ pathto(root_doc) if pathto(root_doc) != '#' }}{{ microovn_path }}/" aria-current="page">
           <img src="{{ pathto(root_doc) if pathto(root_doc) != '#' }}{{ microovn_tag }}" alt="Logo" class="p-logo-image">
+        {% endif %}
           <div class="p-logo-text p-heading--4">MicroOVN
           </div>
         </a>

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -20,7 +20,13 @@ VALE_DIR         ?= $(DOCS_VENVDIR)/lib/python*/site-packages/vale
 VALE_CONFIG      ?= $(SPHINX_DIR)/vale.ini
 PA11Y_CMD        ?= $(SPHINX_DIR)/node_modules/pa11y/bin/pa11y.js --config $(SPHINX_DIR)/pa11y.json
 CHECK_PATH       ?= $(filter-out $(DOCS_VENVDIR),$(wildcard *))
+
+# Integration setup
 INTEGRATION_DIR ?= integration
+# 404 page customization
+LOCAL_404_FILE ?= $(DOCS_BUILDDIR)/404/index.html
+RTD_404_FILE ?= $(READTHEDOCS_OUTPUT)/html/404/index.html
+NAV_404_HREF ?= /microcloud/docs/$(or $(READTHEDOCS_VERSION),local)/
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -174,6 +180,9 @@ html: integrate install
 	cd integration/microceph/docs/ && $(MAKE) html BUILDDIR=$(current_dir)/_build/microceph
 	cd integration/microovn/docs/ && $(MAKE) html BUILDDIR=$(current_dir)/_build/microovn
 	. $(DOCS_VENV); $(SPHINX_BUILD) -W --keep-going -b dirhtml "$(DOCS_SOURCEDIR)" "$(current_dir)/_build" -w $(SPHINX_DIR)/warnings.txt $(SPHINX_OPTS)
+	sed -e 's|<a href="#"><div class="brand">|<a href="$(NAV_404_HREF)"><div class="brand">|' \
+		-e 's|<a class="sidebar-brand" href="#">|<a class="sidebar-brand" href="$(NAV_404_HREF)">|' \
+		"$(LOCAL_404_FILE)" > "$(LOCAL_404_FILE).tmp" && mv "$(LOCAL_404_FILE).tmp" "$(LOCAL_404_FILE)"
 
 # `html-rtd` builds the integrated docs, with the correct paths for Read the Docs.
 # This target is used by the Read the Docs build.
@@ -182,6 +191,9 @@ html-rtd: install
 	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -C integration/microceph/docs/ html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microceph
 	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -C integration/microovn/docs/ html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microovn
 	. $(DOCS_VENV); PATH_PREFIX=$(PATH_PREFIX) $(SPHINX_BUILD) -W --keep-going -b dirhtml "$(DOCS_SOURCEDIR)" "$(READTHEDOCS_OUTPUT)/html" -w $(SPHINX_DIR)/warnings.txt $(SPHINX_OPTS)
+	sed -e 's|<a href="#"><div class="brand">|<a href="$(NAV_404_HREF)"><div class="brand">|' \
+		-e 's|<a class="sidebar-brand" href="#">|<a class="sidebar-brand" href="$(NAV_404_HREF)">|' \
+		"$(RTD_404_FILE)" > "$(RTD_404_FILE).tmp" && mv "$(RTD_404_FILE).tmp" "$(RTD_404_FILE)"
 
 epub: install
 	. $(DOCS_VENV); $(SPHINX_BUILD) -b epub "$(DOCS_SOURCEDIR)" "$(DOCS_BUILDDIR)" -w $(SPHINX_DIR)/warnings.txt $(SPHINX_OPTS)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -180,6 +180,11 @@ html: integrate install
 	cd integration/microceph/docs/ && $(MAKE) html BUILDDIR=$(current_dir)/_build/microceph
 	cd integration/microovn/docs/ && $(MAKE) html BUILDDIR=$(current_dir)/_build/microovn
 	. $(DOCS_VENV); $(SPHINX_BUILD) -W --keep-going -b dirhtml "$(DOCS_SOURCEDIR)" "$(current_dir)/_build" -w $(SPHINX_DIR)/warnings.txt $(SPHINX_OPTS)
+	@echo "Checking 404 page setup ..."
+	@grep -q '<a href="#"><div class="brand">' "$(LOCAL_404_FILE)" || \
+		{ echo "ERROR: brand pattern not found in $(LOCAL_404_FILE). Update the 404 page customization."; exit 1; }
+	@grep -q '<a class="sidebar-brand" href="#">' "$(LOCAL_404_FILE)" || \
+		{ echo "ERROR: sidebar-brand pattern not found in $(LOCAL_404_FILE). Update the 404 page customization."; exit 1; }
 	sed -e 's|<a href="#"><div class="brand">|<a href="$(NAV_404_HREF)"><div class="brand">|' \
 		-e 's|<a class="sidebar-brand" href="#">|<a class="sidebar-brand" href="$(NAV_404_HREF)">|' \
 		"$(LOCAL_404_FILE)" > "$(LOCAL_404_FILE).tmp" && mv "$(LOCAL_404_FILE).tmp" "$(LOCAL_404_FILE)"
@@ -191,6 +196,11 @@ html-rtd: install
 	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -C integration/microceph/docs/ html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microceph
 	PATH_PREFIX=$(PATH_PREFIX) $(MAKE) -C integration/microovn/docs/ html BUILDDIR=$(READTHEDOCS_OUTPUT)/html/microovn
 	. $(DOCS_VENV); PATH_PREFIX=$(PATH_PREFIX) $(SPHINX_BUILD) -W --keep-going -b dirhtml "$(DOCS_SOURCEDIR)" "$(READTHEDOCS_OUTPUT)/html" -w $(SPHINX_DIR)/warnings.txt $(SPHINX_OPTS)
+	@echo "Checking 404 page setup ..."
+	@grep -q '<a href="#"><div class="brand">' "$(RTD_404_FILE)" || \
+		{ echo "ERROR: brand pattern not found in $(RTD_404_FILE). Update the 404 page customization."; exit 1; }
+	@grep -q '<a class="sidebar-brand" href="#">' "$(RTD_404_FILE)" || \
+		{ echo "ERROR: sidebar-brand pattern not found in $(RTD_404_FILE). Update the 404 page customization."; exit 1; }
 	sed -e 's|<a href="#"><div class="brand">|<a href="$(NAV_404_HREF)"><div class="brand">|' \
 		-e 's|<a class="sidebar-brand" href="#">|<a class="sidebar-brand" href="$(NAV_404_HREF)">|' \
 		"$(RTD_404_FILE)" > "$(RTD_404_FILE).tmp" && mv "$(RTD_404_FILE).tmp" "$(RTD_404_FILE)"

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -158,6 +158,10 @@ integrate: integrate-precheck
 	cp _templates/google-tag.html integration/microovn/docs/.sphinx/_templates/
 	cp .sphinx/_integration/header.css integration/microovn/docs/.sphinx/_static/
 
+	# Set up `noindex` tags for MicroCeph and MicroOVN pages
+	cat .sphinx/_integration/extrahead.html >> integration/microceph/docs/.sphinx/_templates/base.html
+	cat .sphinx/_integration/extrahead.html >> integration/microovn/docs/.sphinx/_templates/base.html
+
 	# Add information about where to find the tags/docs to the doc sets
 	cat .sphinx/_integration/add_config.py >> integration/lxd/doc/conf.py
 	cat .sphinx/_integration/add_config.py >> integration/microceph/docs/conf.py

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -112,6 +112,11 @@ integrate-pull:
 # - MicroOVN tag: The integrated docs use the circle of friends logo by
 #   overwriting the MicroOVN logo. Check that the MicroOVN logo is located where
 #   expected.
+# - SEO noindex tags:
+#     - LXD: verify upstream `base.html`, with `seo_noindex` check and `noindex`
+#       tag
+#     - MicroOVN and MicroOVN: verify upstream base.html file, that extends furo
+#       and does not already have an extrahead block
 integrate-precheck: integrate-pull
 	@echo "Running integration prechecks ..."
 
@@ -134,6 +139,29 @@ integrate-precheck: integrate-pull
 	@echo "Checking for MicroOVN tag ..."
 	@test -f integration/microovn/docs/.sphinx/_static/microovn.png || \
 		{ echo "ERROR: MicroOVN tag not found. Update the integration."; exit 1; }
+
+	@echo "Checking noindex tag setup ..."
+	@echo "- Checking LXD noindex setup..."
+	@test -f integration/lxd/doc/_templates/base.html || \
+		{ echo "ERROR: No base.html file in LXD docs. Update the noindex integration."; exit 1; }
+	@grep -q 'seo_noindex' integration/lxd/doc/_templates/base.html || \
+		{ echo "ERROR: LXD's base.html does not check seo_noindex. Update the noindex integration."; exit 1; }
+	@grep -q 'content="noindex"' integration/lxd/doc/_templates/base.html || \
+		{ echo "ERROR: LXD's base.html does not contain the noindex tag. Update the noindex integration."; exit 1; }
+	@echo "- Checking MicroCeph noindex setup..."
+	@test -f integration/microceph/docs/.sphinx/_templates/base.html || \
+		{ echo "ERROR: No base.html file in MicroCeph docs. Update the noindex integration."; exit 1; }
+	@grep -q 'extends "furo/base.html"' integration/microceph/docs/.sphinx/_templates/base.html || \
+		{ echo "ERROR: MicroCeph base.html no longer extends furo/base.html. Update the noindex integration."; exit 1; }
+	@! grep -q 'extrahead' integration/microceph/docs/.sphinx/_templates/base.html || \
+		{ echo "ERROR: MicroCeph base.html defines extrahead block. Update the noindex integration."; exit 1; }
+	@echo "- Checking MicroOVN noindex setup..."
+	@test -f integration/microovn/docs/.sphinx/_templates/base.html || \
+		{ echo "ERROR: No base.html file in MicroOVN docs. Update the noindex integration."; exit 1; }
+	@grep -q 'extends "furo/base.html"' integration/microovn/docs/.sphinx/_templates/base.html || \
+		{ echo "ERROR: MicroOVN base.html no longer extends furo/base.html. Update the noindex integration."; exit 1; }
+	@! grep -q 'extrahead' integration/microovn/docs/.sphinx/_templates/base.html || \
+		{ echo "ERROR: MicroOVN base.html defines extrahead block. Update the noindex integration."; exit 1; }
 
 integrate: integrate-precheck
 	# Create a directory for files to override in MicroCloud docs

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -47,7 +47,8 @@ help:
         vale pa11y run serve install pa11y-install   \
         vale-install clean clean-doc lint-md lint \
         integrate clean-integrate html html-rtd microcloud \
-        serve-microcloud pymarkdownlnt-install
+        serve-microcloud pymarkdownlnt-install \
+        integrate-pull integrate-precheck
 
 full-help: $(DOCS_VENVDIR)
 	@. $(DOCS_VENV); $(SPHINX_BUILD) -M help "$(DOCS_SOURCEDIR)" "$(DOCS_BUILDDIR)" $(SPHINX_OPTS) $(O)
@@ -81,7 +82,7 @@ install: $(DOCS_VENVDIR)
 run: install
 	. $(DOCS_VENV); $(DOCS_VENVDIR)/bin/sphinx-autobuild -b dirhtml --host $(SPHINX_HOST) --port $(SPHINX_PORT) "$(DOCS_SOURCEDIR)" "$(DOCS_BUILDDIR)" $(SPHINX_OPTS)
 
-integrate:
+integrate-pull:
 	# Pull the other repositories
 	cd integration/ && ( git -C lxd fetch || git clone https://github.com/canonical/lxd )
 	git -C integration/lxd reset --hard $(LXDVERSION)
@@ -92,6 +93,43 @@ integrate:
 	cd integration/ && ( git -C microovn fetch || git clone https://github.com/canonical/microovn )
 	git -C integration/microovn reset --hard $(MICROOVNVERSION)
 
+# Integration prechecks
+#
+# - Header templates: Check that header.html files exist in expected locations.
+#   If these files are missing, then the upstream repo may have reorganized the
+#   templates. The integrate rule will copy the integrated docs header, but that
+#   header may not end up being used in the built documentation.
+# - Configuration files: Check that `conf.py` files exist in expected locations.
+#   If the configuration files are missing, then they may have been moved, and
+#   appending `add_conf.py` with `>>` may create new `conf.py` files that will
+#   not be used by the upstream configuration.
+# - MicroOVN tag: The integrated docs use the circle of friends logo by
+#   overwriting the MicroOVN logo. Check that the MicroOVN logo is located where
+#   expected.
+integrate-precheck: integrate-pull
+	@echo "Running integration prechecks ..."
+
+	@echo "Checking for template files ..."
+	@test -f integration/lxd/doc/_templates/header.html || \
+		{ echo "ERROR: LXD header.html template not found. Update the integration."; exit 1; }
+	@test -f integration/microceph/docs/.sphinx/_templates/header.html || \
+		{ echo "ERROR: MicroCeph header.html template not found. Update the integration."; exit 1; }
+	@test -f integration/microovn/docs/.sphinx/_templates/header.html || \
+		{ echo "ERROR: MicroOVN header.html template not found. Update the integration."; exit 1; }
+
+	@echo "Checking for configuration files ..."
+	@test -f integration/lxd/doc/conf.py || \
+		{ echo "ERROR: LXD conf.py not found. Update the integration."; exit 1; }
+	@test -f integration/microceph/docs/conf.py || \
+		{ echo "ERROR: MicroCeph conf.py not found. Update the integration."; exit 1; }
+	@test -f integration/microovn/docs/conf.py || \
+		{ echo "ERROR: MicroOVN conf.py not found. Update the integration."; exit 1; }
+
+	@echo "Checking for MicroOVN tag ..."
+	@test -f integration/microovn/docs/.sphinx/_static/microovn.png || \
+		{ echo "ERROR: MicroOVN tag not found. Update the integration."; exit 1; }
+
+integrate: integrate-precheck
 	# Create a directory for files to override in MicroCloud docs
 	mkdir -p integration/microcloud/_templates/ integration/microcloud/_static
 	mkdir -p integration/microceph/docs/_static

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,6 +9,7 @@ import yaml
 import sys
 from git import Repo
 import re
+from urllib.parse import urlparse
 
 sys.path.append('./')
 sys.path.append('.sphinx/')
@@ -72,6 +73,9 @@ html_context = {
     'display_contributors': False,
 
     'sequential_nav': 'both',
+
+    # Prefix for top navigation menu URLs on 404 pages
+    'nav404_prefix': urlparse(html_baseurl).path,
 }
 
 # Enables the pencil icon to edit pages on GitHub, shown at the top of each page

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -269,7 +269,7 @@ notfound_context = {
 if ('SINGLE_BUILD' in os.environ and os.environ['SINGLE_BUILD'] == 'True'):
     intersphinx_mapping = {
         'lxd': ('https://canonical.com/lxd/docs/v5.21/', None),
-        'microceph': ('https://documentation.ubuntu.com/microceph/v19.2.0-squid/', None),
+        'microceph': ('https://canonical.com/ceph/docs/v19.2.0-squid/', None),
         'microovn': ('https://ubuntu.com/docs/microovn/24.03/', None),
     }
 elif ('READTHEDOCS' in os.environ) and (os.environ['READTHEDOCS'] == 'True'):


### PR DESCRIPTION
Backports several docs-tooling updates:

- #1480: Adds integration checks to the docs Makefile
- #1479: Fixes how several URLs on 404 pages are resolved
- #1475: Set up noindex tags on integrated docs to prevent indexing of LXD, MicroCeph, and MicroOVN portions of the integration
- #1483: Update the MicroCeph URL in configuration settings following the move to canonical.com/ceph/docs