### PR TITLE
Test: Fix OVN api extension check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -176,9 +176,10 @@ jobs:
           - "6/edge"
         microcloud: ["latest/edge"]
         exclude:
-          # Exclude LXD 6 for regular development pipelines to speed up the result cycle.
-          # But launch the LXD 6 tests both for schedules and manual workflow dispatch.
-          - lxd: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' && '6/edge' }}
+          # Exclude LXD 5.21 for regular development pipelines to speed up the result cycle.
+          # MicroCloud edge tests should always run with LXD edge. The LTS edge is tested in the weekly schedule.
+          # Launch the LXD 5.21 tests both for schedules and manual workflow dispatch.
+          - lxd: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' && '5.21/edge' }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/test/includes/microcloud.sh
+++ b/test/includes/microcloud.sh
@@ -551,7 +551,7 @@ validate_system_lxd_ovn() {
   echo "    ${name} Validating OVN network"
 
   # Check if the connection string is set correctly.
-  if ! check_api_extension ovn_dynamic_northbound_connection "${name}"; then
+  if ! check_api_extension ovn_dynamic_northbound_connection; then
     num_conns=3
     if [ "${num_peers}" -lt "${num_conns}" ]; then
       num_conns="${num_peers}"


### PR DESCRIPTION
This caused trouble in the weekly test run with LXD `6/edge`, see https://github.com/canonical/microcloud/actions/runs/32607274546/job/97114518657.

In general always run MicroCloud edge tests with LXD edge and not the LTS edge so we catch issues earlier.