### PR TITLE
Init: Set OVN connection string only if necessary

### DIFF
--- a/cmd/microcloud/main_init.go
+++ b/cmd/microcloud/main_init.go
@@ -885,8 +885,18 @@ func (c *initConfig) setupCluster(s *service.Handler) error {
 
 	fmt.Println("Configuring cluster-wide devices ...")
 
-	var ovnConfig string
-	if s.Services[types.MicroOVN] != nil {
+	// Update LXD's global config.
+	server, _, err := lxdClient.GetServer()
+	if err != nil {
+		return err
+	}
+
+	config := make(map[string]string)
+
+	// LXD can dynamically determine the OVN northbound DB connection string from MicroOVN's `ovn.env` file.
+	// This feature was added with the ovn_dynamic_northbound_connection API extension.
+	// Only set the connection string in case of an older LXD.
+	if s.Services[types.MicroOVN] != nil && !lxdClient.HasExtension("ovn_dynamic_northbound_connection") {
 		serviceOVN := s.Services[types.MicroOVN].(*service.OVNService)
 
 		services, err := serviceOVN.GetServices(context.Background())
@@ -911,14 +921,7 @@ func (c *initConfig) setupCluster(s *service.Handler) error {
 			}
 		}
 
-		ovnConfig = strings.Join(conns, ",")
-	}
-
-	config := map[string]string{"network.ovn.northbound_connection": ovnConfig}
-	// Update LXD's global config.
-	server, _, err := lxdClient.GetServer()
-	if err != nil {
-		return err
+		config["network.ovn.northbound_connection"] = strings.Join(conns, ",")
 	}
 
 	newServer := server.Writable()

--- a/test/includes/microcloud.sh
+++ b/test/includes/microcloud.sh
@@ -550,16 +550,19 @@ validate_system_lxd_ovn() {
 
   echo "    ${name} Validating OVN network"
 
-  num_conns=3
-  if [ "${num_peers}" -lt "${num_conns}" ]; then
-    num_conns="${num_peers}"
+  # Check if the connection string is set correctly.
+  if ! check_api_extension ovn_dynamic_northbound_connection "${name}"; then
+    num_conns=3
+    if [ "${num_peers}" -lt "${num_conns}" ]; then
+      num_conns="${num_peers}"
+    fi
+
+    [ "$(lxc config get network.ovn.northbound_connection --target "${name}" | sed -e 's/,/\n/g' | wc -l)" = "${num_conns}" ]
+
+    # Make sure there's no empty addresses.
+    ! lxc config get network.ovn.northbound_connection --target "${name}" | sed -e 's/,/\n/g' | grep -q '^ssl:$' || false
+    ! lxc config get network.ovn.northbound_connection --target "${name}" | sed -e 's/,/\n/g' | grep -q '^ssl::' || false
   fi
-
-  [ "$(lxc config get network.ovn.northbound_connection --target "${name}" | sed -e 's/,/\n/g' | wc -l)" = "${num_conns}" ]
-
-  # Make sure there's no empty addresses.
-  ! lxc config get network.ovn.northbound_connection --target "${name}" | sed -e 's/,/\n/g' | grep -q '^ssl:$' || false
-  ! lxc config get network.ovn.northbound_connection --target "${name}" | sed -e 's/,/\n/g' | grep -q '^ssl::' || false
 
   # Check that the created UPLINK network has the right DNS servers.
   if [ -n "${dns_namesersers}" ] ; then


### PR DESCRIPTION
Fixes https://github.com/canonical/microcloud/issues/1286

Starting the with the ovn_dynamic_northbound_connection API extension in LXD, we don't anymore have to manually set the OVN northbound DB connection string. This also has the benefit that in case it requires a change, LXD always picks up the latest info from  file setup by MicroOVN.
