### PR TITLE
CLI: Hide the `--state-dir` flag

### DIFF
--- a/cmd/microcloud/main.go
+++ b/cmd/microcloud/main.go
@@ -37,7 +37,7 @@ func main() {
 
 	asker, err := setupAsker(ctx)
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Fprintf(os.Stderr, "Failed setting up asker: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/cmd/microcloud/main.go
+++ b/cmd/microcloud/main.go
@@ -62,6 +62,14 @@ func main() {
 
 	app.SetVersionTemplate("{{.Version}}\n")
 
+	// Don't display the --state-dir flag in the help output.
+	// It is used by the snaps "microcloud" wrapper command but never by the user directly.
+	err = app.PersistentFlags().MarkHidden("state-dir")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Cannot hide --state-dir flag: %v\n", err)
+		os.Exit(1)
+	}
+
 	var cmdInit = cmdInit{common: &commonCmd}
 	app.AddCommand(cmdInit.command())
 


### PR DESCRIPTION
Fixes https://github.com/canonical/microcloud/issues/1243.

It used used by the snaps 'microcloud' wrapper command but never by the user directly.