### PR TITLE
client, test/suites: forward session timeout cause over websocket

### DIFF
--- a/client/websocket.go
+++ b/client/websocket.go
@@ -82,8 +82,13 @@ func NewWebsocketGateway(ctx context.Context, conn *websocket.Conn) *WebsocketGa
 			decoder.DisallowUnknownFields()
 			err = decoder.Decode(&controlClose)
 			if err == nil {
-				// Cancel the inner context with the respective error.
-				defer gwCancel(errors.New(controlClose.ControlMessage))
+				var closeErr error
+				if controlClose.ControlMessage != "" {
+					closeErr = errors.New(controlClose.ControlMessage)
+				}
+
+				// Cancel the inner context too with the respective error.
+				defer gwCancel(closeErr)
 				return
 			}
 
@@ -109,8 +114,16 @@ func (w *WebsocketGateway) Receive() <-chan []byte {
 func (w *WebsocketGateway) ReceiveWithContext(ctx context.Context, v any) error {
 	var err error
 	select {
-	case bytes := <-w.Receive():
-		err = json.Unmarshal(bytes, v)
+	case data, ok := <-w.Receive():
+		if !ok {
+			if w.ctx.Err() != nil {
+				return context.Cause(w.ctx)
+			}
+
+			return errors.New("WebSocket connection closed")
+		}
+
+		err = json.Unmarshal(data, v)
 	case <-w.ctx.Done():
 		err = context.Cause(w.ctx)
 	case <-ctx.Done():
@@ -131,20 +144,20 @@ func (w *WebsocketGateway) Write(v any) error {
 	w.writeLock.Lock()
 	defer w.writeLock.Unlock()
 
-	if w.ctx.Err() != nil {
-		return context.Cause(w.ctx)
-	}
-
 	return w.conn.WriteJSON(v)
 }
 
 // WriteClose sends our websocket control close message.
-// Unlike the actual websocket control close message this supports message longer than 125 bytes
+// Unlike the actual websocket control close message this supports messages longer than 125 bytes
 // as well as special characters.
-// It waits for the other side to hang up or the gateway's context being cancelled.
 func (w *WebsocketGateway) WriteClose(err error) error {
+	var msg string
+	if err != nil {
+		msg = err.Error()
+	}
+
 	writeErr := w.Write(ControlClose{
-		ControlMessage: err.Error(),
+		ControlMessage: msg,
 	})
 	if writeErr != nil {
 		return fmt.Errorf("Failed to write control message: %w", writeErr)

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -440,6 +440,22 @@ test_interactive() {
   lxc exec micro01 -- tail -1 out | grep "User aborted" -q
   lxc exec micro04 -- tail -1 out | grep "Failed waiting during join: Initiator aborted the setup" -q
 
+  # Initiate a MicroCloud cluster with a session timeout and verify both initiator and joiner receive "Session timeout exceeded".
+  reset_systems 3 0 0
+  unset_interactive_vars
+
+  echo "Initiate a MicroCloud cluster with a short session timeout and verify both initiator and joiner receive the timeout error"
+  export MULTI_NODE="yes"
+  export LOOKUP_IFACE="enp5s0"
+  export EXPECT_PEERS=2
+  export SETUP_ZFS="no"
+  export SETUP_CEPH="no"
+  export OVN_WARNING="no"
+
+  ! join_session init micro01 micro02 || false
+  lxc exec micro01 -- tail -1 out | grep "Session timeout exceeded" -q
+  lxc exec micro02 -- tail -1 out | grep "Session timeout exceeded" -q
+
   echo "Try to initiate a MicroCloud with left over networking resources and check it fails to configure OVN"
   reset_systems 3 2 1
 
@@ -622,7 +638,6 @@ _test_case() {
       validate_system_microovn "${name}"
     done
 }
-
 
 test_interactive_combinations() {
   # Test with 2 systems, no disks, no interfaces.


### PR DESCRIPTION
### Description
When a trust establishment session expires, the client previously received a generic connection error (`websocket: close 1006: unexpected EOF`) instead of the actual cause (`Session timeout exceeded`)[cite: 5].

### Changes
* **`client/websocket.go`**:
  * Updated `WriteClose` to write `ControlClose` directly over the WebSocket under `writeLock` so close frames are sent even when `gwCtx` is canceled on timeout[cite: 5].
  * Updated `ReceiveWithContext` to check channel closure and return `context.Cause(w.ctx)`[cite: 5].
* **`test/suites/basic.sh`**:
  * Added a test case in `test_interactive` with `SESSION_TIMEOUT="5"` verifying that both the initiator and joiner receive `"Session timeout exceeded"`[cite: 2].

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md) and attest that all commits in this PR are [signed off](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#including-a-signed-off-by-line-in-your-commits), [cryptographically signed](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-signature-verification), and follow this project's [commit structure](https://github.com/canonical/microcloud/blob/main/CONTRIBUTING.md#commit-structure).
- [x] I have checked and added or updated relevant documentation.

### Related issues
- Fixes #1245

@roosterfish i have taken into consideration the insights you provided and resolved the issue, so take a look at it when you get time.