### PR TITLE
snap: Bump version of Go to 1.26 (release-3.3)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -87,7 +87,7 @@ parts:
     after:
       - dqlite
     build-snaps:
-      - go/1.25/stable
+      - go/1.26/stable
     plugin: nil
     override-pull: |
       craftctl default


### PR DESCRIPTION
1.25 is EOL since six days.