### PR TITLE
Preseed: Drop disk existance check

### DIFF
--- a/cmd/microcloud/preseed.go
+++ b/cmd/microcloud/preseed.go
@@ -918,13 +918,6 @@ func (p *Preseed) Parse(s *service.Handler, c *initConfig, installedServices map
 				directLocal = sys.Storage.Local
 				directCeph = sys.Storage.Ceph
 			}
-
-			for _, disk := range directCeph {
-				_, err := os.Stat(disk.Path)
-				if err != nil {
-					return nil, fmt.Errorf("Failed to find specified disk path: %w", err)
-				}
-			}
 		}
 
 		// Setup directly specified disks for ZFS pool.


### PR DESCRIPTION
Fixes https://github.com/canonical/microcloud/issues/1465.

When in preseed mode, we cannot simply check for the existance of the disks selected for Ceph OSDs from the initiator. An os.Stat on the disk path would only work for disks which are actually located on the initiator.

An approach would be to compare the selected disks against the disks returned from LXD's resources endpoint. However we can only generate a limited list of disks paths from the response like `/dev/xyz` and `/dev/disk/by-id/xyz`. This means we cannot account for all different device disk paths a user might pick to compare against.

Therefore the only practical approach in the moment is to remove the faulty check. In case wrong disks are selected, either local or remote storage setup will fail anyway if the disk is not available.

In the interactive mode we generate a list of disks paths from the LXD resource API response. The user can select disks from this list which ensures only valid disks are picked.