### PR TITLE
test/e2e/README: document the --report argument

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -105,3 +105,11 @@ EVACUATION_COUNTS=0 ./run mc
 # do multuple rolling reboots/evacuation tests:
 EVACUATION_COUNTS=5 ./run mc
 ```
+
+### HTML report
+
+Passing `--report` to the `run` script will generate a brief HTML report upon completion (whether the tests pass or fail). The report file is created in the current directory.
+
+```sh
+./run --report mc
+```


### PR DESCRIPTION
`--report` argument was implemented in #1178 but not documented
## Checklist

- [X] I have read the [contributing guidelines](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-structure).
- [X] I have checked and added or updated relevant documentation.