### PR TITLE
Test: Add release branches

### DIFF
--- a/.github/workflows/markdown-style-checks.yml
+++ b/.github/workflows/markdown-style-checks.yml
@@ -18,6 +18,8 @@ on:
   push:
     branches:
     - main
+    - v*-edge
+    - release-*
     paths:
     - 'doc/**'   # Only run on changes to the doc directory
   pull_request:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+      - v*-edge
+      - release-*
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - main
-      - stable-*
+      - v*-edge
+      - release-*
   pull_request:
 
 permissions: {}


### PR DESCRIPTION
Add `release-*` branches to the various tests and also add the version branches for the sake of completeness. They are [already set](https://github.com/canonical/microcloud/blob/v2-edge/.github/workflows/tests.yml#L7) on the respective files in the version branch. But this makes backporting easier.