### PR TITLE
GitHub: Clone repo non-shallow for launchpad push

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -311,6 +311,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # A non-shallow clone is needed for the push to Launchpad.
+          fetch-depth: 0
           persist-credentials: false
 
       # XXX: from this point onwards in this **specific job**, the private SSH key is


### PR DESCRIPTION
Prevent errors like https://github.com/canonical/microcloud/actions/runs/31676173739/job/94426932340.

In LXD we do the same, also because of the `lxd-private` rebase.